### PR TITLE
Fix handling of send cancels caused by Gmail

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -237,6 +237,19 @@ class GmailComposeView {
 				this._setupConsistencyCheckers();
 				this._updateComposeFullscreenState();
 
+				this.getEventStream()
+					.filter(({eventName}) => eventName === 'presending')
+					.takeUntilBy(this._stopper)
+					.onValue(() => {
+						Kefir.later(15).takeUntilBy(
+							this.getEventStream().filter(({eventName}) => eventName === 'sendCanceled')
+						).onValue(() => {
+							if (isElementVisible(this._element)) {
+								this._eventStream.emit({eventName: 'sendCanceled'});
+							}
+						});
+					});
+
 				return this;
 			}).toProperty()
 		);


### PR DESCRIPTION
Just uncovered this issue while dealing with events in Inbox, so fixing
on the Gmail side as well.

When something about an email (e.g. no recipients) causes Gmail to
cancel a send, we fire a `presending` event but never recognize that
the send was aborted. Since we already have the `sendCanceled` event,
it's pretty simple to express that behavior via the public API.

This change checks whether or not the compose window is still visible
15ms after a `presending` (to let Gmail's JS handle the send
appropriately), then dispatches a `sendCanceled` if one hasn't been
fired already.