### PR TITLE
Disallow getDownloadURL() returning mail.google.com URLs

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-attachment-card-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-attachment-card-view.js
@@ -150,6 +150,13 @@ class GmailAttachmentCardView {
 					this._driver.getLogger().error(err, {
 						finalUrlCensored: finalUrl.replace(/\?[^/]+$/, '?[...]')
 					});
+					if (/^https:\/\/mail\.google\.com\//.test(finalUrl)) {
+						// This URL definitely isn't right: these URLs generally require
+						// authentication and shouldn't be returned by getDownloadURL.
+						throw err;
+					}
+					// Otherwise, don't throw; only log. Maybe Gmail has changed the URL
+					// structure and things will just work.
 				}
 				return finalUrl;
 			} else {


### PR DESCRIPTION
If getDownloadURL() detects that it was about to return a mail.google.com URL, throw an error instead of logging & continuing.

This logic means that if we mess up big time again and get a very-likely-auth-requiring mail.google.com URL, we won't give it to the app. But if Google just changes the attachment domain to something we don't recognize (like mail-attachment.googleusercontent.com -> attachment\.googleusercontent\.com, etc), then we log the unexpected URL but still give it to the app.

(One small extra detail: "getDownloadURL returned unexpected url" error has not showed up in the logs within the last few days and I've never seen it before, so this change should not impact anyone immediately, and is primarily defense-in-depth against unknown edge cases or future gmail changes.)