### PR TITLE
v2 Fix Layout in Compose

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -825,17 +825,8 @@ body:not(.inboxsdk__gmailv1css) table + .inboxsdk__compose_statusbar {
   height: auto;
 }
 
-body:not(.inboxsdk__gmailv1css) .inboxsdk__compose table.GS {
-  display: table;
-}
-
-body:not(.inboxsdk__gmailv1css) .inboxsdk__compose tbody.bze {
-  display: table-row-group;
-}
-
-body:not(.inboxsdk__gmailv1css) .inboxsdk__compose td.ok,
-body:not(.inboxsdk__gmailv1css) .inboxsdk__compose td.az3 {
-  display: table-cell;
+body:not(.inboxsdk__gmailv1css) .inboxsdk__recipient_row {
+  display: flex;
 }
 
 .inboxsdk__recipient_row td.ok {


### PR DESCRIPTION
This PR fixes to, from, etc layout in compose view including regular compose, mail merge, and snippets.

The previous fix for this issue did not take into consideration email aliases (which blew up the table formatting).

![image](https://user-images.githubusercontent.com/197015/38904856-a6c97e42-4261-11e8-8926-a746f5dabdbd.png)

![image](https://user-images.githubusercontent.com/197015/38904827-80062008-4261-11e8-977c-eba8ae5f3caa.png)

![image](https://user-images.githubusercontent.com/197015/38904837-9107247e-4261-11e8-8b12-df52cc3d632a.png)
