### PR TITLE
Collapsible nav items fixup

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.js
@@ -660,6 +660,13 @@ export default class GmailNavItemView {
 		itemContainerElement.classList.add('inboxsdk__navItem_container');
 
 		this._element.appendChild(itemContainerElement);
+
+		// If this is a collapsible nav-item, run collapse or expand to set the container styling
+		if (this._isCollapsible()) {
+			if(this._isCollapsed) this._collapse();
+			else this._expand();
+		}
+
 		return itemContainerElement;
 	}
 


### PR DESCRIPTION
Fixes a nav-items expansion state not being respected if child nav-items aren't added until after the parent item is set to collapsed.
i.e.
Fixes the fact that currently the "Hidden Pipelines" section does not properly hide its children after refreshing Gmail. The hidden items won't actually be hidden until the user clicks on the item twice more (toggling it to expanded, and then back to collapsed).