### PR TITLE
Display angle bracket help string for mod key

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/keyboard-shortcut-help-modifier.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/keyboard-shortcut-help-modifier.js
@@ -205,6 +205,10 @@ function _getAngledBracket(chordChar: string): string {
     case 'meta':
     case 'command':
       return '<⌘>';
+    case 'mod':
+      // Operating system check copied from Combokeys.
+      // https://github.com/avocode/combokeys/blob/0b80e13cf7e5217c5b4fbd393289a87b1f48f7cc/helpers/special-aliases.js#L14
+      return /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? '<⌘>' : '<Ctrl>';
     default:
       return chordChar;
   }


### PR DESCRIPTION
Combokeys / Mousetrap supports "mod", which maps to <kbd>control</kbd> on Windows and <kbd>command</kbd> on macOS. This PR displays the appropriate help string if mod is used in `KeyboardShortcutDescriptor.chord`.
