### PR TITLE
Make tests more dependable

### DIFF
--- a/test/inbox-attachment-card-detection.js
+++ b/test/inbox-attachment-card-detection.js
@@ -10,7 +10,7 @@ import jsdomDoc from './lib/jsdom-doc';
 import fakePageGlobals from './lib/fake-page-globals';
 import querySelector from '../src/platform-implementation-js/lib/dom/querySelectorOrFail';
 
-import makePageParserTree from '../src/platform-implementation-js/dom-driver/inbox/makePageParserTree';
+import makePageParserTree from './lib/makePageParserTree';
 import pageParserOptions from '../src/platform-implementation-js/dom-driver/inbox/pageParserOptions';
 import parser from '../src/platform-implementation-js/dom-driver/inbox/detection/attachmentCard/parser';
 

--- a/test/inbox-attachment-overlay-detection.js
+++ b/test/inbox-attachment-overlay-detection.js
@@ -10,7 +10,7 @@ import jsdomDoc from './lib/jsdom-doc';
 import fakePageGlobals from './lib/fake-page-globals';
 import querySelector from '../src/platform-implementation-js/lib/dom/querySelectorOrFail';
 
-import makePageParserTree from '../src/platform-implementation-js/dom-driver/inbox/makePageParserTree';
+import makePageParserTree from './lib/makePageParserTree';
 import pageParserOptions from '../src/platform-implementation-js/dom-driver/inbox/pageParserOptions';
 import parser from '../src/platform-implementation-js/dom-driver/inbox/detection/attachmentOverlay/parser';
 

--- a/test/inbox-compose-detection.js
+++ b/test/inbox-compose-detection.js
@@ -10,7 +10,7 @@ import jsdomDoc from './lib/jsdom-doc';
 import fakePageGlobals from './lib/fake-page-globals';
 import querySelector from '../src/platform-implementation-js/lib/dom/querySelectorOrFail';
 
-import makePageParserTree from '../src/platform-implementation-js/dom-driver/inbox/makePageParserTree';
+import makePageParserTree from './lib/makePageParserTree';
 import pageParserOptions from '../src/platform-implementation-js/dom-driver/inbox/pageParserOptions';
 
 import parser from '../src/platform-implementation-js/dom-driver/inbox/detection/compose/parser';

--- a/test/inbox-message-detection.js
+++ b/test/inbox-message-detection.js
@@ -10,7 +10,7 @@ import jsdomDoc from './lib/jsdom-doc';
 import fakePageGlobals from './lib/fake-page-globals';
 import querySelector from '../src/platform-implementation-js/lib/dom/querySelectorOrFail';
 
-import makePageParserTree from '../src/platform-implementation-js/dom-driver/inbox/makePageParserTree';
+import makePageParserTree from './lib/makePageParserTree';
 import pageParserOptions from '../src/platform-implementation-js/dom-driver/inbox/pageParserOptions';
 import parser from '../src/platform-implementation-js/dom-driver/inbox/detection/message/parser';
 

--- a/test/inbox-search-detection.js
+++ b/test/inbox-search-detection.js
@@ -5,7 +5,7 @@ import querySelector from '../src/platform-implementation-js/lib/dom/querySelect
 import fakePageGlobals from './lib/fake-page-globals';
 import pageParserOptions from '../src/platform-implementation-js/dom-driver/inbox/pageParserOptions';
 import parser from '../src/platform-implementation-js/dom-driver/inbox/detection/searchBar/parser';
-import makePageParserTree from '../src/platform-implementation-js/dom-driver/inbox/makePageParserTree';
+import makePageParserTree from './lib/makePageParserTree';
 import lsMap from 'live-set/map';
 
 function searchBarFinder(document) {

--- a/test/inbox-thread-detection.js
+++ b/test/inbox-thread-detection.js
@@ -9,7 +9,7 @@ import jsdomDoc from './lib/jsdom-doc';
 import fakePageGlobals from './lib/fake-page-globals';
 import querySelector from '../src/platform-implementation-js/lib/dom/querySelectorOrFail';
 
-import makePageParserTree from '../src/platform-implementation-js/dom-driver/inbox/makePageParserTree';
+import makePageParserTree from './lib/makePageParserTree';
 import pageParserOptions from '../src/platform-implementation-js/dom-driver/inbox/pageParserOptions';
 import parser from '../src/platform-implementation-js/dom-driver/inbox/detection/thread/parser';
 

--- a/test/lib/makePageParserTree.js
+++ b/test/lib/makePageParserTree.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+import type {Driver} from '../../src/platform-implementation-js/driver-interfaces/driver';
+import _makePageParserTree from '../../src/platform-implementation-js/dom-driver/inbox/makePageParserTree';
+import type PageParserTree from 'page-parser-tree';
+
+const activePageParserTrees = [];
+beforeEach(function() {
+  if (activePageParserTrees.length) {
+    throw new Error(`activePageParserTrees.length ${activePageParserTrees.length}`);
+  }
+});
+afterEach(function() {
+  activePageParserTrees.forEach(page => {
+    page.dump();
+  });
+  activePageParserTrees.length = 0;
+});
+
+export default function makePageParserTree(driver: ?Driver, root: Document|HTMLElement): PageParserTree {
+  const page = _makePageParserTree(driver, root);
+  activePageParserTrees.push(page);
+  return page;
+}


### PR DESCRIPTION
Dispose of PageParserTree instances after each mocha test. The PageParserTree instances were never disposed of before, and their finders (running on a regular interval) could execute after the instance's test had ended and a different test had set up an incompatible environment.