### PR TITLE
Fix button style for ButterBar error state

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -2689,11 +2689,11 @@ body.inboxsdk__gmailv1css .inboxsdk__butterbar .a8k {
   background-color: #c53929 !important;
 }
 
-.inboxsdk__butterbar.inboxsdk__butterbar_error .a8k {
+.inboxsdk__butterbar.inboxsdk__butterbar_error [role='button'] {
   color: #fff;
 }
 
-.inboxsdk__butterbar.inboxsdk__butterbar_error .a8k::before {
+.inboxsdk__butterbar.inboxsdk__butterbar_error [role='button']::before {
   background: #fff;
 }
 


### PR DESCRIPTION
Old:
![Old](https://user-images.githubusercontent.com/267284/54646366-0c944100-4a5c-11e9-9af0-e8fbc28221c8.png)

New:
![New](https://user-images.githubusercontent.com/267284/54646367-0c944100-4a5c-11e9-822c-d3dbb3aa4260.png)

This references the `a8k` class, which seems fragile but perhaps is how InboxSDK works?

Box: [InboxSDK: fix button style for showError()](https://mail.google.com/mail/u/0/#box/agxzfm1haWxmb29nYWVyNAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRiAgMyr_tf9Cww)