### PR TITLE
No hover action fix

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.js
@@ -461,6 +461,7 @@ class GmailThreadRowView {
             }
             else {
               buttonSpan = document.createElement('span');
+              // T-KT is one of the class names on the star button. 
               buttonSpan.classList.add('T-KT');
             }
 

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -609,24 +609,30 @@ span.inboxsdk__thread_row_custom_draft_label + div.yW {
   height: 16px;
 }
 
+/* .zA td.apU.xy refers to the <td/> element that houses the favorite star in thread row view.
+ The <span> element is what inboxSDK will render threadRowButtons as when Gmail hover actions are disabled.
+ The following rules fix the issue where threadRowButtons were spilling over into the thread row email text. 
+ */
 body:not(.inboxsdk__gmailv1css) .zA td.apU.xY {
     width: initial;
 }
 
-body:not(.inboxsdk__gmailv1css) .zA td.apU.xY .inboxsdk__thread_row_button {
+body:not(.inboxsdk__gmailv1css) .zA td.apU.xY span.inboxsdk__thread_row_button {
     margin: 0 10px;
     opacity: 0.16;
 }
 
-body:not(.inboxsdk__gmailv1css) .zA.aqw td.apU.xY .inboxsdk__thread_row_button {
+body:not(.inboxsdk__gmailv1css) .zA.aqw td.apU.xY span.inboxsdk__thread_row_button {
     opacity: 0.54;
 }
 
-body:not(.inboxsdk__gmailv1css) .zA.aqw td.apU.xY .inboxsdk__thread_row_button:hover {
+body:not(.inboxsdk__gmailv1css) .zA.aqw td.apU.xY span.inboxsdk__thread_row_button:hover {
     opacity: 1;
 }
 
-body:not(.inboxsdk__gmailv1css) .zA td.apU.xY .inboxsdk__thread_row_button::before {
+body:not(.inboxsdk__gmailv1css) .zA td.apU.xY span.inboxsdk__thread_row_button::before {
+  /* Google adds in a pseduo ::before element to span elems with the T-KT class applied.
+  Explicity setting this width and height to zero as remove weird positioning that results */
     width: 0px;
     height: 0px;
 }


### PR DESCRIPTION
When user has hover actions turned off, the styling of thread row buttons was overflowing into the email text field. [related box link](https://mail.google.com/mail/u/0/?zx=7islbm7ewh7i#box/agxzfm1haWxmb29nYWVyMAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRjRss5tDA)