### PR TITLE
Update kefir-cast for Rx5 support

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6152,9 +6152,9 @@
       "integrity": "sha1-SB8YuidPxVgBddtcxnznqCKOolA="
     },
     "kefir-cast": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/kefir-cast/-/kefir-cast-3.1.0.tgz",
-      "integrity": "sha1-KTlzn7yOXblL6xGPaBCgW7uaCTA="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/kefir-cast/-/kefir-cast-3.2.0.tgz",
+      "integrity": "sha512-UQanlwnhM6XRoyhG73IZyffoSt4JY3wNMKwMw2wcbrYQR7fRENwiDLXdEA36arqd4S0lWqt3KNNfYaMUS/ffBg=="
     },
     "kefir-stopper": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jsdom": "^9.2.1",
     "kefir": "~3.6.1",
     "kefir-bus": "^2.2.0",
-    "kefir-cast": "^3.1.0",
+    "kefir-cast": "^3.2.0",
     "kefir-stopper": "^2.1.0",
     "lazypipe": "^1.0.1",
     "live-set": "^0.4.1",


### PR DESCRIPTION
I just published a new version of kefir-cast that has support for the latest version of RxJS. This pull request updates inboxsdk to use it.