### PR TITLE
Add ComposeView.getCurrentDraftID()

### DIFF
--- a/src/docs/compose-view.js
+++ b/src/docs/compose-view.js
@@ -73,6 +73,14 @@ var ComposeView = /** @lends ComposeView */ {
 	getDraftID: function() {},
 
 	/**
+	 * Acts the same as {ComposeView.getDraftID()}, except that if the ComposeView
+	 * does not yet have a draft ID assigned, then the returned Promise resolves
+	 * to null immediately instead of waiting.
+	 * @return {Promise.<string>}
+	 */
+	getCurrentDraftID: function() {},
+
+	/**
 	 * Returns an html string of the contents of the body of the compose view.
 	 * @return {string}
 	 */

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -628,6 +628,14 @@ var GmailComposeView = ud.defn(module, class GmailComposeView {
 		return this._threadID;
 	}
 
+	async getCurrentDraftID(): Promise<?string> {
+		if (!this.getMessageID()) {
+			return null;
+		} else {
+			return this.getDraftID();
+		}
+	}
+
 	async getDraftID(): Promise<?string> {
 		if (!this._draftIDpromise) {
 			this._draftIDpromise = this._getDraftIDimplementation();

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
@@ -368,6 +368,9 @@ var InboxComposeView = ud.defn(module, class InboxComposeView {
     // TODO
     return null;
   }
+  getCurrentDraftID(): Promise<?string> {
+    throw new Error("Not yet implemented");    
+  }
   getDraftID(): Promise<?string> {
     throw new Error("Not yet implemented");
   }

--- a/src/platform-implementation-js/driver-interfaces/compose-view-driver.js
+++ b/src/platform-implementation-js/driver-interfaces/compose-view-driver.js
@@ -63,6 +63,7 @@ export type ComposeViewDriver = {
 	getInitialMessageID(): ?string;
 	getMessageID(): ?string;
 	getThreadID(): ?string;
+	getCurrentDraftID(): Promise<?string>;
 	getDraftID(): Promise<?string>;
 	addTooltipToButton(buttonViewController: Object, buttonDescriptor: Object, tooltipDescriptor: TooltipDescriptor): void;
 	closeButtonTooltip(buttonViewController: Object): void;

--- a/src/platform-implementation-js/views/compose-view.js
+++ b/src/platform-implementation-js/views/compose-view.js
@@ -115,6 +115,10 @@ _.extend(ComposeView.prototype, {
 		return memberMap.get(this).composeViewImplementation.getDraftID();
 	},
 
+	getCurrentDraftID() {
+		return memberMap.get(this).composeViewImplementation.getCurrentDraftID();
+	},
+
 	getHTMLContent(){
 		return memberMap.get(this).composeViewImplementation.getHTMLContent();
 	},


### PR DESCRIPTION
While working on making the Streak client use draft IDs for things, I found that `ComposeView.getDraftID()`'s behavior was only sometimes what I wanted. If you call `getDraftID()` on a compose that doesn't have a draft (or message) id yet, then the returned promise doesn't resolve until the draft gets a message id. This works well for the use-case of saving the draft id, but it doesn't work well when the user opens a compose and you want to recognize whether this compose is a draft id you've seen before. In the latter case, if the compose doesn't currently have a draft (or message) id yet, then the compose is definitely a brand new compose and you want to know that immediately. `getCurrentDraftID()` has been added for this case. If the message doesn't have a draft id yet, the promise immediately resolves to null.
