### PR TITLE
Add some more basic send logging while we work on other fixes

### DIFF
--- a/src/injected-js/inbox/setupAjaxInterceptor.js
+++ b/src/injected-js/inbox/setupAjaxInterceptor.js
@@ -107,39 +107,45 @@ export default function setupAjaxInterceptor() {
           const originalRequest = JSON.parse(connection.originalSendBody);
 
           const updateList = (
-            originalRequest['2'] &&
-            originalRequest['2']['1']
+            originalRequest[2] &&
+            originalRequest[2][1]
           );
           if (!updateList) {
             logIfParseFailed(originalRequest);
             return;
           }
 
-          const sendUpdateMatch = updateList.find((update) => (
-            update['2'] &&
-            update['2']['2'] &&
-            update['2']['2']['14'] &&
-            update['2']['2']['14']['1'] &&
-            update['2']['2']['14']['1']['1'] &&
-            update['2']['2']['14']['1']['1'].indexOf('msg-a:') > -1
-          ));
+          const sendUpdateMatch = updateList.find((update) => {
+            const updateWrapper = (
+              update[2] &&
+              update[2][2] &&
+              (update[2][2][14] || update[2][2][2])
+            );
+
+            return (
+              updateWrapper &&
+              updateWrapper[1] &&
+              updateWrapper[1][1] &&
+              updateWrapper[1][1].indexOf('msg-a:') > -1
+            );
+          });
           if (!sendUpdateMatch) {
             logIfParseFailed(originalRequest);
             return;
           }
 
-          const sendUpdate = (
-            sendUpdateMatch['2'] &&
-            sendUpdateMatch['2']['2'] &&
-            sendUpdateMatch['2']['2']['14'] &&
-            sendUpdateMatch['2']['2']['14']['1']
+          const sendUpdateWrapper = (
+            sendUpdateMatch[2] &&
+            sendUpdateMatch[2][2] &&
+            (sendUpdateMatch[2][2][14] || sendUpdateMatch[2][2][2])
           );
+          const sendUpdate = sendUpdateWrapper[1];
 
           const draftID = (
-            sendUpdate['1'] &&
-            sendUpdate['1'].replace('msg-a:', '')
+            sendUpdate[1] &&
+            sendUpdate[1].replace('msg-a:', '')
           );
-          const actionList = sendUpdate['11'];
+          const actionList = sendUpdate[11];
           if (!(actionList && draftID)) {
             logIfParseFailed(originalRequest);
             return;
@@ -175,8 +181,8 @@ export default function setupAjaxInterceptor() {
           const originalResponse = JSON.parse(connection.originalResponseText);
 
           const updateList = (
-            originalResponse['2'] &&
-            originalResponse['2']['6']
+            originalResponse[2] &&
+            originalResponse[2][6]
           );
           if (!updateList) {
             sendFailed();
@@ -184,13 +190,13 @@ export default function setupAjaxInterceptor() {
           }
 
           const sendUpdateMatch = updateList.find((update) => (
-            update['1'] &&
-            update['1']['3'] &&
-            update['1']['3']['7'] &&
-            update['1']['3']['7']['1'] &&
-            update['1']['3']['7']['1']['5'] &&
-            update['1']['3']['7']['1']['5'][0] &&
-            update['1']['3']['7']['1']['5'][0]['14']
+            update[1] &&
+            update[1][3] &&
+            update[1][3][7] &&
+            update[1][3][7][1] &&
+            update[1][3][7][1][5] &&
+            update[1][3][7][1][5][0] &&
+            update[1][3][7][1][5][0][14]
           ));
           if (!sendUpdateMatch) {
             sendFailed();
@@ -198,15 +204,15 @@ export default function setupAjaxInterceptor() {
           }
 
           const sendUpdate = (
-            sendUpdateMatch['1'] &&
-            sendUpdateMatch['1']['3'] &&
-            sendUpdateMatch['1']['3']['7'] &&
-            sendUpdateMatch['1']['3']['7']['1'] &&
-            sendUpdateMatch['1']['3']['7']['1']['5'] &&
-            sendUpdateMatch['1']['3']['7']['1']['5'][0]
+            sendUpdateMatch[1] &&
+            sendUpdateMatch[1][3] &&
+            sendUpdateMatch[1][3][7] &&
+            sendUpdateMatch[1][3][7][1] &&
+            sendUpdateMatch[1][3][7][1][5] &&
+            sendUpdateMatch[1][3][7][1][5][0]
           );
 
-          const rfcID = sendUpdate['14'];
+          const rfcID = sendUpdate[14];
 
           triggerEvent({
             type: 'emailSent',


### PR DESCRIPTION
I'm pretty sure there's some kind of race condition going on w/ outgoing send requests, and while I am working on that problem I want to expand some logging to get more info.

We're seeing a ton of outgoing requests that *appear* to be valid sends, but don't have action lists that match our [predefined set of required actions](https://github.com/StreakYC/GmailSDK/blob/0ee6be59ad3d73c6a9e333556dd9a7fbf558db37/src/injected-js/inbox/setupAjaxInterceptor.js#L99). My guess is that our list is a little too long and includes stuff that isn't in the send requests from some users (my hunch is that really only `^f_bt` is actually required to send a message but I want more data). For these requests, I'm now going to log the send actions without sanitizing them because they don't contain any sensitive info. Hopefully once I see the data coming through it'll be clear what needs to change to handle this subset of failing cases.

In addition to the action list logging, I'm adding support for one other schema that has been popping up in the logs. I've seen a bunch of different request shapes in the data, but most of them appear to be requests that don't contain any info on a message being saved/sent whatsoever (this is evidence of the race I mentioned earlier). Because the action list is sanitized I can't tell whether or not this second schema is only for draft saves *or* if it's an alternate schema for email sends. By adding support for it right now I'll be able to check whether it needs to be supported for sends.