### PR TITLE
Flow-type Modal.js

### DIFF
--- a/src/platform-implementation-js/namespaces/modal.js
+++ b/src/platform-implementation-js/namespaces/modal.js
@@ -1,46 +1,41 @@
-'use strict';
+/* @flow */
 
-var _ = require('lodash');
+import _ from 'lodash';
+import {defn, defonce} from 'ud';
+import ModalView from '../widgets/modal-view';
+import type {Driver} from '../driver-interfaces/driver';
+import type {PiOpts} from '../platform-implementation';
 
-var ModalView = require('../widgets/modal-view');
-
-
-var memberMap = new Map();
+const memberMap = defonce(module, () => new WeakMap());
 
 // Deprecated, applications should use Widgets instead.
-function Modal(appId, driver, piOpts) {
-    var members = {};
+class Modal {
+  constructor(appId: string, driver: Driver, piOpts: PiOpts) {
+    const members = {appId, driver, piOpts};
     memberMap.set(this, members);
-
-    members.appId = appId;
-    members.driver = driver;
-    members.piOpts = piOpts;
-}
-
-_.assign(Modal.prototype, {
+  }
 
   // Deprecated, use Widgets.showModalView
-  show: function(options){
-    var driver = memberMap.get(this).driver;
+  show(options: Object): ModalView {
+    const driver = memberMap.get(this).driver;
     if (memberMap.get(this).piOpts.inboxBeta) {
       driver.getLogger().deprecationWarning('Modal.show', 'Widgets.showModalView');
     }
-    var modalViewDriver = driver.createModalViewDriver(options);
-    var modalView = new ModalView({driver, modalViewDriver});
+    const modalViewDriver = driver.createModalViewDriver(options);
+    const modalView = new ModalView({driver, modalViewDriver});
     modalView.show();
 
     return modalView;
-  },
-
-  // Deprecated, does not have an exact replacement. Use Widgets.showModalView.
-  createModalView: function(options){
-    var driver = memberMap.get(this).driver;
-    driver.getLogger().deprecationWarning('Modal.createModalView', 'Widgets.showModalView');
-
-    var modalViewDriver = driver.createModalViewDriver(options);
-    return new ModalView({driver, modalViewDriver});
   }
 
-});
+  // Deprecated, does not have an exact replacement. Use Widgets.showModalView.
+  createModalView(options: Object): ModalView {
+    const driver = memberMap.get(this).driver;
+    driver.getLogger().deprecationWarning('Modal.createModalView', 'Widgets.showModalView');
 
-module.exports = Modal;
+    const modalViewDriver = driver.createModalViewDriver(options);
+    return new ModalView({driver, modalViewDriver});
+  }
+}
+
+export default defn(module, Modal);


### PR DESCRIPTION
Flow-types sdk.Modal which is used by Dropbox. This file being flow-typed would've caught the issue that killed the dropbox extension for the last day.
