### PR TITLE
add more logging details

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/get-address-information-extractor.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/get-address-information-extractor.js
@@ -29,7 +29,7 @@ export default function getAddressInformationExtractor(
 		} else {
 			Logger.error(new Error(`contactNode can't be found`), {
         addressType,
-        composeViewHtml: censorHTMLstring(composeView.getElement().outerHTML)
+        composeViewHtml: censorHTMLstring(composeView.getElement().querySelectorAll('form')[1].outerHTML)
 			});
 
 			return null;


### PR DESCRIPTION
The previous PR added the `composeView`'s HTML, but that got clipped. Whoop whoop.

What we actually want is to see what node is being passed into `getAddressInformationExtractor()`.