### PR TITLE
Fixes and logging for overflow menu positioning

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/manage-button-grouping.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/manage-button-grouping.js
@@ -43,7 +43,7 @@ export default defn(module, function manageButtonGrouping(gmailComposeView: Gmai
 
 	gmailComposeView.getEventStream()
 					.filter(event =>
-						event.eventName === 'resize'
+						event.eventName === 'resize' || event.eventName === 'restored'
 					)
 					.onValue(() => {_fixToolbarPosition(gmailComposeView);});
 


### PR DESCRIPTION
- Don't try to reposition the overflow toolbar while the compose is minimized.
- Try to reposition the overflow toolbar when the compose is restored.
- Log if it seems like we've placed the overflow toolbar wrongly.
