### PR TITLE
disable simulated-click identification method entirely

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/thread-row-identifier.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/thread-row-identifier.js
@@ -46,7 +46,8 @@ class ThreadRowIdentifier {
       }
     }
 
-    if (false) { // TODO fix or remove
+    // TODO fix or remove
+    if (false) { // eslint-disable-line
       // Try identifying the row by simulating a ctrl-click on it. Note that if
       // the thread row corresponds to an open minimized draft, then we won't
       // get a result, and the compose will be restored, so we counteract that


### PR DESCRIPTION
Issue seems to be affecting new gmail now for some people