### PR TITLE
Remove nav item margins causing misalignment

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1871,16 +1871,6 @@ body:not(.inboxsdk__gmailv1css) .inboxsdk__navItem > .TO.n4 {
   padding-left: 0;
 }
 
-/* The qj class has "margin-right: 24px" by default, but we tweak that here so icons
- properly align with the Gmail label icons, which have 3px of of margin-left in the
- element inside their qj container. The one exception to this is for GROUPER type
- nav-items (which have the "n4" class) where we use Gmail css for the icon.
- */
-body:not(.inboxsdk__gmailv1css) .inboxsdk__navItem > .TO:not(.n4) .qj {
-  margin-left: 3px;
-  margin-right: 21px;
-}
-
 body:not(.inboxsdk__gmailv1css) .inboxsdk__navItem > .TO.n4 .qj > .G-asx {
   margin-right: 0;
 }


### PR DESCRIPTION
Gmail must have since updated so that these style overrides are no longer necessary.

Before:
<img width="179" alt="Screen Shot 2020-03-06 at 12 05 26" src="https://user-images.githubusercontent.com/267284/76119325-0d432180-5fa4-11ea-883e-ba3c5147f46f.png">

After:
<img width="179" alt="Screen Shot 2020-03-06 at 12 04 44" src="https://user-images.githubusercontent.com/267284/76119319-09af9a80-5fa4-11ea-9aa8-ed566960b6b3.png">