### PR TITLE
fix error icon hover color

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -2776,7 +2776,7 @@ body.inboxsdk__gmailv1css .inboxsdk__butterbar .a8k {
 }
 
 .inboxsdk__butterbar.inboxsdk__butterbar_error [role='button']::before {
-  background: #fff;
+  background: rgba(255, 255, 255, 0.08);
 }
 
 /* end butter/snack bar */


### PR DESCRIPTION
For butter bar error messages, hover was completely white out-ing the close icon.

This PR changes the hover background on error butter bars to Material's suggested .08 opacity.

OLD
![Screen Shot 2019-08-21 at 10 43 50 AM](https://user-images.githubusercontent.com/197015/63456067-f3c0fa80-c402-11e9-9129-c1b0f13228cc.png)

NEW
![Screen Shot 2019-08-21 at 10 53 02 AM](https://user-images.githubusercontent.com/197015/63456082-fae80880-c402-11e9-859c-606aff7584bf.png)

