### PR TITLE
Only report element errors for master app

### DIFF
--- a/src/platform-implementation-js/dom-driver/inbox/get-compose-view-driver-stream.js
+++ b/src/platform-implementation-js/dom-driver/inbox/get-compose-view-driver-stream.js
@@ -20,7 +20,10 @@ const impStream = udKefir(module, imp);
 function imp(driver: InboxDriver): Kefir.Stream<ComposeViewDriver> {
   return detectionRunner({
     name: 'compose',
-    finder, watcher, parser
+    finder, watcher, parser,
+    logError(err: Error, details?: any) {
+      driver.getLogger().errorSite(err, details);
+    }
   })
     .map(({el, removalStream, parsed}) => {
       const view = new InboxComposeView(driver, el, parsed);

--- a/src/platform-implementation-js/lib/dom/detectionRunner.js
+++ b/src/platform-implementation-js/lib/dom/detectionRunner.js
@@ -21,17 +21,16 @@ type GenericParserResults = {
 // results by using finder.
 export default function detectionRunner<P: GenericParserResults>(
   {
-    name, parser, watcher, finder,
+    name, parser, watcher, finder, logError,
     root=document,
-    logError=(err, details) => Logger.error(err, details),
     interval=5000
   }: {
     name: string;
     parser: (el: HTMLElement) => P;
     watcher: (root: Document) => Kefir.Stream<ElementWithLifetime>;
     finder: (root: Document) => Array<HTMLElement>;
+    logError: (err: Error, details?: any) => void;
     root?: Document;
-    logError?: (err: Error, details?: any) => void;
     interval?: number;
   }
 ): Kefir.Stream<ElementWithLifetime&{parsed: P}> {

--- a/src/platform-implementation-js/lib/logger.js
+++ b/src/platform-implementation-js/lib/logger.js
@@ -110,6 +110,14 @@ class Logger {
     _logError(err, details, this._appId, true);
   }
 
+  errorSite(err: Error, details?: any) {
+    // Only the first logger instance reports Site errors.
+    if (!this._isMaster) {
+      return;
+    }
+    this.error(err, details);
+  }
+
   // Should only be used by the InboxSDK users for their own app events.
   eventApp(name: string, details?: any) {
     _trackEvent(this._appId, 'app', name, details);
@@ -133,7 +141,7 @@ class Logger {
 
   // Track Site events.
   eventSite(name: string, details?: any) {
-    // Only the first logger instance reports Gmail events.
+    // Only the first logger instance reports Site events.
     if (!this._isMaster) {
       return;
     }


### PR DESCRIPTION
We would only report 'compose open' events for the master app/extension, but we would report errors with compose views from all apps, so errors would be over-reported relatively. This fixes that.
