### PR TITLE
Fix sidebar icon floating above compose mole

### DIFF
--- a/src/platform-implementation-js/style/inbox.css
+++ b/src/platform-implementation-js/style/inbox.css
@@ -120,7 +120,6 @@
 .IDMAP_sidebar_iconArea {
   position: absolute;
   right: -16px;
-  z-index: 100;
 
   /* needed to prevent rendering bug in chrome where the element is
   visibly duplicated when the parent becomes position:fixed. */


### PR DESCRIPTION
Fixes this:

![image](https://cloud.githubusercontent.com/assets/1850998/23384095/33e8be82-fcfe-11e6-99b7-84c403e7bddc.png)
