### PR TITLE
Inbox test improvements & fixups

### DIFF
--- a/test/chrome/inbox.js
+++ b/test/chrome/inbox.js
@@ -16,15 +16,8 @@ describe('Inbox', function() {
       const composeButton = browser.execute(() =>
         document.querySelector(`button[aria-labelledby="${Array.prototype.filter.call(document.querySelectorAll('button + label'), el => el.textContent === 'Compose')[0].id}"]`)
       );
-      const composeButtonHtml = browser.execute((el) => el.outerHTML, composeButton.value).value;
-      console.log('composeButton initial HTML (before click): ', composeButtonHtml);
       composeButton.click();
-      try {
-        browser.waitForVisible('div[role=dialog] div[jsaction^=compose]');
-      } catch (e) {
-        console.log('composeButton initial HTML: ', composeButtonHtml);
-        throw e;
-      }
+      browser.waitForVisible('div[role=dialog] div[jsaction^=compose]', 10*1000);
 
       assert.strictEqual(browser.getText('.test__tooltipButton'), 'Counter: 0');
       browser.click('.test__tooltipButton');


### PR DESCRIPTION
- Add logging of the HTML for the new compose window button — we've seen some intermittent failures and want to have more context should it arise again.
- Add a check for the `CI` env variable to toggle calling
`browser.debug()` on test errors rather than relying on manual
commenting/uncommenting (woo!).
- Add a bunch of console logging that was necessary for debugging and
will probably be helpful during future issues.
- Make test significantly more reliable against timing/DOM visibility/
frame switching issues.