### PR TITLE
Bring back the box shadow on streak upcoming sidepanel.

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1468,7 +1468,6 @@ body.inboxsdk__gmailv1css .IDMAP_sidebar_iconArea + div:before {
 
 .bq9:not(.brC-brG).companion_app_sidebar_wrapper_visible {
   display: block !important;
-  box-shadow: none;
 }
 
   .companion_global_app_sidebar_visible .thread_app_sidebar {


### PR DESCRIPTION
[Box: streak upcoming lost left border in gmail v2](https://mail.google.com/mail/u/0/#box/agxzfm1haWxmb29nYWVyMAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRjRzctrDA)

The Streak upcoming sidepanel wasn't showing a box shadow on its left border. This PR removes the CSS rule that was explicitly setting the box shadow to none. 