### PR TITLE
Fix nav buttons

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/arrow-dropdown-button-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/arrow-dropdown-button-view.js
@@ -3,8 +3,6 @@
 import GenericButtonView from '../../../../lib/dom/generic-button-view';
 
 export default class ArrowDropdownButtonView extends GenericButtonView {
-  _element: HTMLElement; // inherited
-
   constructor(buttonOptions: Object) {
     const element = document.createElement('img');
     element.setAttribute('class', 'afM');
@@ -25,10 +23,10 @@ export default class ArrowDropdownButtonView extends GenericButtonView {
   }
 
   activate() {
-    this._element.classList.add('afO');
+    this.getElement().classList.add('afO');
   }
 
   deactivate() {
-    this._element.classList.remove('afO');
+    this.getElement().classList.remove('afO');
   }
 }

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/inbox-dropdown-button-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/inbox-dropdown-button-view.js
@@ -3,8 +3,6 @@
 import GenericButtonView from '../../../../lib/dom/generic-button-view';
 
 export default class InboxDropdownButtonView extends GenericButtonView {
-  _element: HTMLElement; // inherited
-
   constructor() {
     const element = document.createElement('div');
     element.setAttribute('class', 'aAE qi J-J5-Ji J-JN-M-I');
@@ -23,12 +21,12 @@ export default class InboxDropdownButtonView extends GenericButtonView {
   }
 
   activate() {
-    this._element.classList.add('J-JN-M-I-JO');
-    this._element.classList.add('J-JN-M-I-Kq');
+    this.getElement().classList.add('J-JN-M-I-JO');
+    this.getElement().classList.add('J-JN-M-I-Kq');
   }
 
   deactivate() {
-    this._element.classList.remove('J-JN-M-I-JO');
-    this._element.classList.remove('J-JN-M-I-Kq');
+    this.getElement().classList.remove('J-JN-M-I-JO');
+    this.getElement().classList.remove('J-JN-M-I-Kq');
   }
 }


### PR DESCRIPTION
It turns out this "fix" I did to make flow happy about these files referencing private properties from each other had a bad runtime effect. Declaring properties like this causes the properties to be set to `undefined` after the `super(...)` call.