### PR TITLE
Add ComposeView.hideNativeStatusBar()

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -515,6 +515,17 @@ class GmailComposeView {
 		return statusBar;
 	}
 
+	hideNativeStatusBar(): () => void {
+		const statusArea = this.getStatusArea();
+		const nativeStatusBar = querySelector(statusArea, 'table');
+
+		nativeStatusBar.style.display = 'none';
+
+		return () => {
+			nativeStatusBar.style.display = '';
+		};
+	}
+
 	replaceSendButton(el: HTMLElement): () => void {
 		const sendButton = this.getSendButton();
 		const sendAndArchive = this.getSendAndArchiveButton();

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
@@ -643,6 +643,9 @@ class InboxComposeView {
   addStatusBar(options?: {height?: number, orderHint?: number}): StatusBar {
     throw new Error("Not implemented");
   }
+  hideNativeStatusBar(): () => void {
+    throw new Error('Not Implemented');
+  }
   isReply(): boolean {
     if (this._p.attributes.isInline) return true;
     throw new Error("Not implemented");

--- a/src/platform-implementation-js/driver-interfaces/compose-view-driver.js
+++ b/src/platform-implementation-js/driver-interfaces/compose-view-driver.js
@@ -57,6 +57,7 @@ export type ComposeViewDriver = {
 	// addOuterSidebar(options: {title: string, el: HTMLElement}): void;
 	// addInnerSidebar(options: {el: HTMLElement}): void;
 	addStatusBar(options?: {height?: number, orderHint?: number}): StatusBar;
+	hideNativeStatusBar(): () => void;
 	isReply(): boolean;
 	isInlineReplyForm(): boolean;
 	getBodyElement(): HTMLElement;

--- a/src/platform-implementation-js/views/compose-view.js
+++ b/src/platform-implementation-js/views/compose-view.js
@@ -83,6 +83,10 @@ class ComposeView extends EventEmitter {
 		return get(memberMap, this).composeViewImplementation.addStatusBar(statusBarDescriptor);
 	}
 
+	hideNativeStatusBar(): () => void {
+		return get(memberMap, this).composeViewImplementation.hideNativeStatusBar();
+	}
+
 	addRecipientRow(options){
 		return {
 			destroy: get(memberMap, this).composeViewImplementation.addRecipientRow(kefirCast((Kefir: any), options))


### PR DESCRIPTION
This hides the native status area while retaining custom status bars. I'm keeping it undocumented because 1) it's pretty aggressive and should be used very thoughtfully (and I don't trust everyone to do that) and 2) It's a bit difficult to make this work well with multiple extensions trying to do conflicting things (doable, but annoying).

cc @omarstreak 