### PR TITLE
Add sendAndArchive option for ComposeView.send()

### DIFF
--- a/src/docs/compose-view.js
+++ b/src/docs/compose-view.js
@@ -38,6 +38,7 @@ var ComposeView = /** @lends ComposeView */ {
 	 * Simulates clicking the compose's send button.
 	 * ^gmail
 	 * ^inbox
+	 * @param {SendOptions} sendOptions - An optional configuration object for the send.
 	 * @return {void}
 	 */
 	send: function() {},
@@ -626,6 +627,23 @@ var ComposeButtonDescriptor = /** @lends ComposeButtonDescriptor */{
 	 * @type {boolean}
 	 */
 	enabled: null
+};
+
+/**
+ * @class
+ * This type is optionally passed into the {ComposeView.send()} method as a way to configure the send.
+ */
+var SendOptions = /** @lends SendOptions */{
+	/**
+	 * Whether or not the message should be sent using Gmail's 'send and archive'
+	 * feature when available. If you set this to true but the ComposeView does
+	 * not have a Send and Archive button available, {ComposeView.send()}
+	 * will fall back to the normal Send button.
+	 * ^optional
+	 * ^default=false
+	 * @type {boolean}
+	 */
+	sendAndArchive:null
 };
 
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -649,8 +649,14 @@ class GmailComposeView {
 		}
 	}
 
-	send() {
-		simulateClick(this.getSendButton());
+	send({sendAndArchive}: {sendAndArchive: boolean}) {
+		const sendAndArchiveButton = this.getSendAndArchiveButton();
+
+		if (sendAndArchive && sendAndArchiveButton) {
+			simulateClick(sendAndArchiveButton);
+		} else {
+			simulateClick(this.getSendButton());
+		}
 	}
 
 	discard() {

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
@@ -559,7 +559,7 @@ class InboxComposeView {
       simulateClick(this._els.closeBtn);
     }
   }
-  send() {
+  send({sendAndArchive}: {sendAndArchive: boolean}) {
     if (!this._els.sendBtn) throw new Error("Compose View missing send element");
     simulateClick(this._els.sendBtn);
   }

--- a/src/platform-implementation-js/driver-interfaces/compose-view-driver.js
+++ b/src/platform-implementation-js/driver-interfaces/compose-view-driver.js
@@ -41,7 +41,7 @@ export type ComposeViewDriver = {
 	setFromEmail(email: string): void;
 	focus(): void;
 	close(): void;
-	send(): void;
+	send({sendAndArchive: boolean}): void;
 	discard(): void;
 	popOut(): void;
 	replaceSendButton(el: HTMLElement): () => void;

--- a/src/platform-implementation-js/views/compose-view.js
+++ b/src/platform-implementation-js/views/compose-view.js
@@ -105,8 +105,8 @@ class ComposeView extends EventEmitter {
 		get(memberMap, this).composeViewImplementation.close();
 	}
 
-	send() {
-		get(memberMap, this).composeViewImplementation.send();
+	send({sendAndArchive}: {sendAndArchive: boolean} = {sendAndArchive: false}) {
+		get(memberMap, this).composeViewImplementation.send({sendAndArchive});
 	}
 
 	discard() {


### PR DESCRIPTION
Got a request from one of the people on my old team to allow defaulting
to 'Send and Archive' if available rather than normal 'Send' — thought
it seemed useful enough and was a pretty quick change so I figured
I'd throw it in as an opt-in config.