### PR TITLE
Fix reading id of freshly-sent message

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -615,6 +615,15 @@ class GmailComposeView {
           .catch(() => {
             //do nothing because this means the message hasn't been saved yet
           });
+
+        this._driver.reportRecentSyncDraftId(syncMessageId);
+        this._stopper.onValue(() => {
+          this._driver.reportDraftClosed(syncMessageId);
+        });
+      } else {
+        this._driver
+          .getLogger()
+          .error(new Error('Draft is missing sync draft id'));
       }
 
       const legacyThreadIdElement: ?HTMLInputElement = (this._element.querySelector(

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.js
@@ -94,7 +94,13 @@ class GmailMessageView {
         if (!syncMessageId)
           throw new Error('data-message-id attribute has no value');
 
-        if (messageIdElement.hasAttribute('data-legacy-message-id')) {
+        // Only respect data-legacy-message-id if data-message-id is not the id
+        // of a draft we've seen recently, in order to work around a Gmail bug.
+        // https://github.com/StreakYC/GmailSDK/issues/515#issuecomment-457420619
+        if (
+          messageIdElement.hasAttribute('data-legacy-message-id') &&
+          !this._driver.isRecentSyncDraftId(syncMessageId.replace('#', ''))
+        ) {
           partialReadyStream = Kefir.constant(null);
         } else {
           // we have a data message id, but not the legacy message id. So now we have to poll for the gmail message id


### PR DESCRIPTION
Fixes #515.

There's actually two very similar bugs here, an InboxSDK bug and a Gmail bug, that both can cause this issue. This fixes the InboxSDK bug by not using the syncMessageId->legacyMessageId cache for syncDraftId->legacyMessageId lookups, and then works around the Gmail bug. See https://github.com/StreakYC/GmailSDK/issues/515#issuecomment-457420619 for more information.