### PR TITLE
Resize sidebar button icons to match Gmail

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1611,11 +1611,11 @@ body.inboxsdk__gmailv1css
 }
 
 .IDMAP_sidebar_iconArea .inboxsdk__button_icon {
-  margin: 16px 16px 8px 16px;
+  margin: 18px 18px 10px 18px;
   border: none;
   background: #fff;
-  height: 24px;
-  width: 24px;
+  height: 20px;
+  width: 20px;
   overflow: hidden;
   padding: 0;
   cursor: pointer;
@@ -1623,7 +1623,7 @@ body.inboxsdk__gmailv1css
 }
 
 .IDMAP_sidebar_iconArea.sidebar_global_iconArea .inboxsdk__button_icon {
-  margin-bottom: 16px;
+  margin-bottom: 18px;
 }
 
 body:not(.inboxsdk__gmailv1css) .IDMAP_sidebar_iconArea .inboxsdk__button_icon {
@@ -1640,10 +1640,10 @@ body:not(.inboxsdk__gmailv1css)
   content: '';
   background: #f1f3f4;
   position: absolute;
-  top: -8px;
-  left: -8px;
-  right: -8px;
-  bottom: -8px;
+  top: -10px;
+  left: -10px;
+  right: -10px;
+  bottom: -10px;
   border-radius: 50%;
   z-index: 0;
 }
@@ -1660,8 +1660,8 @@ body.inboxsdk__gmailv1css .IDMAP_sidebar_iconArea .inboxsdk__button_icon {
 }
 
 .IDMAP_sidebar_iconArea .inboxsdk__button_iconImg {
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
   margin-top: 0px;
 }
 


### PR DESCRIPTION
Our sidebar icons are slightly larger than Gmail's; 24px vs. 20px. When the supplied image is 20x20 it becomes slightly fuzzy when enlarged to 24x24.

Before:
<img width="230" alt="Screen Shot 2019-07-26 at 14 51 06" src="https://user-images.githubusercontent.com/267284/61983425-3256c700-afb5-11e9-80f7-af75c35e959b.png">

After:
<img width="230" alt="Screen Shot 2019-07-26 at 14 51 22" src="https://user-images.githubusercontent.com/267284/61983427-32ef5d80-afb5-11e9-8b79-634608fdf4af.png">
