### PR TITLE
add name to attr whitelist

### DIFF
--- a/src/common/censorHTMLstring.ts
+++ b/src/common/censorHTMLstring.ts
@@ -16,6 +16,7 @@ export const ATTRIBUTE_WHITELIST: Set<string> = new Set([
   'aria-labelledby',
   'aria-busy',
   'aria-multiselectable',
+  'name',
   // inbox props
   'data-action-data',
   'data-item-id',


### PR DESCRIPTION
Some devs are reporting `contactNode can't be found` when trying to call `composeView.setToRecipients()`: https://share.streak.com/V4zHQVGAYFiI8Va0BhZ878.

I'm unable to repro but I've found `Error: Failed to find element with selector: .GS tr textarea.vO[name="to"], .GS tr input[name="to"]` error logs in BQ.

So I think all I have to do is find the new name attr value. 

