### PR TITLE
add close button to butter html and el options

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-butter-bar-driver.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-butter-bar-driver.js
@@ -121,7 +121,7 @@ export default class GmailButterBarDriver {
 
       // Set up the close button shown in most Snack Bars in Material Gmail.
       // This button is hidden by css in Gmailv1.
-      noticeCloseButton = document.createElement('div');
+      let noticeCloseButton = document.createElement('div');
       noticeCloseButton.classList.add('bBe');
       noticeCloseButton.setAttribute('role', 'button');
       noticeCloseButton.tabIndex = 0;


### PR DESCRIPTION
Add close button in the butter bar when options has `html` or `el`. 

Previously, only options with `text` rendered the close button.