### PR TITLE
Lessen the error spam about missing body elements

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -50,6 +50,8 @@ import type {ComposeViewDriver, StatusBar} from '../../../driver-interfaces/comp
 import type Logger from '../../../lib/logger';
 import type GmailDriver from '../gmail-driver';
 
+let hasReportedMissingBody = false;
+
 class GmailComposeView {
 	_element: HTMLElement;
 	_isInlineReplyForm: boolean;
@@ -750,6 +752,20 @@ class GmailComposeView {
 		const element = this.getElement();
 		const bodyElement = this.getBodyElement();
 		const bodyContainer = _.find(element.children, child => child.contains(bodyElement));
+		if (!bodyContainer) {
+			if (!hasReportedMissingBody) {
+				hasReportedMissingBody = true;
+				this._driver.getLogger().error(
+					new Error("getMinimized failed to find bodyContainer"),
+					{
+						bodyElement: !!bodyElement,
+						hasMessageIDElement: !!this._messageIDElement,
+						ended: (this._eventStream:any).ended
+					}
+				);
+			}
+			return false;
+		}
 
 		return bodyContainer.style.display !== '';
 	}


### PR DESCRIPTION
I'm not clear what's going on yet, but we're getting a ton of logged errors because GmailComposeView's getBodyElement can return null. This logs the error once per session, and returns a dummy element so other things don't break.
