### PR TITLE
Remove type annotation for sidebar

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.js
@@ -72,7 +72,7 @@ class GmailAppSidebarPrimary {
 
   _currentIds: Set<string> = new Set();
 
-  _orderManager = new OrderManager<PanelDescriptor>({
+  _orderManager = new OrderManager({
     get() {
       try {
         return JSON.parse(


### PR DESCRIPTION
Fixes sidebar issue by removing the type annotation introduced in 9b779dad5b8f146aede77ec276385809b5af32ca.  Unsure why the existence of this annotation changes the evaluation of the JS. 