### PR TITLE
Adjust the customSendContainer height to match Material Gmail

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -397,7 +397,7 @@ body:not(.inboxsdk__gmailv1css) .inboxsdk__compose_groupedActionToolbar_arrow {
   vertical-align: middle;
 }
 
-body.inboxsdk__gmailv1css .inboxsdk__compose_customSendContainer {
+body:not(.inboxsdk__gmailv1css) .inboxsdk__compose_customSendContainer {
   height: 36px;
   line-height: 36px;
 }


### PR DESCRIPTION
Some styling adjustments to compensate for the compose toolbar area becoming taller in Material Gmail (as compared to Gmailv1)
Box: [snippets editor save and cancel buttons](https://www.streak.com/a/boxes/agxzfm1haWxmb29nYWVyMAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRih6dllDA)
Box: [material mail merge editor buttons](https://www.streak.com/a/boxes/agxzfm1haWxmb29nYWVyMAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRjx79xlDA)