### PR TITLE
Fix MessageView.getAttachmentType returning UNLOADED for DRIVE cards

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-attachment-card-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-attachment-card-view.js
@@ -20,7 +20,41 @@ function GmailAttachmentCardView(options, driver) {
 	this._eventStream = new Bacon.Bus();
 	this._driver = driver;
 
-	this.getAttachmentType = _.once(() => {
+	if(options.element){
+		this._element = options.element;
+	}
+	else{
+		this._createNewElement(options);
+	}
+}
+
+util.inherits(GmailAttachmentCardView, AttachmentCardViewDriver);
+
+_.assign(GmailAttachmentCardView.prototype, {
+
+	__memberVariables: [
+		{name: '_element', destroy: false, get: true},
+		{name: '_driver', destroy: false},
+		{name: '_cachedType', destroy: false},
+		{name: '_eventStream', destroy: true, get: true, destroyFunction: 'end'}
+	],
+
+	_isStandardAttachment() {
+		return this.getAttachmentType() === 'FILE';
+	},
+
+	getAttachmentType() {
+		if (this._cachedType) {
+			return this._cachedType;
+		}
+		const type = this._readAttachmentType();
+		if (type !== 'UNLOADED') {
+			this._cachedType = type;
+		}
+		return type;
+	},
+
+	_readAttachmentType() {
 		if (this._element.classList.contains('inboxsdk__attachmentCard')) {
 			return 'CUSTOM';
 		}
@@ -37,28 +71,6 @@ function GmailAttachmentCardView(options, driver) {
 			return 'DRIVE';
 		}
 		return 'UNKNOWN';
-	});
-
-	if(options.element){
-		this._element = options.element;
-	}
-	else{
-		this._createNewElement(options);
-	}
-}
-
-util.inherits(GmailAttachmentCardView, AttachmentCardViewDriver);
-
-_.assign(GmailAttachmentCardView.prototype, {
-
-	__memberVariables: [
-		{name: '_element', destroy: false, get: true},
-		{name: '_driver', destroy: false},
-		{name: '_eventStream', destroy: true, get: true, destroyFunction: 'end'}
-	],
-
-	_isStandardAttachment() {
-		return this.getAttachmentType() === 'FILE';
 	},
 
 	addButton: function(options){

--- a/test/gmail-attachment-card-view.js
+++ b/test/gmail-attachment-card-view.js
@@ -1,3 +1,6 @@
+/* @flow */
+//jshint ignore:start
+
 import assert from "assert";
 import jsdomDoc from "./lib/jsdom-doc";
 import GmailAttachmentCardView from "../src/platform-implementation-js/dom-driver/gmail/views/gmail-attachment-card-view";


### PR DESCRIPTION
Fix MessageView.getAttachmentType returning UNLOADED for DRIVE cards always.

DRIVE cards start out in the unloaded state, and then Gmail asynchronously fills in their DOM. MessageView.getAttachmentType's initial return value would be cached, so it would always return UNLOADED.
