### PR TITLE
Gmail: Move box-shadow and border rules onto the dropdown.el element

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-dropdown-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-dropdown-view.js
@@ -19,10 +19,10 @@ Object.assign(GmailDropdownView.prototype, {
 
 	_setupElement: function(){
 		this._containerElement = document.createElement('div');
-		this._containerElement.setAttribute('class', 'J-M uEPqDe inboxsdk__menu');
+		this._containerElement.setAttribute('class', 'inboxsdk__menu');
 
 		this._contentElement = document.createElement('div');
-		this._contentElement.setAttribute('class', 'SK AX');
+		this._contentElement.setAttribute('class', 'inboxsdk__menuContent');
 
 		this._containerElement.appendChild(this._contentElement);
 	}

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -74,12 +74,29 @@ div.T-I.inboxsdk__button {
   text-shadow: none;
 }
 
-.J-M.inboxsdk__menu {
+.inboxsdk__menu {
   min-width: 1em;
   min-height: 1em;
   padding: 0px;
   overflow: visible;
   max-height: none;
+
+  /* Copied from Gmail's .J-M class */
+  z-index: 7;
+  cursor: default;
+  font-size: 13px;
+  margin: 0;
+  outline: none;
+}
+
+.inboxsdk__menu > .inboxsdk__menuContent {
+  padding: 0;
+  -webkit-box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  -webkit-transition: opacity .218s;
+  transition: opacity .218s;
+  border: 1px solid rgba(0,0,0,.2);
+  background: #fff;
 }
 
 .f4.J-N-JX.inboxsdk__message_more_icon {


### PR DESCRIPTION
This moves the box-shadow and border rules of the SDK's dropdowns onto the dropdown.el element given to the app, so the app can override them. (This was already the case in Inbox; this pull request makes Gmail do this too.) This allows https://github.com/StreakYC/MailFoo/pull/4168 to work.