### PR TITLE
Handle errors in processPreloadedThreads

### DIFF
--- a/src/injected-js/gmail/thread-identifier/index.js
+++ b/src/injected-js/gmail/thread-identifier/index.js
@@ -10,7 +10,11 @@ import Marker from '../../../common/marker';
 import findParent from '../../../common/find-parent';
 
 export function setup() {
-  processPreloadedThreads();
+  try {
+    processPreloadedThreads();
+  } catch (err) {
+    logger.error(err, 'Failed to process preloaded thread identifiers');
+  }
 
   document.addEventListener('inboxSDKtellMeThisThreadIdByDatabase', function(event:any) {
     const threadId = getGmailThreadIdForThreadRowByDatabase(event.target);


### PR DESCRIPTION
If we have an exception in processPreloadedThreads, then the injected script never gets to the `setupDataExposer()` step which the InboxSDK waits on before resolving the load promise.

(A user recently reported an exception in processPreloadedThreads that happened when using an extension that corrupted Gmail's `<script>` tag that we're preloading data from.)