### PR TITLE
Add some extra meta for router.goto parameter issues

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/create-link.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/create-link.js
@@ -38,7 +38,10 @@ export default function createLink(GmailRouteProcessor: GmailRouteProcessor, rou
 	try {
 		processedRoute = populateRouteID(routeID, params);
 	} catch (error) {
-		Logger.error(error);
+		Logger.error(error, {
+			routeID,
+			paramsKey: Object.keys(params)
+		});
 
 		processedRoute = parts
 							.map(function(part){


### PR DESCRIPTION
We want to log some extra info about the specific route IDs that are causing exceptions when validating parameters. Right now we're only going to log the route ID plus the parameter names that were included in the params object.