### PR TITLE
Measure against the Compose body, not the whole container

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/manage-button-grouping.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/manage-button-grouping.js
@@ -136,7 +136,7 @@ function _narrowButtonsIfNeeded(gmailComposeView: GmailComposeView) {
 function _doButtonsNeedToGroup(gmailComposeView: GmailComposeView): boolean {
 	return (
 		!gmailComposeView.getElement().querySelector('.inboxsdk__compose_groupedActionToolbar') &&
-		gmailComposeView.getElement().clientWidth < _getBottomBarTableWidth(gmailComposeView) &&
+		gmailComposeView.getBodyElement().clientWidth < _getBottomBarTableWidth(gmailComposeView) &&
 		gmailComposeView.getElement().querySelectorAll('.inboxsdk__composeButton').length > 1
 	);
 }


### PR DESCRIPTION
Box: [Reply Compose buttons not always collapsing when they should](https://www.streak.com/a/boxes/agxzfm1haWxmb29nYWVyMAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRjh7ulmDA)