### PR TITLE
Fix waiting for composeview to be ready

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -194,9 +194,10 @@ class GmailComposeView {
 
 		this.ready = _.constant(
 			kefirWaitFor(
-				() => !this._element || !!this.getBodyElement(),
+				() => !!this.getBodyElement(),
 				3*60 * 1000 //timeout
-			).filter(() => !!this._element)
+			)
+			.takeUntilBy(this._stopper)
 			.map(() => {
 				this._composeID = ((this._element.querySelector('input[name="composeid"]'): any): HTMLInputElement).value;
 				this._messageIDElement = this._element.querySelector('input[name="draft"]');


### PR DESCRIPTION
If the compose was closed before being ready, then we wouldn't stop waiting until the timer timed out and threw an error.
