### PR TITLE
enforce open() calls in ui event handlers

### DIFF
--- a/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.js
+++ b/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.js
@@ -9,6 +9,7 @@ import delayAsap from '../../lib/delay-asap';
 import type {Driver} from '../../driver-interfaces/driver';
 import idMap from '../../lib/idMap';
 import querySelector from '../../lib/dom/querySelectorOrFail';
+import checkInUserInputEvent from '../../lib/checkInUserInputEvent';
 
 class ContentPanelViewDriver {
   _driver: Driver;
@@ -131,6 +132,7 @@ class ContentPanelViewDriver {
   }
 
   open(isOpenManual: boolean = false) {
+    checkInUserInputEvent();
     ((document.body:any):HTMLElement).dispatchEvent(new CustomEvent('inboxsdkSidebarPanelOpen', {
       bubbles: true,
       cancelable: false,

--- a/src/platform-implementation-js/lib/checkInUserInputEvent.js
+++ b/src/platform-implementation-js/lib/checkInUserInputEvent.js
@@ -1,0 +1,19 @@
+/* @flow */
+
+const UIEvent = global.UIEvent;
+
+// Throws an error if this is called outside of dispatch of a UIEvent.
+// This is intended to emulate a window.open-like restriction, to allow a
+// function to only be called in response to a user action.
+export default function checkInUserInputEvent() {
+  if (!isInUserInputEvent()) {
+    throw new Error('This function is restricted so it may only be called during a user input event.');
+  }
+}
+
+function isInUserInputEvent(): boolean {
+  const event = global.event;
+  if (!event) return false;
+  if (!(event instanceof UIEvent)) return false;
+  return event.isTrusted && event.eventPhase != 0;
+}


### PR DESCRIPTION
Reasoning from the "Opening the Global sidebar programmatically" box:

>Yeah, we currently lack a way to programmatically open the sidebar. ... This was partly intentional to discourage extensions from doing things like auto-opening the sidebar on every load (which would be especially problematic if several InboxSDK extensions all tried to do this; one of our major goals for the InboxSDK is to get Gmail extensions to play nice with each other and [fall into the pit of success](https://blog.codinghorror.com/falling-into-the-pit-of-success/) even in the multi-extension case), but we realize we may have neglected use-cases like onboarding flows.
>If we added a method to open the sidebar, do you think it would it be okay for your use-case if the method could only be called during handling of a click event (or any kind of input event) from the user? (This restriction is modeled on the restrictions that browsers have around window.open for popups.) This is assuming you want to open the sidebar in response to the user clicking a "start tour" button in a modal or app toolbar dropdown.
