### PR TITLE
Log event for registering custom routes

### DIFF
--- a/src/platform-implementation-js/namespaces/router.js
+++ b/src/platform-implementation-js/namespaces/router.js
@@ -73,8 +73,11 @@ class Router {
 		};
 
 		const removeCustomRouteFromDriver = get(memberMap, this).driver.addCustomRouteID(routeID);
-		const {customRoutes} = get(memberMap, this);
+		const {customRoutes, driver} = get(memberMap, this);
+
 		customRoutes.push(customRouteDescriptor);
+
+		driver.getLogger().eventSdkPassive('Router.handleCustomRoute');
 
 		return function(){
 			removeCustomRouteFromDriver();


### PR DESCRIPTION
We realized that understanding the usage levels/breakdown for
`handleCustomRoute()` may be useful to us going forward if we want
to make some changes/be more restrictive on how users interact with
custom route handlers. This adds a passive event to do just that.

Also, swap some `var`s for `const` and use destructuring where it was already happening ad-hoc because it's essentially impossible for me to avoid cleaning that stuff up when I'm in a file.