### PR TITLE
Correctly deal with inaccessible stylesheets

### DIFF
--- a/src/platform-implementation-js/dom-driver/inbox/getSidebarClassnames.js
+++ b/src/platform-implementation-js/dom-driver/inbox/getSidebarClassnames.js
@@ -45,6 +45,16 @@ const getSidebarClassnames: () => {
 
   // rules will contain both the chat and nav sidebar rules.
   const rules = t.toArray(Array.prototype.slice.call(document.styleSheets), t.compose(
+    t.filter(sheet => {
+      try {
+        return sheet.cssRules && sheet.cssRules.length;
+      } catch (err) {
+        // ignore. Sometimes pages have stylesheets that don't permit their
+        // rules to be enumerated. Possibly caused by other extensions including
+        // a css file from another domain?
+        return false;
+      }
+    }),
     t.mapcat(sheet => Array.prototype.slice.call(sheet.cssRules || [])),
     t.mapcat(rulesToStyleRules),
     // We have all page rules. Filter it down to just rules mentioning one of


### PR DESCRIPTION
A user complained about certain Inbox stuff breaking because of an exception thrown on accessing `sheet.cssRules` in getSidebarClassnames. The error logs show a lot of other people hitting the issue too.

I wasn't able to locally reproduce the issue, but I think it's caused by an extension adding a CSS file to the page on another domain without CORS headers. In that case, I don't believe the sheet's cssRules property can be accessed. We now ignore those sheets, which should fix the issue.