### PR TITLE
MessageDescriptor text should be optional

### DIFF
--- a/src/docs/butter-bar.js
+++ b/src/docs/butter-bar.js
@@ -62,7 +62,7 @@ var ButterBar = /** @lends ButterBar */ {
  */
 var MessageDescriptor = /** @lends MessageDescriptor */ {
   /**
-   * Text to show.
+   * Text to show. Either the text property or the html property must be passed.
    * ^optional
    * @type {string}
    */


### PR DESCRIPTION
From this block https://github.com/StreakYC/GmailSDK/blob/master/src/platform-implementation-js/dom-driver/gmail/gmail-butter-bar-driver.js#L171-L177 `html`, `el`, and `text` one of these is required but `text` itself is optional.