### PR TITLE
Gracefully degrade when RFC ID fetch fails for custom lists

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.js
@@ -228,7 +228,7 @@ const setupSearchReplacing = (
           return driver.getMessageIdManager().getRfcMessageIdForGmailThreadId(gtid)
             .then(rfcId => ({gtid, rfcId}), err => findIdFailure(gtid, err));
         }
-      })).then((pairs: IDPairsWithRFC) => ({start, total, threads: pairs}))
+      })).then((pairs: IDPairsWithRFC) => ({start, total, threads: pairs.filter(Boolean)}))
     ))
     .flatMap(Kefir.fromPromise)
     .onValue((


### PR DESCRIPTION
When adding pagination support we removed a `_.compact()` which seemed
unnecessary. Turns out that when we are given a Gmail thread ID
*but* we can't fetch it's corresponding RFC ID, we end up with a
sparse array. This is due to the rejection handler inside our
`Promise.all()` returning `null` and eventually populating our combined
result array with `null`.

For now, this change simply filters out the unwanted `null`s so we
end up with the dense array we expected. Tested and works as intended.

Going forward, though, we have a couple things to think about:

1) The `IDPairsWithRFC` type we are annotating doesn't *actually*
accept sparsity. Should probably make that a little more explicit but
that's outside the scope of this commit.
2) Now that we're accepting a `total` property to show, gracefully
leaving out missing threads has the side-effect of making the total
count inaccurate. There doesn't seem to be an easy way to solve this,
but worth giving a little thought to.