### PR TITLE
Hide formatting bar via hideNativeStatusBar()

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -540,11 +540,23 @@ class GmailComposeView {
 	hideNativeStatusBar(): () => void {
 		const statusArea = this.getStatusArea();
 		const nativeStatusBar = querySelector(statusArea, 'table');
+		const formattingToolbar = this.getFormattingToolbar();
+		const isFormattingToolbarOpen = (
+			formattingToolbar && formattingToolbar.style.display !== 'none'
+		);
 
 		nativeStatusBar.style.display = 'none';
 
+		if (formattingToolbar && isFormattingToolbarOpen) {
+			formattingToolbar.style.display = 'none';
+		}
+
 		return () => {
 			nativeStatusBar.style.display = '';
+
+			if (formattingToolbar && isFormattingToolbarOpen) {
+				formattingToolbar.style.display = '';
+			}
 		};
 	}
 


### PR DESCRIPTION
This just grabs the formatting bar, checks whether or not it's open, and hide it with the native status bar if so. Didn't add anything for Inbox b/c we haven't yet implemented `hideNativeStatusBar()` there.

cc @omarstreak 