### PR TITLE
Fix ComposeView.insertHTMLIntoBodyAtCursor failing if compose is fullscreened

### DIFF
--- a/examples/compose-stream/content.js
+++ b/examples/compose-stream/content.js
@@ -182,7 +182,7 @@ InboxSDK.load(2, 'compose-stream-example').then(inboxSDK => {
     composeView.on('bccContactRemoved', console.log.bind(console, 'bccContactRemoved'));
     composeView.on('recipientsChanged', console.log.bind(console, 'recipientsChanged'));
     composeView.on('fromContactChanged', console.log.bind(console, 'fromContactChanged'));
-    
+
     composeView.on('responseTypeChanged', console.log.bind(console, 'responseTypeChanged'));
 
     composeView.on('fullscreenChanged', console.log.bind(console, 'fullscreenChanged'));

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -677,7 +677,7 @@ class GmailComposeView {
     var retVal = insertHTMLatCursor(
       this.getBodyElement(),
       html,
-      this._lastSelectionRange
+      this.getLastSelectionRange()
     );
     this._triggerDraftSave();
 
@@ -1178,14 +1178,14 @@ class GmailComposeView {
   getSelectedBodyHTML(): ?string {
     return getSelectedHTMLInElement(
       this.getBodyElement(),
-      this._lastSelectionRange
+      this.getLastSelectionRange()
     );
   }
 
   getSelectedBodyText(): ?string {
     return getSelectedTextInElement(
       this.getBodyElement(),
-      this._lastSelectionRange
+      this.getLastSelectionRange()
     );
   }
 
@@ -1824,6 +1824,15 @@ class GmailComposeView {
   }
 
   getLastSelectionRange(): ?Range {
+    // The selection range can become invalid if the compose view has become expanded or
+    // minimized since the range was set.
+    const range = this._lastSelectionRange;
+    if (
+      range &&
+      !this.getBodyElement().contains(range.commonAncestorContainer)
+    ) {
+      this._lastSelectionRange = undefined;
+    }
     return this._lastSelectionRange;
   }
 


### PR DESCRIPTION
If you placed the cursor into a ComposeView, toggled the fullscreen status, and then used the insertHTMLIntoBodyAtCursor method, nothing would be inserted into the compose view (and instead, the elements would be inserted inside of invisible formatting elements elsewhere in the page).

This happened because we still remembered the lastSelectionRange from before the compose view was (un)fullscreened, which no longer points to the compose view because the compose view was moved elsewhere in the DOM.

We now check the lastSelectionRange for validity on access.