### PR TITLE
Put deprecation warnings on old sent event properties

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -204,7 +204,7 @@ class GmailComposeView {
               ['threadID', 'gmailThreadId'].forEach(prop => {
                 // These properties are nonenumerable.
                 Object.defineProperty((data:any), prop, {
-                  get() {
+                  get: () => {
                     this._driver.getLogger().deprecationWarning(
                       `composeView sent event.${prop}`, 'composeView sent event.getThreadID()');
                     return response.threadID;
@@ -213,7 +213,7 @@ class GmailComposeView {
               });
               ['messageID', 'gmailMessageId'].forEach(prop => {
                 Object.defineProperty((data:any), prop, {
-                  get() {
+                  get: () => {
                     this._driver.getLogger().deprecationWarning(
                       `composeView sent event.${prop}`, 'composeView sent event.getMessageID()');
                     return response.messageID;


### PR DESCRIPTION
These properties aren't supported in gmail v2, so it's more important that we log this now.

Tested with devtools in the compose-stream example extension.