### PR TITLE
Add new search input selector

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.js
@@ -69,7 +69,9 @@ const GmailElementGetter = {
 	},
 
 	getSearchInput(): ?HTMLInputElement {
-		return ((document.getElementById('gbqfq'): any): ?HTMLInputElement);
+		const classicUIInput = ((document.getElementById('gbqfq'): any): ?HTMLInputElement);
+		const materialUIInput = ((document.querySelector('input.gb_Ze'): any): ?HTMLInputElement);
+		return classicUIInput || materialUIInput;
 	},
 
 	getSearchSuggestionsBoxParent(): ?HTMLElement {


### PR DESCRIPTION
I was looking into why clicking/hitting enter on search autocomplete suggestions to trigger their actions weren't working in our new Gmail test account, which I thought was due to some kind of data change. After looking at it closer turns out it was because of a change to the search input (it no longer has the id we were using), which was causing the downstream DOM traversal to fail. By the time I had investigated enough to figure out that it was a DOM issue I essentially already had the fix, so why not PR it? 😄

With this change custom autocomplete appears to be 100% operational.