### PR TITLE
Handle failure in _waitForAddonTitleAndSuppress

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
@@ -476,7 +476,10 @@ class GmailThreadView {
 
 			const widthManager = addonSidebarContainerEl ? this._setupWidthManager() : null;
 
-			makeElementChildStream(querySelector(iconContainerElement, '.J-KU-Jg'))
+			const elementToWatch = iconContainerElement.querySelector('.J-KU-Jg');
+			if (!elementToWatch) return;
+
+			makeElementChildStream(elementToWatch)
 				.filter(({el}) =>
 						el.getAttribute('role') === 'tab' &&
 						el.getAttribute('data-tooltip') === addonTitle


### PR DESCRIPTION
Line 478 of the original file (`querySelector(iconContainerElement, '.J-KU-Jg')`) threw an unhandled error for gabi.klein@icc.humandx.org in the "Streak sidebar randomly missing and buttons not showing" box.