### PR TITLE
fix mem leak in getMainContentElementChangedStream

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter/get-main-content-element-changed-stream.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter/get-main-content-element-changed-stream.ts
@@ -25,7 +25,7 @@ export default function getMainContentElementChangedStream(
               return { target: el };
             })
             .filter(_isNowVisible)
-            .map(e => e.target)
+            .map(() => el)
         )
     )
     .toProperty();


### PR DESCRIPTION
Fixes this mem leak.

![image](https://user-images.githubusercontent.com/197015/94724623-6d6a2e00-030f-11eb-8b48-a19eaab4415a.png)

