### PR TITLE
Drop the padding below inserted status bars

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -781,7 +781,6 @@ body:not(.inboxsdk__gmailv1css) .inboxsdk__compose_statusbar {
 
 body:not(.inboxsdk__gmailv1css) table + .inboxsdk__compose_statusbar {
   margin-top: -8px;
-  padding-bottom: 16px;
 }
 
 .inboxsdk__compose_statusbarActive .aoI {


### PR DESCRIPTION
Box: [extra space at the bottom of bottom compose status area](https://www.streak.com/a/boxes/agxzfm1haWxmb29nYWVyMAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRjxs_BlDA)