### PR TITLE
Remove useless return type descriptions, add to fn descriptions

### DIFF
--- a/src/docs/compose.js
+++ b/src/docs/compose.js
@@ -20,15 +20,16 @@ var Compose = /** @lends Compose */ {
   * ^gmail
   * ^inbox
   * @param {func(ComposeView)} handler - The function to be called.
-  * @return {function} a function to call when you want to unregister this handler
+  * @return {function}
   */
   registerComposeViewHandler: function(){},
 
   /**
-   * Opens a new compose view. Any handlers you've registered for ComposeViews will be called as well.
+   * Opens a new compose view. Any handlers you've registered for ComposeViews will be called as well. Returns
+   * a promise which will resolve with the new ComposeView once it has opened.
    * ^gmail
    * ^inbox
-   * @return {Promise.<ComposeView>} a promise that will resolve to a ComposeView once the ComposeView has opened
+   * @return {Promise.<ComposeView>}
    */
   openNewComposeView: function(){},
 

--- a/src/docs/custom-route-view.js
+++ b/src/docs/custom-route-view.js
@@ -10,7 +10,7 @@ var CustomRouteView = /** @lends CustomRouteView */{
 	* should inject your content into this element.
 	* ^gmail
   * ^inbox
-	* @return {HTMLElement} the main element of your custom route
+	* @return {HTMLElement}
 	*/
 	getElement: function(){},
 

--- a/src/docs/inboxsdk.js
+++ b/src/docs/inboxsdk.js
@@ -7,21 +7,24 @@ var InboxSDK = {
 };
 
 /**
-* Loads the InboxSDK remotely and prepares it to be used.
+* Loads InboxSDK remotely and prepares it to be used. Returns a promise
+* which resolves with the SDK interface (see usage examples under "Structuring
+* Your App") when the SDK is loaded and ready to be used.
 * @function
 * @param {number} version - The API version of the SDK to use. The recommended value right now is <code>1</code>. The value <code>2</code> may be used to opt in early to use the Inbox support which is still under development. See the <a href="#InboxSupport">Inbox Support</a> section for more information.
 * @param {string} appId - The AppId that you registered for on the <a href="/register">AppId Registration page</a>.
 * @param {LoadOptions} [options] - Optional options object.
-* @return {Promise} A promise which resolves when the SDK is loaded and ready to be used.
+* @return {Promise}
 */
 InboxSDK.load = function(){};
 
 /**
-* Loads a remote script into this extension's content script space and evals it
+* Loads a remote script into the extension's content script space and evals it.
+* Returns a promise which resolves when the script is finished downloading and eval'ing.
 * @function
 * @param {string} url - The URL of the remote script to load.
 * @param {LoadScriptOptions} [options] - Optional options object.
-* @return {Promise} a promise which resolves when this script is finished downloading and eval'ing
+* @return {Promise}
 */
 InboxSDK.loadScript = function(){};
 

--- a/src/docs/list-route-view.js
+++ b/src/docs/list-route-view.js
@@ -7,18 +7,20 @@
 var ListRouteView = /** @lends ListRouteView */ {
 
 	/**
-	 * Adds a collapsible section to the top of the page.
+	 * Adds a collapsible section to the top of the page and returns
+	 * a CollapsibleSectionView which represents it.
 	 * ^gmail
 	 * @param {SectionDescriptor|Stream.<SectionDescriptor>} options - configuration options of the CollapsibleSectionView
-	 * @returns {CollapsibleSectionView} the CollapsibleSectionView that was added
+	 * @returns {CollapsibleSectionView}
 	 */
 	addCollapsibleSection: function(){},
 
 	/**
-	 * Adds a non-collapsible section to the top of the page.
+	 * Adds a non-collapsible section to the top of the page and returns
+	 * a SectionView which represents it.
 	 * ^gmail
 	 * @param {SectionDescriptor|Stream.<SectionDescriptor>} options - configuration options of the SectionView
-	 * @returns {SectionView} the SectionView that was added
+	 * @returns {SectionView}
 	 */
 	addSection: function(){},
 

--- a/src/docs/message-view.js
+++ b/src/docs/message-view.js
@@ -128,10 +128,10 @@ var MessageView = /** @lends MessageView */{
 
 	/**
 	 * Gets Gmail's representation of the timestamp of the message.
-	 * Note: this is the string representation because timezone information is not available,
+	 * Note: this returns a string representation because timezone information is not available,
 	 * the accuracy is limited to minutes, and it is formatted to the user's language.
 	 * ^gmail
-	 * @return {string} The date as a string.
+	 * @return {string}
 	 */
 	getDateString: function(){},
 

--- a/src/docs/router.js
+++ b/src/docs/router.js
@@ -22,13 +22,14 @@ var Router = /** @lends Router */ {
 
 	/**
 	* Get a URL that can be used to navigate to a view. You'll typically want to use this to set the href of an <a> element or similar.
+	* Returns the encoded URL string.
 	* ^gmail
 	* ^inbox
 	* @param {string} routeID - A route specifying where the link should navigate the user to.
 	* @param {Object} params - an object containing the parameters that will be encoded in the link and decoded when the user
 	* subsequently visits the route. Handlers for the specified routeID will receive a copy of this object. This object must contain
 	* only simple key value pairs with no nested arrays/objects.
-	* @return {string} the encoded URL
+	* @return {string}
 	*/
 	createLink: function(){},
 
@@ -53,7 +54,7 @@ var Router = /** @lends Router */ {
 	* @param {string} routeID - which route this handler is registering for
 	* @param {func(CustomRouteView)} handler - The callback to call when the route changes to a custom route matching
 	* the provided routeID
-	* @return {function} a function which can be called to to stop handling these routes
+	* @return {function}
 	*/
 	handleCustomRoute: function(){},
 
@@ -64,7 +65,7 @@ var Router = /** @lends Router */ {
 	* which can be called to unregister the route handler.
 	* ^gmail
 	* @param {func(RouteView)} handler - The callback to call when the route changes
-	* @return {function} a function which can be called to to stop handling these routes
+	* @return {function}
 	*/
 	handleAllRoutes: function(){},
 
@@ -83,7 +84,7 @@ InboxSDK.load('1', 'MY_APP_ID').then(function(sdk) {
 });
 	* @param {NativeListRouteIDs} routeID - which list route this handler is registering for.
 	* @param {func(ListRouteView)} handler - The callback to call when the route changes to a list route matching the routeId.
-	* @return {function} a function which can be called to stop handling these routes
+	* @return {function}
 	*/
 	handleListRoute: function(){},
 
@@ -101,7 +102,7 @@ InboxSDK.load('1', 'MY_APP_ID').then(function(sdk) {
 	* ^gmail
 	* @param {string} routeID - which route this handler is registering for
 	* @param {function(offset)} handler - passed a page offset at must return an array (or Promise for an array) of thread ids.
-	* @return {function} a function which can be called to stop handling these routes
+	* @return {function}
 	*/
 	handleCustomListRoute: function() {},
 

--- a/src/docs/thread-row-view.js
+++ b/src/docs/thread-row-view.js
@@ -65,23 +65,23 @@ var ThreadRowView = /** @lends ThreadRowView */ {
   /**
   * Gets the subject of this thread.
   * ^gmail
-  * @return {string} The subject.
+  * @return {string}
   */
   getSubject: function(){},
 
   /**
   * Gets string representation of the timestamp of the most recent message on the thread.
-  * Note: this is the string representation because timezone information is not available,
+  * Note: this returns a string representation because timezone information is not available,
   * the accuracy is limited to minutes, and it is formatted to the user's language.
   * ^gmail
-  * @return {string} The date as a string.
+  * @return {string}
   */
   getDateString: function(){},
 
   /**
    * Gets the Gmail Thread ID of the thread.
    * ^gmail
-   * @return {string} The gmail threadID.
+   * @return {string}
    */
   getThreadID: function(){},
 
@@ -90,9 +90,10 @@ var ThreadRowView = /** @lends ThreadRowView */ {
   * such as those with only a single Draft message in them will occasionally change their
   * thread ID. If you're using the thread ID as a key, you may experiemnce unexpected behaviour
   * if you're not careful about this fact. This method provides you with an easy way to tell if
-  * the thread has a stable ID. It will only return a thread ID if it is expected to stay the same.
+  * the thread has a stable ID. It will only return a thread ID if it is expected to stay the same,
+  * otherwise it will return <code>null</code>.
   * ^gmail
-  * @return {string} The gmail threadID or null if its not stable.
+  * @return {string|null}
   */
   getThreadIDIfStable: function(){},
 
@@ -120,10 +121,10 @@ var ThreadRowView = /** @lends ThreadRowView */ {
   getVisibleMessageCount: function(){},
 
   /**
-  * Gets the <b>visible</b> contacts listed on the row. Note: this may not include all
+  * Gets an Array of the <b>visible</b> contacts listed on the row. Note: this may not include all
   * participants on the thread as this information is not visible.
   * ^gmail
-  * @return {Contact[]} the visible contact objects
+  * @return {Contact[]}
   */
   getContacts: function(){},
 

--- a/src/docs/thread-view.js
+++ b/src/docs/thread-view.js
@@ -17,19 +17,23 @@ var ThreadView = /** @lends ThreadView */ {
 	addSidebarContentPanel: function(){},
 
 	/**
-	* Gets all the loaded MessageView objects currently in the thread. See MessageView for more information on what "loaded" means. Note that load more messages may load into the thread later!
-	* If it's important to get future messages, use {Conversations.registerMessageViewHandler} instead.
+	* Gets an Array of all the loaded MessageView objects currently in the thread.
+	* See MessageView for more information on what "loaded" means.
+	* Note that more messages may load into the thread later! If it's important
+	* to get future messages, use {Conversations.registerMessageViewHandler} instead.
 	* ^gmail
 	* ^inbox
-	* @return {MessageView[]} an array of message view objects
+	* @return {MessageView[]}
 	*/
 	getMessageViews: function(){},
 
 	/**
-	* Gets all the {MessageView} objects in the thread regardless of their load state. See {MessageView} for more information on what "loaded" means.
+	* Gets an Array of all the {MessageView} objects in the thread
+	* regardless of their load state. See {MessageView} for more information
+	* on what "loaded" means.
 	* ^gmail
 	* ^inbox
-	* @return {MessageView[]} an array of message view objects
+	* @return {MessageView[]}
 	*/
 	getMessageViewsAll: function(){},
 
@@ -37,7 +41,7 @@ var ThreadView = /** @lends ThreadView */ {
 	 * Gets the subject of this thread.
 	 * ^gmail
 	 * ^inbox
-	 * @return {string} The subject.
+	 * @return {string}
 	 */
 	getSubject: function(){},
 
@@ -45,7 +49,7 @@ var ThreadView = /** @lends ThreadView */ {
 	 * Gets the Gmail Thread ID of the thread.
 	 * ^gmail
 	 * ^inbox
-	 * @return {string} The gmail threadID.
+	 * @return {string}
 	 */
 	getThreadID: function(){},
 

--- a/src/docs/user.js
+++ b/src/docs/user.js
@@ -8,7 +8,7 @@ var User = /** @lends User */ {
 	 * Get the email address of the currently logged in user.
 	 * ^gmail
 	 * ^inbox
-	 * @return {string} an email address
+	 * @return {string}
 	 */
 	getEmailAddress: function(){},
 


### PR DESCRIPTION
We had a bunch of descriptions for return types in the docs which
didn't show up due to the way we process jsdoc files. This removes
all of the old descriptions and adds further context to the doc entries
for the functions they belong to where necessary to improve clarity.

cc @AgentME 