### PR TITLE
fix styling for when toolbar is in text mode

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-toolbar-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-toolbar-view.js
@@ -285,7 +285,7 @@ class GmailToolbarView {
 	_determineToolbarIconMode(){
 		const moveSectionElement = this._getMoveSectionElement();
 		if (!moveSectionElement) throw new Error("No move section element");
-		const isIconMode = Array.from(moveSectionElement.querySelectorAll('[role=button]'))
+		const isIconMode = Array.from(moveSectionElement.querySelectorAll('[role=button]:not(.inboxsdk__button)'))
 			.some(buttonElement =>
 				buttonElement.hasAttribute('title') || buttonElement.hasAttribute('data-tooltip')
 			);

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -895,6 +895,36 @@ body.inboxsdk__gmailv1css .inboxsdk__recipient_row td.az3 {
   display: none !important;
 }
 
+body:not(.inboxsdk__gmailv1css) [data-toolbar-icononly=false] .inboxsdk__button_text {
+  color: #5f6368;
+}
+
+body:not(.inboxsdk__gmailv1css) [data-toolbar-icononly=false] .asa:before {
+  border-radius: 4px;
+  border: none !important;
+}
+
+body:not(.inboxsdk__gmailv1css) [data-toolbar-icononly=false] .inboxsdk__button {
+  align-items: center;
+  border: none;
+  display: inline-flex;
+  justify-content: center;
+  outline: none;
+  position: relative;
+  z-index: 0;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Google Sans',Roboto,RobotoDraft,Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  letter-spacing: .15px;
+  background: none;
+  box-sizing: border-box;
+  color: #5f6368;
+  cursor: pointer;
+  font-weight: 500;
+  outline: none;
+  padding: 0 8px;
+}
+
 .inboxsdk__menuItem img, .inboxsdk__menuItem .inboxsdk__icon {
   height: 16px;
   width: 16px;


### PR DESCRIPTION
Box: [When Gmail is in text toolbar (not icon mode) show Streak Icon + Text](http://www.streak.com/a/boxes/agxzfm1haWxmb29nYWVyMAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRiR47hoDA)