### PR TITLE
Make the custom view container always fill the available space

### DIFF
--- a/src/platform-implementation-js/style/inbox.css
+++ b/src/platform-implementation-js/style/inbox.css
@@ -68,6 +68,7 @@
   left: 0;
   right: 0;
   /* needs to take up the whole screen so that it blocks clicks to elements behind it. */
+  display: flex;
   display: -webkit-flex;
   min-height: 100%;
   background: rgb(242, 242, 242);


### PR DESCRIPTION
Fixes custom views in Inbox so that the container element always fills the full height of the screen (as it already does when in Gmail).