### PR TITLE
Use transparent background behind sidebar icon

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1613,7 +1613,7 @@ body.inboxsdk__gmailv1css
 .IDMAP_sidebar_iconArea .inboxsdk__button_icon {
   margin: 18px 18px 10px 18px;
   border: none;
-  background: #fff;
+  background: transparent;
   height: 20px;
   width: 20px;
   overflow: hidden;


### PR DESCRIPTION
The icons have an unsightly white border when using a non-default Gmail theme.

Before:
![Screen Shot 2019-08-21 at 16 08 54](https://user-images.githubusercontent.com/267284/63474485-2c29fe00-c42e-11e9-8e2d-0e752a598c90.png)

After:
![Screen Shot 2019-08-21 at 16 08 34](https://user-images.githubusercontent.com/267284/63474495-33e9a280-c42e-11e9-97e5-bce0662aeda7.png)