### PR TITLE
Fix getDraftId debug logging to not give stale cached values

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.js
@@ -670,8 +670,8 @@ class GmailDriver {
 		return get(this._messageIDsToThreadIDs, messageID);
 	}
 
-	getDraftIDForMessageID(messageID: string): Promise<GetDraftIdResult> {
-		return getDraftIDForMessageID(this, messageID);
+	getDraftIDForMessageID(messageID: string, skipCache=false): Promise<GetDraftIdResult> {
+		return getDraftIDForMessageID(this, messageID, skipCache);
 	}
 
 }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -1248,7 +1248,7 @@ class GmailComposeView {
               if (!newMessageId) {
                 throw new Error('Should not happen');
               }
-              const {draftID, debugData} = await this._driver.getDraftIDForMessageID(newMessageId);
+              const {draftID, debugData} = await this._driver.getDraftIDForMessageID(newMessageId, true);
               const err = new Error('Failed to read draft ID -- after check');
               this._driver.getLogger().error(err, {
                 message: 'getDraftID error -- after check',


### PR DESCRIPTION
ComposeView.getDraftID() has been failing sometimes for some users. Haven't been able to reproduce the problem, so there's some telemetry in the code to log some data when the error happens. One thing we log is whether we were able to successfully get the draft ID ten seconds later, but it turns out this was busted: the code would just re-check the cached draft ID. This fixes that.