### PR TITLE
Reemit compose window keyboard events so React can hear them

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-recipient-row.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-recipient-row.js
@@ -10,13 +10,13 @@ export default function addRecipientRow(gmailComposeView: GmailComposeView, reci
 		.takeUntilBy(gmailComposeView.getStopper())
 		.onValue((options) => {
 			if(row){
-				(row:any).remove();
+				row.remove();
 				row = null;
 			}
 
 			if(options) {
 				row = _createRecipientRowElement(gmailComposeView, options);
-				_reemitKeyboardEvents(row, gmailComposeView.getStopper());
+				_reemitKeyboardEvents(row);
 			}
 			gmailComposeView.getElement().dispatchEvent(new CustomEvent('resize', {
 				bubbles: false, cancelable: false, detail: null
@@ -25,7 +25,7 @@ export default function addRecipientRow(gmailComposeView: GmailComposeView, reci
 
 	return () => {
 		if (row) {
-			(row:any).remove();
+			row.remove();
 			row = null;
 			gmailComposeView.getElement().dispatchEvent(new CustomEvent('resize', {
 				bubbles: false, cancelable: false, detail: null
@@ -66,7 +66,7 @@ function _createRecipientRowElement(gmailComposeView: GmailComposeView, options:
 	return row;
 }
 
-function _reemitKeyboardEvents(rowEl: HTMLElement, stopper: Kefir.Observable<null>) {
+function _reemitKeyboardEvents(rowEl: HTMLElement) {
 	// Gmail stops propagation of keyboard events from escaping
 	// a specific compose window, which prevents any React components rendered
 	// in the compose window's subtree from getting them (since React adds
@@ -78,7 +78,7 @@ function _reemitKeyboardEvents(rowEl: HTMLElement, stopper: Kefir.Observable<nul
 		Kefir.fromEvents(rowEl, 'keypress'),
 		Kefir.fromEvents(rowEl, 'keydown'),
 		Kefir.fromEvents(rowEl, 'keyup')
-	]).takeUntilBy(stopper).onValue((event: KeyboardEvent) => {
+	]).onValue((event: KeyboardEvent) => {
 		event.stopPropagation();
 
 		const fakeEvent = new KeyboardEvent(event.type);


### PR DESCRIPTION
Turns out Gmail is stopping keyboard events from propagating out of compose windows, which has been causing weird keyboard handling problems with any React components that we (and presumably others) decide to render into compose windows due to how React handles events.

I was originally going to try to scope this reemitting behavior to single methods (i.e. `addRecipientRow()` since that's what we happen to be using here), but after thinking about it more I'm leaning toward doing it all the time given that there's many different ways to end up adding a React component to a compose window that could run into these problems. More than happy to reconsider that.