### PR TITLE
Fix snippet manager jank on header fields.

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -850,7 +850,7 @@ body:not(.inboxsdk__gmailv1css) .inboxsdk__recipient_row {
 
 .inboxsdk__recipient_row td.ok {
   height: 20px;
-  padding: 0px;
+  padding: 0px !important;
 }
 
 .inboxsdk__recipient_row td.az3 {


### PR DESCRIPTION
[Snippet Manager alignment jank](https://mail.google.com/mail/u/0/#box/agxzfm1haWxmb29nYWVyMAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRixmqhrDA)

When creating a new snippet from a draft, users were seeing a misalignment between snippet header labels and their  corresponding input fields. This was caused by the async nature of loading our styles and gmail styles. This PR enforces our style over gmail to fix the misalignment. 