### PR TITLE
page-parser-tree optimization and bugfixes

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4454,9 +4454,9 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz"
     },
     "page-parser-tree": {
-      "version": "0.3.2",
-      "from": "page-parser-tree@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/page-parser-tree/-/page-parser-tree-0.3.2.tgz"
+      "version": "0.3.3",
+      "from": "page-parser-tree@>=0.3.3 <0.4.0",
+      "resolved": "https://registry.npmjs.org/page-parser-tree/-/page-parser-tree-0.3.3.tgz"
     },
     "pako": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "node-dir": "^0.1.6",
     "notp": "^2.0.3",
     "order-manager": "^1.0.0",
-    "page-parser-tree": "^0.3.1",
+    "page-parser-tree": "^0.3.3",
     "pdelay": "^1.0.0",
     "postcss-selector-parser": "^2.2.0",
     "react": "^15.3.2",


### PR DESCRIPTION
* Fix bugs in page-parser-tree with owned elements: when an element was first emitted by page-parser-tree, its owned items wouldn't be present in the tag-tree until the next async step. (Given that avoiding this issue was one of the primary motivating factors for making page-parser-tree, this was a bit embarrassing of an issue.) Fixed by the addition of Schedulers to live-set.
* Optimize initial PageParserTree setup: instead of using pullChanges() on every subscription, instead we just flush the Scheduler used by PageParserTree's LiveSets.
* Optimize PageParserTree element handling: create fewer LiveSets, don't create any at runtime when elements come in.