### PR TITLE
Changes selector for sender html element to work in both expanded and collapsed states

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.js
@@ -184,7 +184,7 @@ class GmailMessageView {
     let sender = this._sender;
     if (sender) return sender;
 
-    const senderSpan = querySelector(this._element, 'h3.iw span[email]');
+    const senderSpan = querySelector(this._element, 'td.gF span[email]');
 
     const emailAddress = senderSpan.getAttribute('email');
     if (!emailAddress) throw new Error('Could not find email address');


### PR DESCRIPTION
When the message was in a collapsed state, calling `getSender` would fail and throw an error.  This selector works in both states of the message view.