### PR TITLE
Convert ThreadRowViewDriver interface def to flow

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.js
@@ -8,11 +8,10 @@ import asap from 'asap';
 import kefirBus from 'kefir-bus';
 import type {Bus} from 'kefir-bus';
 
-import assertInterface from '../../../lib/assert-interface';
 import querySelector from '../../../lib/dom/querySelectorOrFail';
 import makeMutationObserverChunkedStream from '../../../lib/dom/make-mutation-observer-chunked-stream';
 import kefirCast from 'kefir-cast';
-import ThreadRowViewDriver from '../../../driver-interfaces/thread-row-view-driver';
+import type {ThreadRowViewDriver} from '../../../driver-interfaces/thread-row-view-driver';
 import delayAsap from '../../../lib/delay-asap';
 import kefirStopper from 'kefir-stopper';
 
@@ -101,6 +100,7 @@ class GmailThreadRowView {
   _isDestroyed: boolean = false;
 
   constructor(element: HTMLElement, rowListViewDriver: GmailRowListView, gmailDriver: GmailDriver) {
+    (this: ThreadRowViewDriver);
     assert(element.hasAttribute('id'), 'check element is main thread row');
 
     this._isVertical = _.intersection(_.toArray(element.classList), ['zA','apv']).length === 2;
@@ -899,8 +899,6 @@ class GmailThreadRowView {
     return subjectRefresher;
   }
 }
-
-assertInterface(GmailThreadRowView.prototype, ThreadRowViewDriver);
 
 export default defn(module, GmailThreadRowView);
 

--- a/src/platform-implementation-js/driver-interfaces/driver.js
+++ b/src/platform-implementation-js/driver-interfaces/driver.js
@@ -15,6 +15,8 @@ import type GmailThreadView from '../dom-driver/gmail/views/gmail-thread-view';
 import type InboxThreadView from '../dom-driver/inbox/views/inbox-thread-view';
 export type ThreadViewDriver = GmailThreadView|InboxThreadView;
 
+import type {ThreadRowViewDriver} from './thread-row-view-driver';
+
 import type {MessageViewDriver} from './message-view-driver';
 
 import type GmailAttachmentCardView from '../dom-driver/gmail/views/gmail-attachment-card-view';
@@ -51,7 +53,7 @@ export type Driver = {
 	getUserEmailAddress(): string;
 	getUserContact(): Contact;
 	getAccountSwitcherContactList(): Contact[];
-	getThreadRowViewDriverStream(): Kefir.Observable<Object>;
+	getThreadRowViewDriverStream(): Kefir.Observable<ThreadRowViewDriver>;
 	addNavItem(appId: string, navItemDescriptor: Object): Object;
 	getSentMailNativeNavItem(): Promise<Object>;
 	createLink(a: any, b: any): any;

--- a/src/platform-implementation-js/driver-interfaces/thread-row-view-driver.js
+++ b/src/platform-implementation-js/driver-interfaces/thread-row-view-driver.js
@@ -1,9 +1,11 @@
-module.exports = {
-  addLabel: 1,
-  addButton: 1,
-  addAttachmentIcon: 1,
-  replaceDate: 1,
-  getSubject: 0,
-  getDateString: 0,
-  getThreadID: 0
+/* @flow */
+
+export type ThreadRowViewDriver = {
+  addLabel(label: Object): void;
+  addButton(buttonDescriptor: Object): void;
+  addAttachmentIcon(opts: Object): void;
+  replaceDate(opts: Object): void;
+  getSubject(): string;
+  getDateString(): string;
+  getThreadID(): string;
 };


### PR DESCRIPTION
Take the old `assertInterface` runtime validation and move it to
a proper flow def. This is pretty naive and mostly just replaces
what was already there, plus some basic param/return type info.