### PR TITLE
Fix list view actions inside custom thread lists

### DIFF
--- a/src/injected-js/gmail/setup-gmail-interceptor.js
+++ b/src/injected-js/gmail/setup-gmail-interceptor.js
@@ -364,6 +364,7 @@ export default function setupGmailInterceptor() {
           params.search && params.view === 'tl' &&
           connection.url.match(/^\?/) &&
           params.q &&
+          !params.act &&
           (customSearchQuery = find(customSearchQueries, x => x === params.q))
         ) {
           if (customListJob) {


### PR DESCRIPTION
When trying to use native Gmail actions (archive, delete, move, etc.)
on messages in a custom list view, Gmail would error out in the UI —
*even though* the desired action actually took place in the backend.

This ended up being due to our XHR request intercept logic being
too lax in its matching of outgoing requests, which led to it thinking
it should mess with the request's content when it really shouldn't.

After looking at the outgoing request data it appears the parameters in
all native Gmail actions contain an `act` param with some sort of
ID describing the desired action, so this change modifies our request
interceptor from custom thread lists to ignore requests which have
an `act`. Tested seems to fix the issue as expected.