### PR TITLE
Log an error w/ payload when we fail to parse a send request

### DIFF
--- a/src/common/censorJSONTree.js
+++ b/src/common/censorJSONTree.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+export default function censorJSONTree(object: Object): string {
+  return JSON.stringify(object, (key, value) => (
+    typeof value === 'string' ? '...' : value
+  ));
+}

--- a/src/platform-implementation-js/dom-driver/inbox/inbox-page-communicator.js
+++ b/src/platform-implementation-js/dom-driver/inbox/inbox-page-communicator.js
@@ -29,6 +29,13 @@ export default class InboxPageCommunicator extends CommonPageCommunicator {
 
     return draftID;
   }
+  notifyEmailSending(): void {
+    document.dispatchEvent(new CustomEvent('inboxSDKcomposeViewIsSending', {
+      bubbles: true,
+      cancelable: false,
+      detail: null
+    }));
+  }
   registerAllowedHashLinkStartTerm(term: string) {
     document.dispatchEvent(new CustomEvent('inboxSDKregisterAllowedHashLinkStartTerm', {
       bubbles: false,

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
@@ -115,12 +115,12 @@ class InboxComposeView {
 
     this.getEventStream()
       .takeUntilBy(this._stopper)
-      .filter(({eventName}) => (
-        eventName === 'presending' || eventName === 'sendCanceled'
-      )).map(({eventName}) => (
-        eventName === 'presending'
-      )).onValue(value => {
-        this._isSendPending = value;
+      .onValue(({eventName}) => {
+        if (eventName === 'presending') {
+          this._isSendPending = true;
+        } else if (eventName === 'sendCanceled') {
+          this._isSendPending = false;
+        }
       });
 
     handleComposeLinkChips(this);
@@ -183,6 +183,8 @@ class InboxComposeView {
     };
 
     if (this._isSendPending) {
+      this._driver.getPageCommunicator().notifyEmailSending();
+
       Kefir.merge([
         Kefir.combine([
           this.getEventStream().filter(({eventName}) => eventName === 'sending'),


### PR DESCRIPTION
- If a ComposeView just got destroyed because of a send, tell
the AJAX intercept code so it can report on whether or not it
successfully parsed the send.
- Log an error that includes a censored version of the request payload
so we can debug.
- Add a `takeErrors` to make the code more clear (technically the same effect is already being achieved via a roundabout way).
- Also simplify the isSendPending stream a little because it was
bugging me.