### PR TITLE
Have a better error message from getSyncThreadForOldGmailThreadId

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/getSyncThreadForOldGmailThreadId.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/getSyncThreadForOldGmailThreadId.js
@@ -14,5 +14,10 @@ import type {SyncThread} from '../gmail-sync-response-processor';
 
 export default async function getSyncThreadForOldGmailThreadId(driver: GmailDriver, oldGmailThreadId: string): Promise<SyncThread> {
   const threadDescriptors = await getSyncThreadsForSearch(driver, 'threadid:' + new BigNumber(oldGmailThreadId, 16).toString(10));
-  return threadDescriptors[0];
+  const firstThread = threadDescriptors[0];
+  if (firstThread == null) {
+    console.error(`Thread with ID ${oldGmailThreadId} not found by Gmail`); //eslint-disable-line
+    throw new Error('Thread not found by getSyncThreadForOldGmailThreadId');
+  }
+  return firstThread;
 }


### PR DESCRIPTION
getSyncThreadForOldGmailThreadId shouldn't return null, but sometimes does. The only place that uses getSyncThreadForOldGmailThreadId does not handle nulls from it, so it makes more sense to have a more informative error thrown at the source of the problem instead.