### PR TITLE
v2 fix status bar style in compose mole

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-status-bar.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-status-bar.js
@@ -36,15 +36,7 @@ class StatusBar extends SimpleElementView {
   _prependContainer: ?HTMLElement = null;
 
   constructor(gmailComposeView: GmailComposeView, height: number, orderHint: number, addAboveNativeStatusBar: boolean) {
-    const divNode = document.createElement('div');
-    let el;
-
-    if (gmailComposeView._driver.isUsingMaterialUI()) {
-      const trNode = document.createElement('tr');
-      el = trNode.appendChild(divNode);
-    } else {
-      el = divNode;
-    }
+    let el = document.createElement('div');
 
     super(el);
     this._gmailComposeView = gmailComposeView;

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -796,6 +796,10 @@ div.inboxsdk__compose_statusbar {
 
 body:not(.inboxsdk__gmailv1css) .inboxsdk__compose_statusbar {
   background: none;
+}
+
+/* only include padding when in thread inline view */
+body:not(.inboxsdk__gmailv1css) .HM .I5 .inboxsdk__compose_statusbar {
   padding: 0 16px 16px 16px;
 }
 


### PR DESCRIPTION
1. Fix padding issue in status bar in compose mole
2. Remove table row logic from status bar when in reply-in-line view (extra logic not necessary)

Before
![image](https://user-images.githubusercontent.com/197015/39020317-47b1a52a-43e1-11e8-9d57-52934cba7402.png)

After
![image](https://user-images.githubusercontent.com/197015/39020110-91c8b988-43e0-11e8-8cc8-0c3ba41f3c8a.png)
