### PR TITLE
Use new eslint plugin to detect duplicate fields

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,11 @@ module.exports = {
     node: true,
     es6: true
   },
-  extends: ['eslint:recommended', 'plugin:react/recommended'],
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:no-dupe-class-fields/recommended'
+  ],
   parserOptions: {
     ecmaFeatures: {
       experimentalObjectRestSpread: true,
@@ -14,7 +18,7 @@ module.exports = {
     },
     sourceType: 'module'
   },
-  plugins: ['react', 'flowtype', 'deprecate'],
+  plugins: ['flowtype', 'deprecate'],
   rules: {
     'flowtype/define-flow-type': 1,
     'flowtype/require-valid-file-annotation': ['error', 'always'],

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint": "^5.7.0",
     "eslint-plugin-deprecate": "^0.5.4",
     "eslint-plugin-flowtype": "^3.0.0",
+    "eslint-plugin-no-dupe-class-fields": "^1.0.0",
     "eslint-plugin-react": "^7.1.0",
     "event-listener-with-options": "^1.0.3",
     "flow-bin": "^0.89.0",

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -113,7 +113,6 @@ class GmailComposeView {
   _destroyed: boolean = false;
   _removedFromDOMStopper: Stopper;
   ready: () => Kefir.Observable<GmailComposeView>;
-  getEventStream: () => Kefir.Observable<any>;
 
   constructor(
     element: HTMLElement,

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,7 +758,7 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
   integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==
@@ -2935,6 +2935,13 @@ eslint-plugin-flowtype@^3.0.0:
   integrity sha512-baJmzngM6UKbEkJ5OY3aGw2zjXBt5L2QKZvTsOlXX7yHKIjNRrlJx2ods8Rng6EdqPR9rVNIQNYHpTs0qfn2qA==
   dependencies:
     lodash "^4.17.10"
+
+eslint-plugin-no-dupe-class-fields@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-dupe-class-fields/-/eslint-plugin-no-dupe-class-fields-1.0.0.tgz#fdbe1ef4b310e1602a0839e3c69f3ba7c18bfd63"
+  integrity sha512-vxg1TDAiyMD6hdp4OPhAIaj+68BjcM9RWibOB0voiBoglTCBKipl+tIz9CaSG/iYw1vyYd90//fIBakjweEWqg==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
 
 eslint-plugin-react@^7.1.0:
   version "7.12.3"


### PR DESCRIPTION
Babel 7 now initializes any class properties to `undefined` when the class is instantiated. In GmailComposeView, we accidentally defined `getEventStream` twice, which now breaks in Babel 7. I created [a new eslint plugin to detect this](https://github.com/Macil/eslint-plugin-no-dupe-class-fields) and added it to our eslint config, and then fixed the issue in GmailComposeView. It didn't find any other cases like this.