### PR TITLE
A bit more compose polish

### DIFF
--- a/examples/compose-stream/content.js
+++ b/examples/compose-stream/content.js
@@ -141,6 +141,7 @@ InboxSDK.load(1, 'compose-stream-example', {inboxBeta: true}).then(function(inbo
 		composeView.on('presending', console.log.bind(console, 'presending'));
 		composeView.on('sending', console.log.bind(console, 'sending'));
 		composeView.on('sent', console.log.bind(console, 'sent'));
+		composeView.on('sendCanceled', console.log.bind(console, 'sendCanceled'));
 
 		composeView.on('toContactAdded', console.log.bind(console, 'toContactAdded'));
 		composeView.on('toContactRemoved', console.log.bind(console, 'toContactRemoved'));

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -109,8 +109,8 @@ class GmailComposeView {
 
 							case 'emailSent':
 								var response = GmailResponseProcessor.interpretSentEmailResponse(event.response);
-								if(response.messageID === 'tr'){
-									return []; //this happens when a message is cancelled
+								if(_.includes(['tr','eu'], response.messageID)){
+									return [{eventName: 'sendCanceled'}];
 								}
 								this._emailWasSent = true;
 								if(response.messageID){
@@ -124,6 +124,9 @@ class GmailComposeView {
 							case 'emailDraftReceived':
 								this._draftSaving = false;
 								var response = GmailResponseProcessor.interpretSentEmailResponse(event.response);
+								if (response.messageID === 'eu') {
+									return []; // save was canceled
+								}
 								const events = [{eventName: 'draftSaved', data: response}];
 								if (!response.messageID) {
 									this._driver.getLogger().error(new Error("Missing message id from emailDraftReceived"));


### PR DESCRIPTION
- Aborting a compose no longer causes an error message to be logged.
- Failing to identify an inline reply's thread no longer puts the compose in a bad state.
