### PR TITLE
Fix error logging when inboxsdk.js and platform-implementation.js don't match

### DIFF
--- a/src/common/log-error.js
+++ b/src/common/log-error.js
@@ -113,9 +113,10 @@ const _extensionSeenErrors: {has(e: Error): boolean, add(e: Error): void} = (() 
       }
     },
     add(e: Error) {
-      if (global.WeakMap && (global.__inboxsdk_extensionSeenErrors instanceof global.WeakMap)) {
+      if (global.__inboxsdk_extensionSeenErrors && global.__inboxsdk_extensionSeenErrors.set) {
+        // It's a WeakMap.
         global.__inboxsdk_extensionSeenErrors.set(e, true);
-      } else if (global.WeakSet && (global.__inboxsdk_extensionSeenErrors instanceof global.WeakSet)) {
+      } else if (global.__inboxsdk_extensionSeenErrors && global.__inboxsdk_extensionSeenErrors.add) {
         // Older versions of inboxsdk.js initialized it as a WeakSet instead,
         // so handle that too.
         global.__inboxsdk_extensionSeenErrors.add(e);


### PR DESCRIPTION
I made a little mistake in the last deploy which broke error logging for people on an old inboxsdk.js and the new platform-implementation.js. I've reverted the deploy for the moment.

The file "src/common/log-error.js" is built into both the inboxsdk.js and platform-implementation.js bundles. The variable `global.__inboxsdk_extensionSeenErrors` is created by inboxsdk.js, and then used by both it and platform-implementation.js.

The old version of log-error.js made that variable a WeakSet and expected it to be one. The new version of log-error.js made that variable a WeakMap and expected it to be one. If you mixed an old inboxsdk.js and a new platform-implementation.js, then the variable would be a WeakSet but then platform-implementation would try to use it as a WeakMap. This would throw an exception and prevent error logging from working.

I've fixed it by making log-error.js check whether `global.__inboxsdk_extensionSeenErrors` is a WeakMap or a WeakSet before using it. This change being done in platform-implementation.js is sufficient; both versions of inboxsdk.js are fine used with it.
