### PR TITLE
Check that window.open was overridden successfully

### DIFF
--- a/src/injected-js/thread-identifier/click-and-get-popup-url.js
+++ b/src/injected-js/thread-identifier/click-and-get-popup-url.js
@@ -2,8 +2,9 @@
 //jshint ignore:start
 
 import _ from 'lodash';
+import * as logger from '../injected-logger';
 
-var ignoreErrors = _.constant(true);
+const ignoreErrors = _.constant(true);
 
 function getIfOwn(object: Object, prop: string): any {
   if (Object.prototype.hasOwnProperty.call(object, prop)) {
@@ -15,8 +16,8 @@ function getIfOwn(object: Object, prop: string): any {
 // Simulates a control+meta click on an element, intercepts the call to
 // window.open, and returns the attempted popup's URL.
 export default function clickAndGetPopupUrl(element: HTMLElement): ?string {
-  var event = document.createEvent('MouseEvents');
-  var options = {
+  const event = document.createEvent('MouseEvents');
+  const options = {
     bubbles: true, cancelable: true, button: 0, pointerX: 0, pointerY: 0,
     ctrlKey: true, altKey: false, shiftKey: false, metaKey: true
   };
@@ -26,18 +27,18 @@ export default function clickAndGetPopupUrl(element: HTMLElement): ?string {
     options.ctrlKey, options.altKey, options.shiftKey, options.metaKey, options.button, null
   );
 
-  var url;
-  var oldWindowOpen = window.open, oldWindowOnerror = window.onerror,
+  let url;
+  const oldWindowOpen = window.open, oldWindowOnerror = window.onerror,
     oldFocus = getIfOwn(window.HTMLElement.prototype, 'focus'),
     oldBlur = getIfOwn(window.HTMLElement.prototype, 'blur');
   try {
     window.HTMLElement.prototype.focus = _.noop;
     window.HTMLElement.prototype.blur = _.noop;
     window.onerror = ignoreErrors;
-    window.open = function(_url, _title, _options) {
+    const newOpen = function(_url, _title, _options) {
       url = _url;
       // Gmail checks the returned object for these two values specifically.
-      var newWin = {
+      const newWin = {
         closed: false, focus: _.noop
       };
       setTimeout(function() {
@@ -45,6 +46,16 @@ export default function clickAndGetPopupUrl(element: HTMLElement): ?string {
       }, 5);
       return newWin;
     };
+    window.open = newOpen;
+
+    // If another extension created a setter on window.open, then setting it
+    // could have failed. Log to see if this is a thing that ever happens, and
+    // avoid letting windows be opened.
+    if (window.open !== newOpen) {
+      logger.error(new Error("Failed to override window.open"));
+      return null;
+    }
+
     element.dispatchEvent(event);
   } finally {
     if (oldFocus) {


### PR DESCRIPTION
aialec90@gmail.com reported seeing tabs open while thread rows were being identified. This could happen if setting window.open failed because another extension created a setter for it. This code detects if that has happened, and avoids allowing the tabs to be opened.
