### PR TITLE
Fix issue with outlook 2010/2013 and link chips.

### DIFF
--- a/src/platform-implementation-js/lib/handle-compose-link-chips.js
+++ b/src/platform-implementation-js/lib/handle-compose-link-chips.js
@@ -79,7 +79,7 @@ function _addEnhancements(chipElement: HTMLElement) {
     }
 
     var xElement = document.createElement('div');
-    xElement.innerHTML = '<img src="//ssl.gstatic.com/ui/v1/icons/common/x_8px.png" style="opacity: 0.55; cursor: pointer; float: right; position: relative; top: -1px;">';
+    xElement.innerHTML = '<img src="https://ssl.gstatic.com/ui/v1/icons/common/x_8px.png" style="opacity: 0.55; cursor: pointer; float: right; position: relative; top: -1px;">';
     xElement = xElement.children[0];
 
     xElement.addEventListener('mousedown', function(e){


### PR DESCRIPTION
Protocol-relative URLs in emails cause old unpatched versions of Outlook to hang.

http://www.howto-outlook.com/news/paypalmessagehangs.htm
