### PR TITLE
Still try to place topnav even if the user's name isn't present.

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-toolbar-button-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-toolbar-button-view.js
@@ -148,7 +148,6 @@ function _createAppButtonElement(onclick: (event: Object) => void): HTMLElement 
       element.classList.add('inboxsdk__appButton_noGPlus');
     }
 
-    if (!insertionElement.firstElementChild) throw new Error("Could not make button");
     insertionElement.insertBefore(element, insertionElement.firstElementChild);
     return element;
   } catch(err) {


### PR DESCRIPTION
Still try to place topnav even if the user's name isn't present.

Previously I added logging to log some html of the top-right section if we failed to add the topnav. We used to find the element containing the user's name and place the topnav before the name. It seems like Gmail is rolling out a change that removes the user's name. It appears that we could still find the same insertion point, but our code aborted if it didn't find the user's name element.

It took me a while to figure out if the element we were finding in nameless-Gmail was still the right spot. I experimented with trying to place the html logged from nameless-Gmail into my Gmail, but the CSS classes were completely different and didn't result in anything sensible. I started exploring strategies for logging more html and/or even the CSS rules, or the positions of lots of elements in an area, but then I noticed something in the logged html that made me very sure it was the correct element. In my Gmail, the element containing the top-right section has min-width set to 210px. In the HTML logged from nameless-Gmail, there was an element with min-width set to 135px. I just measured it and realized that's the width of what my top right section would be without the name.
