### PR TITLE
Fix sizeFixer errors

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -649,12 +649,9 @@ class GmailComposeView {
 		return $(innerElement).closest('[role=button]')[0];
 	}
 
-	getScrollBody(): HTMLElement {
-		var scrollBody = this._element.querySelector('table .GP');
-		if (!scrollBody) {
-			throw new Error("Failed to find scroll body");
-		}
-		return scrollBody;
+	getScrollBody(): ?HTMLElement {
+		// This element may not be available immediately for inline composes.
+		return this._element.querySelector('table .GP');
 	}
 
 	getStatusArea(): HTMLElement {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/size-fixer.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/size-fixer.js
@@ -1,5 +1,4 @@
 /* @flow */
-//jshint ignore:start
 
 import _ from 'lodash';
 import Kefir from 'kefir';
@@ -7,6 +6,7 @@ import kefirCast from 'kefir-cast';
 import delayAsap from '../../../../lib/delay-asap';
 import makeMutationObserverChunkedStream from '../../../../lib/dom/make-mutation-observer-chunked-stream';
 import cssSelectorEscape from '../../../../lib/css-selector-escape';
+import streamWaitFor from '../../../../lib/stream-wait-for';
 import type GmailComposeView from '../gmail-compose-view';
 
 var getSizeFixerSheet: () => CSSStyleSheet = _.once(() => {
@@ -32,67 +32,71 @@ export default function sizeFixer(driver: Object, gmailComposeView: GmailCompose
   }
   gmailComposeView.getElement().classList.add('inboxsdk__size_fixer');
 
-  var composeEvents = gmailComposeView.getEventStream();
-  var stopper = composeEvents.filter(() => false).beforeEnd(() => null);
-  var resizeEvents = composeEvents
-    .filter(e => _.includes(['resize', 'fullscreenChanged'], e.eventName))
-    .merge(delayAsap(null));
+  const composeEvents = gmailComposeView.getEventStream();
+  const stopper = composeEvents.ignoreValues().beforeEnd(() => null).toProperty();
 
-  var statusAreaParent: HTMLElement = (gmailComposeView.getStatusArea().parentElement:any);
-  var scrollBody: HTMLElement = gmailComposeView.getScrollBody();
-
-  var sheet = getSizeFixerSheet();
-  var topForm = gmailComposeView.getTopFormElement();
-  var composeId = gmailComposeView.getElement().id;
-  if (!composeId) {
-    composeId = gmailComposeView.getElement().id = `x${Math.random()}x${Date.now()}`;
-  }
-
-  function setRuleForSelector(selector: string, rule: string) {
-    var fullSelector = byId(composeId)+' '+selector;
-    var ix = _.findIndex(sheet.cssRules, cssRule => cssRule.selectorText === fullSelector);
-    if (ix !== -1) {
-      sheet.deleteRule(ix);
-    }
-    sheet.insertRule(fullSelector+' { '+rule+' }', 0);
-  }
-
-  // Emit resize events when the recipients area is toggled
-  makeMutationObserverChunkedStream(statusAreaParent, {attributes:true})
+  streamWaitFor(() => gmailComposeView.getScrollBody())
     .takeUntilBy(stopper)
-    .onValue(() => {
-      gmailComposeView.getElement().dispatchEvent(new CustomEvent('resize', {
-        bubbles: false, cancelable: false, detail: null
-      }));
-    });
+    .onValue(scrollBody => {
+      const resizeEvents = composeEvents
+        .filter(e => _.includes(['resize', 'fullscreenChanged'], e.eventName))
+        .merge(delayAsap(null));
 
-  resizeEvents
-    .bufferBy(resizeEvents.flatMap(x => delayAsap(null)))
-    .filter(x => x.length > 0)
-    .merge(
-      makeMutationObserverChunkedStream(scrollBody, {attributes:true})
-    )
-    .takeUntilBy(stopper)
-    .onValue(() => {
-      var statusUnexpectedHeight = Math.max(statusAreaParent.offsetHeight - 42, 0);
-      var topFormUnexpectedHeight = Math.max(topForm.offsetHeight - 84, 0);
-      var unexpectedHeight = statusUnexpectedHeight+topFormUnexpectedHeight;
+      const statusAreaParent: HTMLElement = (gmailComposeView.getStatusArea().parentElement:any);
 
-      setRuleForSelector(byId(scrollBody.id), `
+      const sheet = getSizeFixerSheet();
+      const topForm = gmailComposeView.getTopFormElement();
+      let composeId = gmailComposeView.getElement().id;
+      if (!composeId) {
+        composeId = gmailComposeView.getElement().id = `x${Math.random()}x${Date.now()}`;
+      }
+
+      function setRuleForSelector(selector: string, rule: string) {
+        const fullSelector = byId(composeId)+' '+selector;
+        const ix = _.findIndex(sheet.cssRules, cssRule => cssRule.selectorText === fullSelector);
+        if (ix !== -1) {
+          sheet.deleteRule(ix);
+        }
+        sheet.insertRule(fullSelector+' { '+rule+' }', 0);
+      }
+
+      // Emit resize events when the recipients area is toggled
+      makeMutationObserverChunkedStream(statusAreaParent, {attributes:true})
+        .takeUntilBy(stopper)
+        .onValue(() => {
+          gmailComposeView.getElement().dispatchEvent(new CustomEvent('resize', {
+            bubbles: false, cancelable: false, detail: null
+          }));
+        });
+
+      resizeEvents
+        .bufferBy(resizeEvents.flatMap(x => delayAsap(null)))
+        .filter(x => x.length > 0)
+        .merge(
+          makeMutationObserverChunkedStream(scrollBody, {attributes:true})
+        )
+        .takeUntilBy(stopper)
+        .onValue(() => {
+          const statusUnexpectedHeight = Math.max(statusAreaParent.offsetHeight - 42, 0);
+          const topFormUnexpectedHeight = Math.max(topForm.offsetHeight - 84, 0);
+          const unexpectedHeight = statusUnexpectedHeight+topFormUnexpectedHeight;
+
+          setRuleForSelector(byId(scrollBody.id), `
 max-height: ${parseInt(scrollBody.style.maxHeight, 10)-unexpectedHeight}px !important;
 min-height: ${parseInt(scrollBody.style.minHeight, 10)-unexpectedHeight}px !important;
 height: ${parseInt(scrollBody.style.height, 10)-unexpectedHeight}px !important;
 `);
-    });
+        });
 
-  stopper.onValue(() => {
-    // Go through the rules array backwards so that we remove them in backwards
-    // order. If we went through in ascending order, we'd have to worry about
-    // the list shrinking out from under us.
-    for (var ix=sheet.cssRules.length-1; ix>=0; ix--) {
-      if (_.startsWith((sheet.cssRules:any)[ix].selectorText, byId(composeId)+' ')) {
-        sheet.deleteRule(ix);
-      }
-    }
-  });
+      stopper.onValue(() => {
+        // Go through the rules array backwards so that we remove them in backwards
+        // order. If we went through in ascending order, we'd have to worry about
+        // the list shrinking out from under us.
+        for (let ix=sheet.cssRules.length-1; ix>=0; ix--) {
+          if (_.startsWith((sheet.cssRules:any)[ix].selectorText, byId(composeId)+' ')) {
+            sheet.deleteRule(ix);
+          }
+        }
+      });
+    });
 }


### PR DESCRIPTION
Since the composeviews becoming synchronously emitted in the drawerview pull request, inline composes trigger an exception in the compose sizeFixer code. The exception was caught and logged, and I'm not sure that the sizeFixer really was important for inline composes, so there were no user-visible consequences of these errors.

This was caused because sizeFixer() runs after the composeview becomes ready, and it calls `composeView.getScrollBody()`, but the element wasn't ready when the inline composeview synchronously became ready. The method is now marked as returning a maybe type instead of throwing an exception, and sizeFixer() uses streamWaitFor when calling it.
