### PR TITLE
Fix destroying message views

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.js
@@ -66,6 +66,7 @@ _.extend(GmailMessageView.prototype, {
 		this._moreMenuAddedElements.forEach(el => {
 			el.remove();
 		});
+		MessageViewDriver.prototype.destroy.call(this);
 	},
 
 	isLoaded: function(){


### PR DESCRIPTION
In my changes yesterday, I added a "destroy" method to GmailMessageView. I failed to realize that GmailMessageView extends MessageViewDriver which extends BasicClass which has a destroy method, and I forgot to call the superclass's destroy method in my new destroy method. This meant that GmailMessageView no longer called `end()` on its eventStream property, so it would never destroy any still open inline compose views that were part of it.

This meant if a user browsed away from a thread while a reply was open, then we would fail to close a compose view which broke things further down the line.

I mistakenly thought the errors began at around 6pm last night, making it unrelated to my earlier (1pmish) deploy, but now I realize that was only the time that I was made aware of the errors, and I failed to investigate that further.
