### PR TITLE
Inbox placeholder methods

### DIFF
--- a/src/platform-implementation-js/dom-driver/inbox/inbox-driver.js
+++ b/src/platform-implementation-js/dom-driver/inbox/inbox-driver.js
@@ -502,7 +502,8 @@ class InboxDriver {
   }
 
   getAccountSwitcherContactList(): Contact[] {
-    throw new Error('not implemented yet');
+    console.log('getAccountSwitcherContactList not implemented'); //eslint-disable-line no-console
+    return [this.getUserContact()];
   }
 
   addNavItem(appId: string, navItemDescriptor: Object): Object {


### PR DESCRIPTION
Adds no-op placeholder methods for `NavItemView.setCollapsed` and `NavItemView.destroy` in Inbox
Adds a partial implementation of `User.getAccountSwitcherContactList` in Inbox

Testing in Streak: https://github.com/StreakYC/MailFoo/pull/4126