### PR TITLE
fix more menu width too

### DIFF
--- a/examples/toolbar-button/content.js
+++ b/examples/toolbar-button/content.js
@@ -102,7 +102,7 @@ InboxSDK.load(1, 'toolbar-example', {appIconUrl: chrome.runtime.getURL('monkey.p
 		messageView.addToolbarButton({
 			section: inboxSDK.Conversations.MessageViewToolbarSectionNames.MORE,
 			iconUrl: chrome.runtime.getURL('monkey.png'),
-			title: 'Foo bar 2',
+			title: 'Foo bar 2 long title text text text',
 			onClick() {
 				console.log('2 message more button click on message from', messageView.getSender().name);
 			}

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.js
@@ -219,6 +219,7 @@ _.extend(GmailMessageView.prototype, {
 		const openMoreMenu = this._openMoreMenu;
 		if (openMoreMenu && this._moreMenuItemDescriptors.length) {
 			const originalHeight = openMoreMenu.offsetHeight;
+			const originalWidth = openMoreMenu.offsetWidth;
 
 			const dividerEl = document.createElement('div');
 			dividerEl.className = 'J-Kh';
@@ -252,10 +253,17 @@ _.extend(GmailMessageView.prototype, {
 				openMoreMenu.appendChild(itemEl);
 			});
 
+			const menuRect = openMoreMenu.getBoundingClientRect();
+
+			const addedWidth = menuRect.width - originalWidth;
+			if (addedWidth > 0) {
+				openMoreMenu.style.left = Math.max(
+					0, parseInt(openMoreMenu.style.left)-addedWidth) + 'px';
+			}
+
 			const moreButton = this._getMoreButton();
 			if (moreButton) {
 				const moreButtonRect = moreButton.getBoundingClientRect();
-				const menuRect = openMoreMenu.getBoundingClientRect();
 
 				// If the menu is positioned above the button, then adjust the menu
 				// upwards to compensate for the buttons we added.


### PR DESCRIPTION
If we added a wide item to a message's more menu, then the menu would no longer be right-aligned with the button that spawned it. This corrects that.
