### PR TITLE
Remove bg color on compose title bar buttons

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -1050,6 +1050,7 @@ class GmailComposeView {
 	}
 
 	setTitleBarColor(color: string): () => void {
+		const buttonParent = querySelector(this._element, '.nH.Hy.aXJ table.cf.Ht td.Hm');
 		const elementsToModify = [
 			querySelector(this._element, '.nH.Hy.aXJ .pi > .l.o'),
 			querySelector(this._element, '.nH.Hy.aXJ .l.m'),
@@ -1057,11 +1058,15 @@ class GmailComposeView {
 			querySelector(this._element, '.nH.Hy.aXJ .l.m > .l.n > .k')
 		];
 
+		buttonParent.classList.add('inboxsdk__compose_customTitleBarColor');
+
 		elementsToModify.forEach((el) => {
 			el.style.backgroundColor = color;
 		});
 
 		return () => {
+			buttonParent.classList.remove('inboxsdk__compose_customTitleBarColor');
+
 			elementsToModify.forEach((el) => {
 				el.style.backgroundColor = '';
 			});

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -194,6 +194,12 @@ div.T-I.inboxsdk__button {
   vertical-align: middle;
 }
 
+.inboxsdk__compose_customTitleBarColor > img.Hl,
+.inboxsdk__compose_customTitleBarColor > img.Hq,
+.inboxsdk__compose_customTitleBarColor > img.Ha {
+  background-color: transparent !important;
+}
+
 /* end */
 
 /* appid warning gmail specific parts */


### PR DESCRIPTION
Before this change, hovering over the minimize/maximize/close buttons in the title bar added a grey background color even when a custom title bar color was set, resulting in a very avant-garde aesthetic. this overrides the background color to transparent while there's a custom color, because imo it would be overkill for our current use to try to decide on the 'correct' hover bg color. the button icons still go from partial opacity to full opacity so there is a user-visible sign of interactivity even without it.

didn't add anything to the Inbox side because they already stick to just bringing the title bar icons to full opacity and avoid a hover background color.

cc @omarstreak 