### PR TITLE
Fix overflow menu tooltip alignment.

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/manage-button-grouping.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/manage-button-grouping.js
@@ -244,11 +244,11 @@ function _positionGroupToolbar(gmailComposeView){
 
 		groupedActionToolbarContainer.style.left = (groupedToolbarButton.offsetLeft + marginLeft) + 'px';
 
-		groupedActionToolbarArrow.style.left = -marginLeft + 'px';
+		groupedActionToolbarArrow.style.left = -(marginLeft+1) + 'px';
 	}
 	else{
 		groupedActionToolbarContainer.style.left = '';
-		groupedActionToolbarArrow.style.left = groupedToolbarButton.offsetLeft + 'px';
+		groupedActionToolbarArrow.style.left = (groupedToolbarButton.offsetLeft-1) + 'px';
 	}
 
 	groupedActionToolbarContainer.style.bottom = (gmailComposeView.getBottomToolbarContainer().clientHeight + 1) + 'px';


### PR DESCRIPTION
Sometimes the compose overflow menu's tooltip is misaligned. This simplifies the code and fixes it.

Also simplifies it by only using the css left property. Don't use margin-left also.
