### PR TITLE
Fix links to custom view routes in Gmail

### DIFF
--- a/examples/custom-view/content.js
+++ b/examples/custom-view/content.js
@@ -16,20 +16,25 @@ InboxSDK.load(2, 'custom-view').then(function(sdk) {
     customRouteView.setFullWidth(false);
 
     customRouteView.getElement().textContent = 'hello world! ' + customRouteView.getParams().monkeyName;
-    var list = document.createElement('ul');
-    threadIds.forEach(function(threadId) {
-      var link = document.createElement('a');
-      link.href = sdk.Router.createLink(sdk.Router.NativeRouteIDs.THREAD, {threadID: threadId});
-      link.onclick = function(event) {
-        event.preventDefault();
-        event.stopPropagation();
-        sdk.Router.goto(sdk.Router.NativeRouteIDs.THREAD, {threadID: threadId});
-      };
-      link.textContent = threadId;
-      var item = document.createElement('li');
+    const list = document.createElement('ul');
+    // threadIds.forEach(function(threadId) {
+    //   const link = document.createElement('a');
+    //   link.href = sdk.Router.createLink(sdk.Router.NativeRouteIDs.THREAD, {threadID: threadId});
+    //   link.textContent = threadId;
+    //   const item = document.createElement('li');
+    //   item.appendChild(link);
+    //   list.appendChild(item);
+    // });
+
+    {
+      const link = document.createElement('a');
+      link.href = sdk.Router.createLink('example/:monkeyName', {monkeyName: 'linktest'});
+      link.textContent = 'linktest';
+      const item = document.createElement('li');
       item.appendChild(link);
       list.appendChild(item);
-    });
+    }
+
     customRouteView.getElement().appendChild(list);
   });
 

--- a/src/injected-js/main.js
+++ b/src/injected-js/main.js
@@ -18,13 +18,13 @@ if (!global.__InboxSDKInjected) {
     const setupErrorSilencer = require('./setup-error-silencer');
     const setupCustomViewEventAssassin = require('./setupCustomViewEventAssassin');
     const setupPushStateListener = require('./setupPushStateListener');
+    const setupInboxCustomViewLinkFixer = require('./setupInboxCustomViewLinkFixer');
 
     const gmailInterceptor = require('./gmail/setup-gmail-interceptor');
     const setupGmonkeyHandler = require('./gmail/setup-gmonkey-handler');
 
     const setupClickAndGetNewIframeSrc = require('./inbox/setupClickAndGetNewIframeSrc');
     const setupInboxFakeWindowResizeListener = require('./inbox/setupInboxFakeWindowResizeListener');
-    const setupInboxCustomViewLinkSmuggler = require('./inbox/setupInboxCustomViewLinkSmuggler');
     const setupComposeViewDraftIDFinder = require('./inbox/setupComposeViewDraftIDFinder');
     const setupInboxAjaxInterceptor = require('./inbox/setupAjaxInterceptor');
 
@@ -34,7 +34,6 @@ if (!global.__InboxSDKInjected) {
     } else if (document.location.origin === 'https://inbox.google.com') {
       setupClickAndGetNewIframeSrc();
       setupInboxFakeWindowResizeListener();
-      setupInboxCustomViewLinkSmuggler();
       setupComposeViewDraftIDFinder();
       setupInboxAjaxInterceptor();
     } else {
@@ -47,6 +46,7 @@ if (!global.__InboxSDKInjected) {
     setupErrorSilencer();
     setupCustomViewEventAssassin();
     setupPushStateListener();
+    setupInboxCustomViewLinkFixer();
   } catch(err) {
     logger.error(err);
   } finally {

--- a/src/injected-js/setupInboxCustomViewLinkFixer.js
+++ b/src/injected-js/setupInboxCustomViewLinkFixer.js
@@ -2,7 +2,7 @@
 
 import closest from 'closest-ng';
 
-export default function setupInboxCustomViewLinkSmuggler() {
+export default function setupInboxCustomViewLinkFixer() {
   const allowedStartTerms = new Set();
 
   document.addEventListener('inboxSDKregisterAllowedHashLinkStartTerm', function(event) {

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.js
@@ -358,6 +358,7 @@ class GmailDriver {
 
 	addCustomRouteID(routeID: string): () => void {
 		this._customRouteIDs.add(routeID);
+		this._pageCommunicator.registerAllowedHashLinkStartTerm(routeID.split('/')[0]);
 		return () => {
 			this._customRouteIDs.delete(routeID);
 		};
@@ -365,6 +366,7 @@ class GmailDriver {
 
 	addCustomListRouteID(routeID: string, handler: Function): () => void {
 		this._customListRouteIDs.set(routeID, handler);
+		this._pageCommunicator.registerAllowedHashLinkStartTerm(routeID.split('/')[0]);
 		return () => {
 			this._customListRouteIDs.delete(routeID);
 		};

--- a/src/platform-implementation-js/dom-driver/inbox/inbox-page-communicator.js
+++ b/src/platform-implementation-js/dom-driver/inbox/inbox-page-communicator.js
@@ -35,13 +35,6 @@ export default class InboxPageCommunicator extends CommonPageCommunicator {
       detail: null
     }));
   }
-  registerAllowedHashLinkStartTerm(term: string) {
-    document.dispatchEvent(new CustomEvent('inboxSDKregisterAllowedHashLinkStartTerm', {
-      bubbles: false,
-      cancelable: false,
-      detail: {term}
-    }));
-  }
 
   clickAndGetNewIframeSrc(el: HTMLElement): Promise<string> {
     const pr = Kefir.fromEvents(el, 'inboxSDKclickAndGetNewIframeSrcResult')

--- a/src/platform-implementation-js/lib/common-page-communicator.js
+++ b/src/platform-implementation-js/lib/common-page-communicator.js
@@ -135,4 +135,12 @@ export default class CommonPageCommunicator {
     });
     return unsilence;
   }
+
+  registerAllowedHashLinkStartTerm(term: string) {
+    document.dispatchEvent(new CustomEvent('inboxSDKregisterAllowedHashLinkStartTerm', {
+      bubbles: false,
+      cancelable: false,
+      detail: {term}
+    }));
+  }
 }


### PR DESCRIPTION
If you have an element `<a href="#box/...">foo</a>` that links to a custom view hash, then gmail preventDefaults the click event because it doesn't recognize the hash. (This may be a recent change copied from Inbox and put into both Gmail v1 and v2, or it may have been something that was always the case in Gmail.) This means that links created by Router.createLink(...) don't work.

An InboxSDK user recently reported Router.createLink(...) links not working in Gmail. This issue hasn't impacted Streak because we have always made our links between views have click events that call Router.goto(...). Streak doesn't seem to have ever depended on links created by Router.createLink(...) working.

We work around this is Inbox currently. This PR changes our Inbox fix for this issue to run in Gmail too.

This PR was tested using the examples/custom-view extension and with Streak.