### PR TITLE
Decrease rate-limit for gmail requests

### DIFF
--- a/src/platform-implementation-js/driver-common/gmailAjax.js
+++ b/src/platform-implementation-js/driver-common/gmailAjax.js
@@ -13,7 +13,7 @@ const IMAGE_REQUEST_TIMEOUT = 1000 * 60; // one minute
 const limitedAjax = rateLimitQueuer(
   rateLimitQueuer(ajax, 1000, 7),
   10 * 1000,
-  40
+  50
 );
 
 // Tool for making ajax requests to Gmail endpoints. When used in Inbox, this


### PR DESCRIPTION
amiramk@gmail.com was reporting an issue where sometimes we could hit the Gmail rate-limit for calls to the show original page. This reduces the rate-limit we enforce on ourselves for http calls to Gmail. Previously, the limit was 7 requests within one second. Now that limit still exists, but there's an additional limit of 50 requests within 10 seconds. This lets us still do a quick burst of requests, but on average the limit will approach 5 requests per second if enough requests happen.

I had previously done experiments to see that 7 requests per second seemed to be safe in isolation; I'm guessing that limit is too high if you're doing other things in Gmail at the same time. I picked the new target rate of 50 requests per 10 seconds as a rough guess that seems unlikely to negatively affect us while giving some more breathing room.