### PR TITLE
Add closedByUser param to ComposeView destroy event

### DIFF
--- a/src/docs/compose-view.js
+++ b/src/docs/compose-view.js
@@ -413,9 +413,10 @@ var ComposeView = /** @lends ComposeView */ {
 	 * @param {string} messageID - If the composeView was closed without being sent and the draft
 	 * was saved, then this property will have the draft's message ID after it saved. Otherwise it
 	 * will be null. This property is only present in Gmail.
-	 * @param {boolean} closedByUser - Whether or not the ComposeView was closed due to a user action
-	 * like clicking the discard/close buttons, or hitting escape. False if the ComposeView was closed
-	 * by an extension calling ComposeView.close(), including other extensions besides yours.
+	 * @param {boolean} closedByInboxSDK - Whether or not the ComposeView was closed
+	 * by an extension calling ComposeView.close(), including other extensions besides your own.
+	 * False if the ComposeView was closed due to a user action like clicking the discard/close
+	 * buttons or hitting escape.
 	 */
 
 	 /**

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -294,7 +294,7 @@ class GmailComposeView {
 	destroy() {
 		this._eventStream.emit({eventName: 'destroy', data: {
 			messageID: this.getMessageID(),
-			closedByUser: !this._closedProgrammatically
+			closedByInboxSDK: this._closedProgrammatically
 		}});
 		this._eventStream.end();
 		this._managedViewControllers.forEach(vc => {

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
@@ -229,7 +229,7 @@ class InboxComposeView {
 
     const cleanup = () => {
       this._eventStream.emit({eventName: 'destroy', data: {
-        closedByUser: !this._closedProgrammatically
+        closedByInboxSDK: this._closedProgrammatically
       }});
       this._eventStream.end();
       this._stopper.destroy();


### PR DESCRIPTION
In the past (both working on Streak and in my previous role) there's been some times where it would've been nice to have a way to detect whether a ComposeView was being destroyed due to a user action (i.e. close/discard buttons or escape press), or if it was due to calling `ComposeView.close()`. As I've been working on the most recent feature addition to Snippets (opening a modal after a compose is closed by the user with unsaved changes), I've run into another case where I really wanted an event parameter rather than trying to set/reset some local variable flag in every single place where `ComposeView.close()` got called and decided it was time to see what it would look like to add this behavior in.

The way this is currently written, there is a `closedByUser` param in the `destroy` event object which is `true` whenever the compose window was closed via some method other than calling `ComposeView.close()`. If *any* SDK app calls `close()` on the compose window, then `closedByUser` will be `false` for all `destroy` events across apps. For my current use case this behavior is perfectly fine, but I'm also open to considering other behaviors when dealing with multiple extensions.