### PR TITLE
log node when "contactNode cant be found"

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/get-address-information-extractor.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/get-address-information-extractor.js
@@ -29,7 +29,8 @@ export default function getAddressInformationExtractor(
     } else {
       Logger.error(new Error(`contactNode can't be found`), {
         addressType,
-        composeViewHtml: censorHTMLstring(composeView.getElement().outerHTML)
+        composeViewHtml: censorHTMLstring(composeView.getElement().outerHTML),
+        node
       });
 
       return null;


### PR DESCRIPTION
Some devs are reporting `contactNode can't be found` when trying to call `composeView.setToRecipients()`: https://share.streak.com/V4zHQVGAYFiI8Va0BhZ878.

However I'm unable to repro and `composeViewHtml` in the log error is clipped in BQ: https://console.cloud.google.com/bigquery?project=mailfoogae&j=bq:US:bquxjob_4c0cd0ac_17672f6911f&page=queryresults.

So I'm just logging out the `node` in `getAddressInformationExtractor()` to see if I can find anything interesting. 

