### PR TITLE
Fix missing @class name in ComposeView docs

### DIFF
--- a/src/docs/compose-view.js
+++ b/src/docs/compose-view.js
@@ -634,7 +634,7 @@ var ComposeButtonDescriptor = /** @lends ComposeButtonDescriptor */{
 };
 
 /**
- * @class
+ * @class SendOptions
  * This type is optionally passed into the {ComposeView.send()} method as a way to configure the send.
  */
 var SendOptions = /** @lends SendOptions */{


### PR DESCRIPTION
caught this while looking at the docs for other reasons...