### PR TITLE
Fix DrawerView.associateComposeView() memory leak

### DIFF
--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-drawer-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-drawer-view.js
@@ -102,7 +102,7 @@ class InboxDrawerView {
       );
     }
     Kefir.merge(closeEvents)
-      .takeUntilBy(this._closing)
+      .takeUntilBy(this._closing.merge(this._composeChanges))
       .onValue(() => this.close());
 
 


### PR DESCRIPTION
Noticed a warning for large numbers of bound listeners on a ComposeView while I was working on Snippets — turns out calling `DrawerView.associateComposeView()` repeatedly wasn't removing old listeners. They all theoretically get cleaned up when the DrawerView gets destroyed, but worth plugging it up anyways...