### PR TITLE
Handle gmail-canceled send better (esp. replies)

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -242,11 +242,12 @@ class GmailComposeView {
 					.takeUntilBy(this._stopper)
 					.onValue(() => {
 						Kefir.later(15).takeUntilBy(
-							this.getEventStream().filter(({eventName}) => eventName === 'sendCanceled')
+							this.getEventStream().filter(({eventName}) => (
+								eventName === 'sendCanceled' ||
+								eventName === 'sending'
+							))
 						).onValue(() => {
-							if (isElementVisible(this._element)) {
-								this._eventStream.emit({eventName: 'sendCanceled'});
-							}
+							this._eventStream.emit({eventName: 'sendCanceled'});
 						});
 					});
 


### PR DESCRIPTION
While the previous way we were handling this was ok for compose moles,
turns out the inline reply element actually doesn't get hidden until
the email send is complete. The end result is that a `sendCanceled` is
triggered for every email send via inline compose.

Lucky for us, it appears Gmail triggers a sending request synchronously
(ish?), so we can rely on on the `sending` event instead of DOM
visibility to inform us that the email is actually getting sent out to
the server.