### PR TITLE
Inbox: Make ComposeViewButton.showTooltip() work on inline composes

### DIFF
--- a/examples/compose-tooltip-button/content.js
+++ b/examples/compose-tooltip-button/content.js
@@ -24,26 +24,23 @@ InboxSDK.load(1, 'simple-example', {inboxBeta:true}).then(function(inboxSDK) {
 			section: 'TRAY_LEFT'
 		});
 
-		if (!composeView.isInlineReplyForm()) {
-			button.showTooltip({
-				imageUrl: chrome.runtime.getURL('partycat.jpg'),
-				title: 'Monkeys Rule!',
-				subtitle: 'the jungle',
-				button: {
-					title: 'Party!',
-					onClick: function(){
-						var div = document.createElement('div');
-						div.innerHTML = 'Hello World!';
-						div.style.background = 'green';
-						button2.showTooltip({
-							el: div
-						});
+		button.showTooltip({
+			imageUrl: chrome.runtime.getURL('partycat.jpg'),
+			title: 'Monkeys Rule!',
+			subtitle: 'the jungle',
+			button: {
+				title: 'Party!',
+				onClick: function(){
+					var div = document.createElement('div');
+					div.innerHTML = 'Hello World!';
+					div.style.background = 'green';
+					button2.showTooltip({
+						el: div
+					});
 
-						setTimeout(function(){button2.closeTooltip();}, 5*1000);
-					}
+					setTimeout(function(){button2.closeTooltip();}, 5*1000);
 				}
-			});
-		}
-
+			}
+		});
 	});
 });

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-button-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-button-view.js
@@ -95,7 +95,11 @@ class InboxComposeButtonView {
 
   showTooltip(tooltipDescriptor: TooltipDescriptor) {
     if (this._composeView.isInlineReplyForm()) {
-      throw new Error("Tooltips not supported in Inbox inline compose");
+      // In Inbox, if you haven't interacted with an inline compose yet, then
+      // it will auto-close as soon as anything else including the tooltip is
+      // interacted with. Focusing the inline compose is enough to make Inbox
+      // think it's been interacted with and to avoid that behavior.
+      this._composeView.getElement().focus();
     }
     if (this._tooltip) {
       this.closeTooltip();


### PR DESCRIPTION
In Inbox, if you click out of an inline compose before interacting with it, then the inline compose closes itself, so clicking on a tooltip we added to the compose would close the compose. I previously disabled tooltips on inline compose views because I didn't fully understand this behavior and couldn't figure out a work-around. Now I figured out a workaround: focusing the composeview's element when the tooltip is created is enough to convince Inbox that the compose has been interacted with and switches it out of auto-close mode.