### PR TITLE
Relax selector used to monitor preview pane

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.js
@@ -307,15 +307,7 @@ class GmailRouteView {
   }
 
   _setupContentAndSidebarView() {
-    var previewPaneContainer = document.querySelector('.Nm .aia');
-
-    if (previewPaneContainer) {
-      this._startMonitoringPreviewPaneForThread(previewPaneContainer);
-      return;
-    }
-
-    var threadContainerElement = this._getThreadContainerElement();
-
+    const threadContainerElement = this._getThreadContainerElement();
     if (threadContainerElement) {
       var gmailThreadView = new GmailThreadView(
         threadContainerElement,
@@ -329,6 +321,16 @@ class GmailRouteView {
         eventName: 'newGmailThreadView',
         view: gmailThreadView
       });
+    } else {
+      // This element is always present in thread lists, but it only has contents
+      // when in preview pane mode. We want to monitor it in either case
+      // because the user could switch into preview pane mode.
+      const previewPaneContainer = document.querySelector(
+        'div[role=main] .aia'
+      );
+      if (previewPaneContainer) {
+        this._startMonitoringPreviewPaneForThread(previewPaneContainer);
+      }
     }
   }
 


### PR DESCRIPTION
Recently (possibly just since last Friday), InboxSDK's compatibility with the split pane broke. It sounds like [changes are coming](https://gsuiteupdates.googleblog.com/2020/02/multiple-inbox-updates.html?m=1) to split pane mode, so this might be a casualty of that.

The fix itself is incredibly simple — just stop requiring the `[gh=tl]` attribute in the selector that finds the split pane container.

Box: [Streak's add to box sidebar incompatible with Gmail's preview pane](https://mail.google.com/mail/u/0/#box/agxzfm1haWxmb29nYWVyNAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRiAgLLA5b6yCAw)