### PR TITLE
Prevent misaligned thread row button

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -588,6 +588,10 @@ body.inboxsdk__gmailv1css .inboxsdk__thread_row_label .inboxsdk__button_icon {
   padding: 0px;
 }
 
+.inboxsdk__thread_row_button .inboxsdk__button_icon {
+  max-height: 100%;
+}
+
 body:not(.inboxsdk__gmailv1css) .inboxsdk__thread_row_custom_date_container {
   max-width: inherit;
 }


### PR DESCRIPTION
The misalignment was caused by the thread row button being taller than its parent container. The solution is to ensure both elements have the same height.

Before:
<img width="166" alt="Screen Shot 2020-01-08 at 09 49 31" src="https://user-images.githubusercontent.com/267284/72003083-81a85100-31fd-11ea-9664-387ba2f354e9.png">

After:
<img width="166" alt="Screen Shot 2020-01-08 at 09 49 23" src="https://user-images.githubusercontent.com/267284/72003082-81a85100-31fd-11ea-8d46-0d46b1d1025c.png">