### PR TITLE
Fix handling of standalone thread windows

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter/get-main-content-element-changed-stream.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter/get-main-content-element-changed-stream.js
@@ -37,7 +37,7 @@ export default function getMainContentElementChangedStream(GmailElementGetter: G
 }
 
 function waitForMainContentContainer(GmailElementGetter){
-	if (GmailElementGetter.isStandalone()) {
+	if (GmailElementGetter.isStandaloneComposeWindow()) {
 		return Kefir.never();
 	}
 	return streamWaitFor(() => GmailElementGetter.getMainContentContainer());


### PR DESCRIPTION
We had code to avoid creating routeviews for stand-alone compose windows, but the if-check was too general and skipped all stand-alone windows including thread windows.