### PR TITLE
Fix extra butter bar message container being visible

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-butter-bar-driver.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-butter-bar-driver.js
@@ -15,6 +15,7 @@ const elements = streamWaitFor(() => document.body.querySelector('div.b8[role="a
     if (!sdkNotice) {
       sdkNotice = (googleNotice.cloneNode(false): any);
       sdkNotice.classList.add('inboxsdk__butterbar');
+      sdkNotice.style.display = 'none';
       googleNotice.parentNode.insertBefore(sdkNotice, googleNotice.nextSibling);
     }
     return {noticeContainer, googleNotice, sdkNotice};


### PR DESCRIPTION
Fixes extra butter bar message container being visible. Right now, the extra element has no height, but the borders are still visible, so Gmail's butterbar messages seem to have a larger bottom border. However, from user reports, it sounds like a change in Gmail's CSS is rolling out, and possibly added a min-height to the element, making the issue more visible.
