### PR TITLE
don't reinsert the containerEl when the parent is the same. This fixe…

### DIFF
--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-drawer-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-drawer-view.js
@@ -284,10 +284,9 @@ class InboxDrawerView {
 
     const {insertionTarget, composeRect} = this._setupComposeInsertionTarget(composeView, closeWithCompose);
 
-    if (this._backdrop) {
-      insertionTarget.appendChild(this._backdrop.getElement());
-    }
-    insertionTarget.appendChild(this._containerEl);
+    if (this._backdrop) insertionTarget.appendChild(this._backdrop.getElement());
+    if (this._containerEl.parentElement !== insertionTarget) insertionTarget.appendChild(this._containerEl);
+
 
     const composeNeedToMoveLeft = this._setupComposeAnimation(composeView, composeRect, false);
     this._positionCompose(composeView, composeNeedToMoveLeft);


### PR DESCRIPTION
…s an issue where calling associate makes the drawer contents lose scroll position