### PR TITLE
Add forceRecipientRowsOpen() and hideNativeRecipientRows()

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -445,6 +445,28 @@ class GmailComposeView {
 		return addRecipientRow(this, options);
 	}
 
+	forceRecipientRowsOpen(): () => void {
+		this._element.classList.add('inboxsdk__compose_forceRecipientsOpen');
+
+		return () => {
+			this._element.classList.remove('inboxsdk__compose_forceRecipientsOpen');
+		};
+	}
+
+	hideNativeRecipientRows(): () => void {
+		const nativeRecipientRows = this.getRecipientRowElements();
+
+		nativeRecipientRows.forEach((row) => {
+			row.classList.add('inboxsdk__compose_forceRecipientRowHidden');
+		});
+
+		return () => {
+			nativeRecipientRows.forEach((row) => {
+				row.classList.remove('inboxsdk__compose_forceRecipientRowHidden');
+			});
+		};
+	}
+
 	getFromContact() {
 		return fromManager.getFromContact(this._driver, this);
 	}

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
@@ -634,6 +634,12 @@ class InboxComposeView {
   addRecipientRow(options: Kefir.Observable<?Object>): () => void {
     throw new Error("Not implemented");
   }
+  forceRecipientRowsOpen(): () => void {
+    throw new Error("Not implemented");
+  }
+  hideNativeRecipientRows(): () => void {
+    throw new Error("Not implemented");
+  }
   addOuterSidebar(options: {title: string, el: HTMLElement}): void {
     throw new Error("Not implemented");
   }

--- a/src/platform-implementation-js/driver-interfaces/compose-view-driver.js
+++ b/src/platform-implementation-js/driver-interfaces/compose-view-driver.js
@@ -54,6 +54,8 @@ export type ComposeViewDriver = {
 	setTitleBarColor(color: string): () => void;
 	addButton(buttonDescriptor: Kefir.Observable<?ComposeButtonDescriptor>, groupOrderHint: string, extraOnClickOptions: Object): Promise<?Object>;
 	addRecipientRow(options: Kefir.Observable<?Object>): () => void;
+	forceRecipientRowsOpen(): () => void;
+	hideNativeRecipientRows(): () => void;
 	// addOuterSidebar(options: {title: string, el: HTMLElement}): void;
 	// addInnerSidebar(options: {el: HTMLElement}): void;
 	addStatusBar(options?: {height?: number, orderHint?: number}): StatusBar;

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -465,6 +465,15 @@ div.inboxsdk__compose_statusbar {
   padding: 0px 3px 3px 3px;
 }
 
+.inboxsdk__compose_forceRecipientsOpen .fX.aXjCH {
+  display: block !important;
+}
+
+.inboxsdk__compose_forceRecipientsOpen .aoD.hl,
+.inboxsdk__compose_forceRecipientRowHidden {
+  display: none !important;
+}
+
 /* toolbar visibility */
 
 [data-thread-toolbar=true] [data-rowlist-toolbar=true] {

--- a/src/platform-implementation-js/views/compose-view.js
+++ b/src/platform-implementation-js/views/compose-view.js
@@ -89,6 +89,14 @@ class ComposeView extends EventEmitter {
 		};
 	}
 
+	forceRecipientRowsOpen(): () => void {
+		return get(memberMap, this).composeViewImplementation.forceRecipientRowsOpen();
+	}
+
+	hideNativeRecipientRows(): () => void {
+		return get(memberMap, this).composeViewImplementation.hideNativeRecipientRows();
+	}
+
 	close(){
 		get(memberMap, this).composeViewImplementation.close();
 	}


### PR DESCRIPTION
This rounds out the recipient-row-related stuff in Gmail enough that we should be able to use it for mail merge.

`forceRecipientRowsOpen()` causes the recipient rows (native or SDK-added) to always be fully visible, rather than disappearing when unfocused. Returns a destroy function.

`hideNativeRecipientRows()` hides the To/CC/BCC fields, but allows custom rows to remain visible. Returns a destroy func.

Combining these two we should be able to hide the native recipient rows, create custom rows for mail merge UI, and force it to be visible.

Neither are documented, and if we wanted to publicly document them I'd want to do some more work on multi-extension coordination.

cc @omarstreak