### PR TITLE
Very partial fix: do not call setStatusBar when unnecessary

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-status-bar.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-status-bar.js
@@ -81,6 +81,8 @@ class StatusBar extends SimpleElementView {
       attributeFilter: ['class'],
       attributes: true
     })
+      .map(() => this._nativeStatusContainer.classList.contains('aDi'))
+      .skipDuplicates()
       .takeUntilBy(this._stopper)
       .onValue(() => this._setStatusBar());
   }


### PR DESCRIPTION
This stops reply status bars from growing infinitely while the user scrolls or merely looks at the page. Now the status bar only grows when the reply status area switches back and forth from fixed positioning. Still need to fix that.