### PR TITLE
Don't log error on email addresses in compose bordered by spaces

### DIFF
--- a/src/platform-implementation-js/lib/extract-contact-from-email-contact-string.js
+++ b/src/platform-implementation-js/lib/extract-contact-from-email-contact-string.js
@@ -4,19 +4,20 @@ import isValidEmail from './is-valid-email';
 
 export default function extractContactFromEmailContactString(contactInfoString: string): Contact {
   let name = null;
-  let emailAddress = '';
+  let emailAddress = null;
 
-  var contactInfoParts = contactInfoString.split('<');
+  const contactInfoParts = contactInfoString.split('<');
+  const firstPartTrimmed = contactInfoParts[0].trim();
   if(contactInfoParts.length > 1){
-    name = contactInfoParts[0].trim();
+    name = firstPartTrimmed;
     emailAddress = contactInfoParts[1].split('>')[0].trim();
   }
   else{
-    if(isValidEmail(contactInfoParts[0])){
-      emailAddress = contactInfoParts[0];
+    if(isValidEmail(firstPartTrimmed)){
+      emailAddress = firstPartTrimmed;
     }
     else{
-      throw new Error(contactInfoParts[0] + ' is not a valid email address');
+      throw new Error(firstPartTrimmed + ' is not a valid email address');
     }
   }
 

--- a/test/extract-contact-from-email-contact-string.js
+++ b/test/extract-contact-from-email-contact-string.js
@@ -7,15 +7,30 @@ import extractContactFromEmailContactString from '../src/platform-implementation
 describe('extractContactFromString', function(){
 
   it('should work with just an email address', function(){
-
-    assert.deepEqual(extractContactFromEmailContactString('monkeys@monkeys.com'), {name: null, emailAddress: 'monkeys@monkeys.com'});
-
+    assert.deepEqual(
+      extractContactFromEmailContactString('monkeys@monkeys.com'),
+      {name: null, emailAddress: 'monkeys@monkeys.com'}
+    );
   });
 
-  it('it should work with a name', function(){
-
-    assert.deepEqual(extractContactFromEmailContactString('George Monkey <monkeys@monkeys.com>'), {name: 'George Monkey', emailAddress: 'monkeys@monkeys.com'});
-
+  it('should work with a name', function(){
+    assert.deepEqual(
+      extractContactFromEmailContactString('George Monkey <monkeys@monkeys.com>'),
+      {name: 'George Monkey', emailAddress: 'monkeys@monkeys.com'}
+    );
   });
 
+  it('should work spaces around an email address', function() {
+    assert.deepEqual(
+      extractContactFromEmailContactString('  monkeys@monkeys.com  '),
+      {name: null, emailAddress: 'monkeys@monkeys.com'}
+    );
+  });
+
+  it('should work with spaces around a name', function(){
+    assert.deepEqual(
+      extractContactFromEmailContactString('  George Monkey <monkeys@monkeys.com>'),
+      {name: 'George Monkey', emailAddress: 'monkeys@monkeys.com'}
+    );
+  });
 });


### PR DESCRIPTION
I'm not sure this caused any user-visible issues (besides Streak maybe not factoring in certain people in box suggestions), but it helps clean up some errors.
