### PR TITLE
Fix send and archive button handling

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -1266,10 +1266,17 @@ class GmailComposeView {
       return sendAndArchiveButton;
     }
 
+    // TODO is the rest of this function necessary?
+
     const sendButton = this.getSendButton();
     const parent = sendButton.parentElement;
     if (!(parent instanceof HTMLElement)) throw new Error('should not happen');
     if (parent.childElementCount <= 1) {
+      this._driver
+        .getLogger()
+        .eventSdkPassive(
+          'getSendAndArchiveButton - old method - failed to find, childElementCount <= 1'
+        );
       return null;
     }
 
@@ -1277,9 +1284,21 @@ class GmailComposeView {
       parent.children[0] !== sendButton
         ? parent.children[0]
         : parent.children[1];
-    return !firstNotSendElement
+    const result = !firstNotSendElement
       ? null
       : firstNotSendElement.querySelector('[role=button]');
+    if (result) {
+      this._driver
+        .getLogger()
+        .eventSdkPassive('getSendAndArchiveButton - old method - found');
+    } else {
+      this._driver
+        .getLogger()
+        .eventSdkPassive(
+          'getSendAndArchiveButton - old method - failed to find'
+        );
+    }
+    return result;
   }
 
   getCloseButton(): HTMLElement {


### PR DESCRIPTION
* Gmail adding the "schedule send" button broke getSendButton(), and https://github.com/StreakYC/GmailSDK/pull/605 fixed that, but caused getSendButton() to incorrectly return the send-and-archive button when it was present.
* Gmail adding the "schedule send" button broke getSendAndArchiveButton().