### PR TITLE
fix for when status bar is fixed and message is long

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-status-bar.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-status-bar.js
@@ -137,7 +137,6 @@ class StatusBar extends SimpleElementView {
           if (this._nativeStatusContainer.classList.contains('aDi')) {
             const nativeStatusContainerPaddingBottom = 16;
             let nativeStatusContainerHeight;
-            let newHeight;
 
             if (this._nativeStatusContainer.style.position === 'absolute') {
               const replyBody = querySelector(this._gmailComposeView.getElement(), '.iN > tbody .Ap');
@@ -148,7 +147,7 @@ class StatusBar extends SimpleElementView {
             }
 
             nativeStatusContainerHeight = parseInt(window.getComputedStyle(this._nativeStatusContainer).height, 10);
-            newHeight = nativeStatusContainerHeight + nativeStatusContainerPaddingBottom + this._currentHeight;
+            const newHeight = nativeStatusContainerHeight + nativeStatusContainerPaddingBottom + this._currentHeight;
             this._nativeStatusContainer.style.height = `${newHeight}px`;
 
             // when the _nativeStatusContainer is position: fixed, adjust the
@@ -167,11 +166,13 @@ class StatusBar extends SimpleElementView {
               // default height so long messages don't "peek through" 
               // when status bar is fixed
               querySelector(this._gmailComposeView.getElement(), '.iN > tbody .aDj.aDi .aC3').style.height = `${emailSpacerHeight}px`;
+              messageSpacer.style.height = `${messageSpacerHeight + newHeight}px`;
+            } else {
+              messageSpacer.style.height = `${messageSpacerHeight}px`;
             }
 
             const nativeStatusBar = querySelector(this._gmailComposeView.getElement(), '.iN > tbody .aDj.aDi .aDh .IZ');
             insertElementInOrder(nativeStatusBar, this.el);
-            messageSpacer.style.height = `${messageSpacerHeight + newHeight}px`;
           } else {
             //append to body
             const composeTable = querySelector(this._gmailComposeView.getElement(), '.iN > tbody');


### PR DESCRIPTION
Fix status bar when:
1. position is fixed
2. when there is a long message (the message "peeks" behind the status bar)
3. when it is an inline reply

OLD OLD
![image](https://user-images.githubusercontent.com/197015/48589054-9c7b8000-e8ee-11e8-92f8-2f4cbcd1a4de.png)

NEW NEW
![image](https://user-images.githubusercontent.com/197015/48589085-bae17b80-e8ee-11e8-9baf-98cfd834bdd6.png)


