### PR TITLE
fix compose mole position

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -125,6 +125,12 @@ body:not(.inboxsdk__gmailv1css) .f4.J-N-JX.inboxsdk__message_more_icon {
 /* compose buttons */
 
 /* fix compose mole position when sidebar is open */
+/* 
+steps to repro:
+1. open compose mole
+2. open non-native sidebar
+3. mole overlaps sidebar
+*/
 body:not(.inboxsdk__gmailv1css) .dw .nH > .no .nH.nn:last-child[style="width: 320px;"] {
   width: 376px !important;
 }


### PR DESCRIPTION
### Issue
Gmail adds width to a spacer div via JS to correctly move the compose mole horizontally when the sidebar opens.

But when a non-native sidebar is opened before a native one, gmail does not add enough width to the spacer div making the compose mole overlap with the sidebar by 56px.

### Fix
Bc there is no specific class that added (again width is added via JS) and we don't know how / when this width is calculated, the fix is to add a class that targets the incorrect width and overrides it with the correct one.