### PR TITLE
Add option to match drawer width with sidebar's

### DIFF
--- a/src/docs/widgets.js
+++ b/src/docs/widgets.js
@@ -279,5 +279,15 @@ var DrawerOptions = /** @lends ModalOptions */ {
    * ^default=false
    * @type {boolean}
    */
-  closeWithCompose: null
+  closeWithCompose: null,
+
+  /**
+   * When true, uses a slimmer drawer that matches the width of the sidebar
+   * content panel.
+   *
+   * ^optional
+   * ^default=false
+   * @type {boolean}
+   */
+  matchSidebarContentPanelWidth: null
 };

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-drawer-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-drawer-view.js
@@ -230,6 +230,11 @@ class InboxDrawerView {
     this._el.setAttribute('role', 'dialog');
     this._el.tabIndex = 0;
     this._el.className = 'inboxsdk__drawer_view';
+
+    if (options.matchSidebarContentPanelWidth) {
+      this._el.classList.add('inboxsdk__match_sidebar_content_panel_width');
+    }
+
     this._containerEl.appendChild(this._el);
 
     if (this._chrome) {

--- a/src/platform-implementation-js/driver-interfaces/driver.d.ts
+++ b/src/platform-implementation-js/driver-interfaces/driver.d.ts
@@ -42,6 +42,7 @@ export interface DrawerViewOptions {
   chrome?: boolean;
   composeView?: ComposeView;
   closeWithCompose?: boolean;
+  matchSidebarContentPanelWidth?: boolean;
 }
 // import InboxDrawerView from '../dom-driver/inbox/views/inbox-drawer-view';
 // export type DrawerViewDriver = InboxDrawerView;

--- a/src/platform-implementation-js/driver-interfaces/driver.js
+++ b/src/platform-implementation-js/driver-interfaces/driver.js
@@ -34,7 +34,8 @@ export type DrawerViewOptions = {
   title?: string,
   chrome?: boolean,
   composeView?: ComposeView,
-  closeWithCompose?: boolean
+  closeWithCompose?: boolean,
+  matchSidebarContentPanelWidth?: boolean
 };
 import type InboxDrawerView from '../dom-driver/inbox/views/inbox-drawer-view';
 export type DrawerViewDriver = InboxDrawerView;

--- a/src/platform-implementation-js/style/shared.css
+++ b/src/platform-implementation-js/style/shared.css
@@ -83,6 +83,10 @@
   transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+.inboxsdk__drawer_view.inboxsdk__match_sidebar_content_panel_width {
+  width: 300px;
+}
+
 .inboxsdk__drawer_view.inboxsdk__active {
   -webkit-transform: none;
   transform: none;


### PR DESCRIPTION
Setting `matchContentPanelWidth` makes the drawer 300px wide. Happy to change the option name if there's something that better expresses the behaviour.

I also considered exposing a `width` parameter, but allowing any arbitrary value seems like a poor idea.