### PR TITLE
apply top to attachement icons only in v1

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -669,10 +669,13 @@ td.gH div.gK span:first-child > img:last-child {
   margin-right: 6px;
 }
 
+body.inboxsdk__gmailv1css .inboxsdk__message_attachment_icon {
+  margin-top: -3px;
+}
+
 .inboxsdk__message_attachment_icon {
   width: 21px;
   height: 21px;
-  margin-top: -3px;
 }
 
 /* Work around issue where clicking "Remove formatting" in Compose causes this


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/197015/38573692-b7b7beb4-3cab-11e8-9b52-16d97f2c54f5.png)

After
![image](https://user-images.githubusercontent.com/197015/38573741-d467fcc2-3cab-11e8-9709-198b3e11a1a6.png)

