### PR TITLE
Handle draft IDs with 's:' (e.g. undone sends)

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-response-processor.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-response-processor.js
@@ -370,7 +370,7 @@ export function readDraftId(response: string, messageID: string): ?string {
     t.map(x => x[60])
   ))[0];
   if (msgA) {
-    const match = msgA.match(/^msg-a:(\S+)$/i);
+    const match = msgA.match(/^msg-[^:]:(\S+)$/i);
     return match && match[1];
   }
   return null;


### PR DESCRIPTION
We've had an issue for, well, pretty much forever where undo-ing a send causes the draft ID for the re-opened ComposeView to come back as `'s'`. Turns out this is because the draft ID we get from Gmail's API response is `'s:<draft_id>'`. Since someone is having issues with it again I went in and switched our code that parses IDs via splitting on `:` to instead use a regex that matches anything after the `msg-a:` prefix. Seems to work fine in both normal and undone-send cases.

cc @aleemstreak 