### PR TITLE
log getRecipientRowForType error

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -1618,7 +1618,7 @@ class GmailComposeView {
       `.GS tr textarea.vO[name="${addressType}"], .GS tr input[name="${addressType}"]`
     );
     const row = closest(input, 'tr');
-    if (!row) throw new Error();
+    if (!row) throw new Error('Recipient row not found');
     return row;
   }
 


### PR DESCRIPTION
Log getRecipientRowForType error for investigation into [contactNode can't be found](https://share.streak.com/V4zHQVGAYFiI8Va0BhZ878).

