### PR TITLE
Don't detect canceled sends for inline ComposeViews

### DIFF
--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
@@ -140,19 +140,20 @@ class InboxComposeView {
             this._driver.getLogger().error(error);
           });
           this._driver.getPageCommunicator().notifyEmailSending();
-
-          Kefir.later(15)
-            .takeUntilBy(sendCanceledStream)
-            .onValue(() => {
-              // In cases where Inbox decides to cancel the send client-side,
-              // we need to make sure we realize sending is not going to happen
-              // and inform consumers who might be expecting a send.
-              // The most common case for this is trying to send an email
-              // with no recipients.
-              if (document.contains(this._element)) {
-                this._eventStream.emit({eventName: 'sendCanceled'});
-              }
-            });
+          if (!this._p.attributes.isInline) {
+            Kefir.later(15)
+              .takeUntilBy(sendCanceledStream)
+              .onValue(() => {
+                // In cases where Inbox decides to cancel the send client-side,
+                // we need to make sure we realize sending is not going to happen
+                // and inform consumers who might be expecting a send.
+                // The most common case for this is trying to send an email
+                // with no recipients.
+                if (document.contains(this._element)) {
+                  this._eventStream.emit({eventName: 'sendCanceled'});
+                }
+              });
+          }
         } else if (eventName === 'sendCanceled') {
           this._isPresending = false;
           this._driver.getPageCommunicator().notifyEmailSendCanceled();


### PR DESCRIPTION
Related to #284. Inline ComposeViews don't get removed until the actual
AJAX request goes up to execute the send, and since sync requests are
highly variable in timing it's not practical to use a short timeout
the way we do for ComposeView moles. Since this issue does cause some
inconsistent behavior in the public API (`sendCanceled` events firing
when they shouldn't), for now this change avoids detecting canceled
sends until we can figure out a better way to handle the
inline behavior.