### PR TITLE
Left-nav right click fixup

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.js
@@ -522,17 +522,8 @@ export default class GmailNavItemView {
 		Kefir
 			.fromEvents(this._element, 'contextmenu')
 			.takeWhile(() => this._accessoryViewController === accessoryViewController)
-			.filter((domEvent) => {
-				// Because nested nav-items are children of their parent nav-items, we need this filter to
-				// make sure that the contextmenu click was on this nav-item and not on a child nav-item.
-				if(domEvent.target === this._element){
-					return true;
-				}
-
-				const navItems = Array.prototype.filter.call(domEvent.path || [], el => el.classList && el.classList.contains('inboxsdk__navItem'));
-				return navItems[0] === this._element;
-			})
 			.onValue((domEvent) => {
+				domEvent.stopPropagation();
 				domEvent.preventDefault();
 
 				accessoryViewController.showDropdown();


### PR DESCRIPTION
I was investigating why HowToPipelineTest started failing on MailFoo and realized it was actually an SDK issue.
I had removed a filter step from the `contextmenu` click handler in `gmail-nav-item` thinking it was unnecessary legacy code. Turns out it did actually serve a purpose. I restored the filter step, added an explanatory comment, and consolidated some copy-pasted logic.

I also fixed an issue with DROPDOWN_BUTTON accessory type when in Gmailv1.