### PR TITLE
set status bar to position: relative

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -803,13 +803,14 @@ body .dw {
 }
 
 div.inboxsdk__compose_statusbar {
-  margin: 0;
   border: 0;
   height: 40px;
+  margin: 0;
 }
 
 body:not(.inboxsdk__gmailv1css) .inboxsdk__compose_statusbar {
   background: none;
+  position: relative;
 }
 
 /* only include padding when in thread inline view */


### PR DESCRIPTION
When the status bar container is `position: absolute` (set by Gmail), clicks weren't getting to elements in the status bar that did not have `position: relative`.

This PR fixes this by explicitly setting `.inboxsdk__compose_statusbar`'s position.