### PR TITLE
v2 add margin to modal header

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -913,45 +913,49 @@ body.inboxsdk__gmailv1css .inboxsdk__menuItem.J-N:not(.J-N-JT) .J-N-JX {
   overflow: hidden;
 }
 
-  .inboxsdk__modal_fullscreen.inboxsdk__modal_hideTop .inboxsdk__modal_close {
-    display: none;
-  }
+.inboxsdk__modal_fullscreen .inboxsdk__modal_container .inboxsdk__modal_toprow {
+  margin-right: 16px;
+}
 
-  .inboxsdk__modal_fullscreen.inboxsdk__modal_hideTop .inboxsdk__modal_container {
-    padding-top: 0px;
-  }
+.inboxsdk__modal_fullscreen.inboxsdk__modal_hideTop .inboxsdk__modal_close {
+  display: none;
+}
 
-  .inboxsdk__modal_fullscreen.inboxsdk__modal_hideTop .inboxsdk__modal_content {
-    margin-top: 0px;
-  }
+.inboxsdk__modal_fullscreen.inboxsdk__modal_hideTop .inboxsdk__modal_container {
+  padding-top: 0px;
+}
 
-  .inboxsdk__modal_fullscreen.inboxsdk__modal_hideTop .Kj-JD-K7 {
-    margin: 0px;
-  }
+.inboxsdk__modal_fullscreen.inboxsdk__modal_hideTop .inboxsdk__modal_content {
+  margin-top: 0px;
+}
 
-  .inboxsdk__modal_fullscreen.inboxsdk__modal_hideSides .inboxsdk__modal_container {
-    padding-left: 0px;
-    padding-right: 0px
-  }
+.inboxsdk__modal_fullscreen.inboxsdk__modal_hideTop .Kj-JD-K7 {
+  margin: 0px;
+}
 
-  .inboxsdk__modal_fullscreen.inboxsdk__modal_hideBottom .inboxsdk__modal_content {
-    margin-bottom: 0px;
-  }
+.inboxsdk__modal_fullscreen.inboxsdk__modal_hideSides .inboxsdk__modal_container {
+  padding-left: 0px;
+  padding-right: 0px
+}
 
-  .inboxsdk__modal_fullscreen.inboxsdk__modal_hideBottom .inboxsdk__modal_container {
-    padding-bottom: 0px;
-  }
+.inboxsdk__modal_fullscreen.inboxsdk__modal_hideBottom .inboxsdk__modal_content {
+  margin-bottom: 0px;
+}
 
-  .inboxsdk__modal_toprow.inboxsdk__modal_toprow--constrain-title-width {
-    display: -webkit-flex;
-    display: flex;
-  }
+.inboxsdk__modal_fullscreen.inboxsdk__modal_hideBottom .inboxsdk__modal_container {
+  padding-bottom: 0px;
+}
 
-  .inboxsdk__modal_toprow--constrain-title-width > span[role="heading"] {
-    -webkit-flex: 1;
-    flex: 1;
-    width: 0;
-  }
+.inboxsdk__modal_toprow.inboxsdk__modal_toprow--constrain-title-width {
+  display: -webkit-flex;
+  display: flex;
+}
+
+.inboxsdk__modal_toprow--constrain-title-width > span[role="heading"] {
+  -webkit-flex: 1;
+  flex: 1;
+  width: 0;
+}
 
 /* end modal */
 


### PR DESCRIPTION
Fix so model headers do not run into the close `x` icon.

Note, the tabs were off. So I fixed that. The only new code is this:
```
.inboxsdk__modal_fullscreen .inboxsdk__modal_container .inboxsdk__modal_toprow {
  margin-right: 16px;
}
```

Before
![image](https://user-images.githubusercontent.com/197015/38650680-0aa376ca-3db2-11e8-9370-8d2528426947.png)

After
![image](https://user-images.githubusercontent.com/197015/38650684-12e3317c-3db2-11e8-8e95-5d09faa324b6.png)
