### PR TITLE
Inbox CSS improvements

### DIFF
--- a/src/platform-implementation-js/dom-driver/inbox/views/InboxToolbarButtonView.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/InboxToolbarButtonView.js
@@ -39,11 +39,12 @@ class InboxToolbarButtonView {
           return;
         } else {
           this._buttonEl.classList.add('inboxsdk__active');
-          dropdown = new DropdownView(new InboxDropdownView('inboxsdk__toolbar_dropdown'), buttonEl);
+          dropdown = new DropdownView(new InboxDropdownView(), buttonEl);
           dropdown.setPlacementOptions({
             position: 'bottom',
             hAlign: 'right',
-            vAlign: 'top'
+            vAlign: 'top',
+            buffer: 10
           });
           dropdown.on('destroy', () => {
             this._buttonEl.classList.remove('inboxsdk__active');

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-button-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-button-view.js
@@ -50,7 +50,8 @@ class InboxComposeButtonView {
           dropdown.setPlacementOptions({
             position: 'top',
             hAlign: 'left',
-            vAlign: 'bottom'
+            vAlign: 'bottom',
+            buffer: 5
           });
           dropdown.on('destroy', () => {
             this._buttonEl.classList.remove('inboxsdk__active');

--- a/src/platform-implementation-js/style/inbox.css
+++ b/src/platform-implementation-js/style/inbox.css
@@ -234,7 +234,7 @@
 
 .inboxsdk__dropdown {
   padding: 0;
-  margin-bottom: 5px;
+  margin: 0;
   overflow: visible;
   z-index: 100;
   outline: none;
@@ -245,13 +245,10 @@
   min-width: 1em;
   min-height: 1em;
   padding: 0;
+  margin: 0;
   box-shadow: 0 0 6px rgba(0,0,0,.16), 0 6px 12px rgba(0,0,0,.32);
   border-radius: 2px;
   position: relative;
-}
-
-.inboxsdk__dropdown.inboxsdk__toolbar_dropdown {
-  margin: 10px 0;
 }
 
 .inboxsdk__tooltip {


### PR DESCRIPTION
* Some of Streak's toolbar buttons are done through CSS classnames which specify a solid background color and a CSS mask (as opposed to a background image). This CSS change makes those centered.
* Sometimes Streak absolutely-positions stuff inside of dropdowns with the intent that it's relative to the visible dropdown. In Inbox, sometimes the invisible parent element has some padding.
* Fix issue where there was a small non-clickable region around SDK dropdowns because dropdowns had invisible padding (which is considered part of the element) instead of margin.