### PR TITLE
Use extractContents()/insertNode() instead of surroundContents()

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/insert-link-into-body.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/insert-link-into-body.js
@@ -22,7 +22,7 @@ function _insertLinkIntoBody(gmailComposeView, text, href){
 	const range = selection.getRangeAt(0);
 	const link = document.createElement('a');
 	link.href = href;
-	link.appendChild(range.extractContents());
+	range.extractContents();
 	range.insertNode(link);
 	link.textContent = text;
 


### PR DESCRIPTION
Turns out when you use `surroundContents()` to wrap a range, it throws
if the range splits a non-text node (i.e. half of a `<div>`'s contents
are selected). If you use the `extractContents()`/`insertNode()` combo
it is (basically) functionally equivalent, and will clone the split
range instead of trying to re-use it.

As far as I can tell, this preserves the same behavior in all
replacement cases.

(MDN context for the curious: https://developer.mozilla.org/en-US/docs/Web/API/Range/surroundContents)