### PR TITLE
composeView.getFromContact() fix

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/from-manager.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/from-manager.js
@@ -26,12 +26,12 @@ export function getFromContact(driver: GmailDriver, gmailComposeView: GmailCompo
 }
 
 export function getFromContactChoices(driver: GmailDriver, gmailComposeView: GmailComposeView): Contact[] {
-  const choiceParent = gmailComposeView.getElement().querySelector('div.J-M.jQjAxd.J-M-awS[role=menu] > div.SK.AX');
-  if (!choiceParent) {
+  const choiceEls = gmailComposeView.getElement().querySelectorAll('div.J-M.jQjAxd.J-M-awS[role=menu] > div.SK.AX > div[value][role=menuitem]');
+  if (choiceEls.length == 0) {
     // From field isn't present
     return [driver.getUserContact()];
   }
-  return Array.from(choiceParent.children).map(item => ({
+  return Array.from(choiceEls).map(item => ({
     emailAddress: item.getAttribute('value') || '',
     name: item.textContent.replace(/<.*/, '').trim()
   }));


### PR DESCRIPTION
1. Make getFromContact() gracefully handle the case where getFromContactChoices() returns a list that's missing a contact that matches the currently-known email address.
2. Make getFromContactChoices() handle the case where there are multiple 'div.J-M.jQjAxd.J-M-awS[role=menu] > div.SK.AX' elements within the composeview. I've never personally seen that case, but it seems to describe someone in the mailing list. I assume the other element is some kind of menu. Instead of looking for that element and then doing things with its children, we just select the children directly. Additionally we only pay attention to the children matching 'div[value][role=menuitem]'.