### PR TITLE
Make inbox chrome test more dependable

### DIFF
--- a/test/chrome/inbox.js
+++ b/test/chrome/inbox.js
@@ -21,7 +21,7 @@ describe('Inbox', function() {
 
     // Test an inline compose
     browser.click('.scroll-list-section-body div[role=listitem][jsinstance*="gmail:thread"]');
-    browser.pause(1500);
+    browser.waitForVisible('div[jsaction*=quickCompose][jsaction$=quick_compose_handle_focus]', 10*1000);
     browser.click('div[jsaction*=quickCompose][jsaction$=quick_compose_handle_focus]');
     browser.click('div.inboxsdk__button_icon[title="Monkeys!"]');
     assert(browser.isVisible('div.extension-dropdown-test'));


### PR DESCRIPTION
Wait for thread to load before continuing. Don't assume it will be loaded within 1.5 seconds.
