### PR TITLE
Use correct method (HEAD) in getDownloadURL.

### DIFF
--- a/src/injected-js/xhr-helper.js
+++ b/src/injected-js/xhr-helper.js
@@ -18,7 +18,10 @@ export default function xhrHelper() {
     // xhr.responseURL to have the wrong value (possibly a Chrome bug).
     if (global.fetch) {
       (async () => {
-        const response = await fetch(opts.url, {credentials: 'include'});
+        const response = await fetch(opts.url, {
+          method: opts.method || 'GET',
+          credentials: 'include'
+        });
         document.dispatchEvent(new CustomEvent('inboxSDKpageAjaxDone', {
           bubbles: false, cancelable: false,
           detail: {


### PR DESCRIPTION
There was a minor mistake in https://github.com/StreakYC/GmailSDK/pull/509: it caused getDownloadURL to use GET requests instead of HEAD. GET means that the attachment would be unnecessarily downloaded by the client, but it wouldn't affect the correctness of getDownloadURL.