### PR TITLE
fix thread row attachment icon style

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -582,20 +582,20 @@ span.inboxsdk__thread_row_custom_draft_label + div.yW {
   vertical-align: middle;
 }
 
-.inboxsdk__thread_row_attachment_icons_present {
+.xY.inboxsdk__thread_row_attachment_icons_present {
   max-width: inherit;
 }
 
 /* narrow vertical preview pane */
-.Zs .inboxsdk__thread_row_attachment_icons_present {
+.Zs .xY.inboxsdk__thread_row_attachment_icons_present {
   flex-grow: 0;
 }
 
-.Zs .inboxsdk__thread_row_label {
+.Zs .xY.inboxsdk__thread_row_label {
   order: 1;
 }
 
-.Zs .inboxsdk__thread_row_icon_wrapper {
+.Zs .xY.inboxsdk__thread_row_icon_wrapper {
   order: 1;
   margin-left: 3px;
   margin-right: 0px;


### PR DESCRIPTION
Removing `body:not(.inboxsdk__gmailv1css)` in https://github.com/StreakYC/GmailSDK/pull/684 made the styles on `inboxsdk__thread_row_attachment_icons_present` less specific (so Gmail's style was being applied). 

Now we target `.xY.inboxsdk__thread_row_attachment_icons_present` (instead of just `.inboxsdk__thread_row_attachment_icons_present`).