### PR TITLE
Remove margin left for custom suggestion img

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -2433,7 +2433,6 @@ table.cf.wd.inboxsdk__shortcutHelp_table {
 .inboxsdk__custom_suggestion img {
   max-width: 32px;
   max-height: 32px;
-  margin-left: -11px;
 }
 
 .inboxsdk__custom_suggestion_iconHTML {


### PR DESCRIPTION
## What's in this PR?
This is to remove the margin left offset we had to align our custom img with gmail suggestion icon row.

**Before**
![image](https://user-images.githubusercontent.com/7209644/59789456-c29d4000-9282-11e9-8d02-a3790d4ae315.png)


**After**

![image](https://user-images.githubusercontent.com/7209644/59789379-a8636200-9282-11e9-8481-5ec7aec9aeee.png)
