### PR TITLE
Add ComposeView.hideRecipientArea()

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -467,6 +467,14 @@ class GmailComposeView {
 		};
 	}
 
+	hideRecipientArea(): () => void {
+		this._element.classList.add('inboxsdk__compose_hideRecipientArea');
+
+		return () => {
+			this._element.classList.remove('inboxsdk__compose_hideRecipientArea');
+		};
+	}
+
 	getFromContact() {
 		return fromManager.getFromContact(this._driver, this);
 	}

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
@@ -661,6 +661,9 @@ class InboxComposeView {
       });
     };
   }
+  hideRecipientArea(): () => void {
+    throw new Error('Not implemented');
+  }
   addOuterSidebar(options: {title: string, el: HTMLElement}): void {
     throw new Error("Not implemented");
   }

--- a/src/platform-implementation-js/driver-interfaces/compose-view-driver.js
+++ b/src/platform-implementation-js/driver-interfaces/compose-view-driver.js
@@ -59,6 +59,7 @@ export type ComposeViewDriver = {
 	addRecipientRow(options: Kefir.Observable<?Object>): () => void;
 	forceRecipientRowsOpen(): () => void;
 	hideNativeRecipientRows(): () => void;
+	hideRecipientArea(): () => void;
 	// addOuterSidebar(options: {title: string, el: HTMLElement}): void;
 	// addInnerSidebar(options: {el: HTMLElement}): void;
 	addStatusBar(options?: {height?: number, orderHint?: number, addAboveNativeStatusBar?: boolean}): StatusBar;

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -510,6 +510,8 @@ div.inboxsdk__compose_statusbar {
   display: block !important;
 }
 
+.inboxsdk__compose_hideRecipientArea .fX.aXjCH,
+.inboxsdk__compose_hideRecipientArea .aoD.hl,
 .inboxsdk__compose_forceRecipientsOpen .aoD.hl,
 .inboxsdk__compose_forceRecipientRowHidden {
   display: none !important;

--- a/src/platform-implementation-js/views/compose-view.js
+++ b/src/platform-implementation-js/views/compose-view.js
@@ -101,6 +101,10 @@ class ComposeView extends EventEmitter {
 		return get(memberMap, this).composeViewImplementation.hideNativeRecipientRows();
 	}
 
+	hideRecipientArea(): () => void {
+		return get(memberMap, this).composeViewImplementation.hideRecipientArea();
+	}
+
 	close(){
 		get(memberMap, this).composeViewImplementation.close();
 	}


### PR DESCRIPTION
Right now we have `forceRecipientsOpen()` and `hideNativeRecipientRows()`, which nicely handle the cases where we want to add a custom row and keep it (and only it) visible all the time (this is what we do with Mail Merge in Streak). For Snippets, though, we want to completely hide the *entire* recipient area, and simply hiding all the native rows plus the 'Recipients' text placeholder doesn't fully remove the extra space allotted for the recipients area.