### PR TITLE
Allow icon html for thread row view

### DIFF
--- a/examples/thread-rows/content.css
+++ b/examples/thread-rows/content.css
@@ -11,3 +11,7 @@
   width: 16px;
   height: 16px;
 }
+
+.icon-html-class {
+  background: red;
+}

--- a/examples/thread-rows/content.js
+++ b/examples/thread-rows/content.js
@@ -46,6 +46,14 @@ InboxSDK.load(2, 'thread-rows').then(function(inboxSDK) {
       iconBackgroundColor: 'green'
     });
 
+    const iconHtml = "<div style='width: 56px;height: 4px;background: aqua;'></div>"
+
+    threadRowView.addAttachmentIcon({
+      iconHtml,
+      iconClass: 'icon-html-class',
+      title: 'icon html'
+    })
+
     threadRowView.addAttachmentIcon(Kefir.repeatedly(2000, [
       {
         iconClass: 'test_icon_thing',
@@ -54,6 +62,11 @@ InboxSDK.load(2, 'thread-rows').then(function(inboxSDK) {
       {
         iconUrl: 'https://ssl.gstatic.com/ui/v1/icons/mail/gplus.png',
         title: 'blah blah'
+      },
+      {
+        iconHtml: '<div>x</div>',
+        iconClass: 'icon-html-class',
+        title: 'icon html'
       }
     ]));
     threadRowView.replaceDraftLabel(Kefir.repeatedly(1000, [

--- a/src/docs/thread-row-view.js
+++ b/src/docs/thread-row-view.js
@@ -315,6 +315,14 @@ var ThreadRowAttachmentIconDescriptor = /** @lends ThreadRowAttachmentIconDescri
   iconClass: null,
 
   /**
+   * An optional Html for the icon to show. This property can not be used with iconUrl.
+   * ^optional
+   * ^default=null
+   * @type {string}
+   */
+  iconHtml: null,
+
+  /**
    * The tooltip text to show when the user hovers over the icon.
    * ^optional
    * @type {string}

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.js
@@ -753,6 +753,12 @@ class GmailThreadRowView {
       img.src = 'images/cleardot.gif';
       return img;
     });
+
+    const getCustomIconWrapper = once(() => {
+      const div = document.createElement('div');
+      return div;
+    });
+
     var added = false;
     var currentIconUrl;
 
@@ -764,6 +770,7 @@ class GmailThreadRowView {
         const attachmentDiv = querySelector(this._elements[0], 'td.yf.xY');
         if (!opts) {
           if (added) {
+            getCustomIconWrapper().remove();
             getImgElement().remove();
             added = false;
 
@@ -778,7 +785,8 @@ class GmailThreadRowView {
             }
           }
         } else {
-          const img = getImgElement();
+          const img =
+            opts.iconHtml != null ? getCustomIconWrapper() : getImgElement();
           if (opts.tooltip) {
             img.setAttribute('data-tooltip', opts.tooltip);
           } else {
@@ -786,9 +794,23 @@ class GmailThreadRowView {
           }
 
           img.className =
-            'inboxsdk__thread_row_addition inboxsdk__thread_row_attachment_icon ' +
-            (opts.iconClass || '');
-          if (currentIconUrl != opts.iconUrl) {
+            opts.iconHtml != null
+              ? 'inboxsdk__thread_row_addition inboxsdk__thread_row_attachment_iconWrapper ' +
+                (opts.iconClass || '')
+              : 'inboxsdk__thread_row_addition inboxsdk__thread_row_attachment_icon ' +
+                (opts.iconClass || '');
+
+          if (opts.iconHtml != null) {
+            if (attachmentDiv.contains(getImgElement())) {
+              getImgElement().remove();
+            }
+
+            img.innerHTML = opts.iconHtml;
+          } else if (currentIconUrl != opts.iconUrl) {
+            if (attachmentDiv.contains(getCustomIconWrapper())) {
+              getCustomIconWrapper().remove();
+            }
+
             img.style.background = opts.iconUrl
               ? 'url(' + opts.iconUrl + ') no-repeat 0 0'
               : '';

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -671,10 +671,18 @@ span.inboxsdk__thread_row_custom_draft_label + div.yW {
   display: none;
 }
 
+.inboxsdk__thread_row_attachment_iconWrapper,
 .inboxsdk__thread_row_attachment_icon {
   margin-left: 3px;
   width: 16px;
   height: 16px;
+}
+
+.inboxsdk__thread_row_attachment_iconWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: max-content;
 }
 
 /* .zA td.apU.xy refers to the <td/> element that houses the favorite star in thread row view.


### PR DESCRIPTION
## What's in this PR?
This enables us to pass custom icon html so that we can show info like this in thread row view for https://gallery.io/projects/MCHbtQVoQ2HCZWriid4aP9sV/files/MCEJu8Y2hyDScec7xyhsY0n98VNqSGhCVs8

**Demo**
![Kapture 2019-06-28 at 17 03 42](https://user-images.githubusercontent.com/7209644/60376916-c0478e00-99c6-11e9-9fa2-ff114faed2ad.gif)
