### PR TITLE
Small gmail thread row bugfix

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.js
@@ -288,7 +288,7 @@ class GmailThreadRowView {
         labelMod.gmailLabelView.updateLabelDescriptor(labelDescriptor);
 
         const labelParentDiv = this._getLabelParent();
-        if (labelParentDiv.children !== labelMod.gmailLabelView.getElement().parentElement) {
+        if (labelParentDiv !== labelMod.gmailLabelView.getElement().parentElement) {
           labelParentDiv.insertBefore(
             labelMod.gmailLabelView.getElement(), labelParentDiv.lastChild);
         }


### PR DESCRIPTION
https://github.com/StreakYC/GmailSDK/pull/320 introduced a bug that meant we re-added the label to the dom more often than necessary.