### PR TITLE
Refactor show-custom-thread-list to use simpler async function

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.js
@@ -29,12 +29,6 @@ type HandlerResult = {
   threads: Array<ThreadDescriptor>
 };
 
-type NormalizedHandlerResult<T> = {
-  start: number,
-  total: number | 'MANY',
-  threads: T
-};
-
 const threadListHandlersToSearchStrings: Map<Function, string> = new Map();
 
 const MAX_THREADS_PER_PAGE = 50;


### PR DESCRIPTION
show-custom-thread-list.js was written before we had async functions, and its main core is really a long promise chain (well, one-item Kefir chain, which is practically equivalent) which is a lot simpler to express as an async function. This should make it a lot more maintainable. There's a few bugs reported with custom thread lists lately, so this should help toward that.

This refactor passes the test added in https://github.com/StreakYC/GmailSDK/pull/588 without any modifications to the test.