### PR TITLE
check for input node

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/get-address-information-extractor.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/get-address-information-extractor.js
@@ -12,7 +12,11 @@ export default function getAddressInformationExtractor(
   composeView: GmailComposeView
 ): (node: HTMLElement) => ?Contact {
   return function(node: HTMLElement): ?Contact {
-    const contactNode = node.querySelector(`input[name='${addressType}']`);
+    const contactNode =
+      node instanceof HTMLInputElement &&
+      node.getAttribute('name') === addressType
+        ? node
+        : node.querySelector(`input[name='${addressType}']`);
 
     var emailAddress = null;
     var name = null;


### PR DESCRIPTION
Users are seeing this error: `contactNode can't be found`.

Here's the thread: https://share.streak.com/V4zHQVGAYFiI8Va0BhZ878.
Here's it in the code: https://github.com/StreakYC/GmailSDK/blob/master/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/get-address-information-extractor.js#L30-L33

I can't repro on any of my accounts, but from what users are saying, the issue likely stems from `getAddressChangesStream()` calling `getAddressInformationExtractor()`. 

The stream is expecting an added node: `<div class='.vR'>` with an `<input />` child which we use to get recipient info. This is what I see in my test accounts. However in the [logs](https://00f74ba44b4fe1548d018f86a41d3f16b54621c900-apidata.googleusercontent.com/download/storage/v1/b/streak_error_logs/o/requestId%2F5fdce13a3a40a24205858982dad9f83e91bb864419ee09f328fffebf34cb4450a6b4d5d778dbf303b096a560298923ec97d910ed.json?jk=AFshE3VquzLEYB8CyITfzeGLjvtp96T-f1qCp6UZtNDKNxlOQz4zFvFQQxHapyqwp-0W6xZQ5P_Mp-ym_4FPlJvG65DjckSSn1E8oLQ8N2XoKQxf_NBWa_qzPg9-IbX2N9e6ZVuQhrMvyEFQwILUIdUHF-phDiRhYbM8FUDNrz_rAGuZQ6wbqpX3OxXNFXFz5J9cp_QBbZPPL6j9hSAwz0KsN0ib5qYrCnixT2291MMmEgNFNejmx2EqyBtJGbFSw1LUoZiKBiIBwhPJwkKg69C3fZf64k4XqGIKtVeM3fC8bLYYxVeqZLrgwnOqLm4twE6NI-IAjvdmrv5f0QgaIZch6RWLM_uGcgdVKU2nZN80SWJKW0gq6-UmeJjIg_-2arjkfKOsVdPlwSkvyjcDNX972JJL9BNpIghGJ3dXcJFboyaAvGaNohrkb8wuDZVREfZwpjaA6FfBNbc-QEdUF_PODIqqxFbdpak2yhJ8L_aOnHPGxnQb5-NyaOB0-KBcfh6W686IPUTPB9BWzxSi17_HXlZEWveezn3tO6ncZGHIxjV07H90NsQQGEjfv9t0RlasAYB2uWaiv0r-kNyFlOr86Mu6nseFhxAnpRUcGnPL9OYQx7RA1baoCTt75hP3Le2AH0MWJx8U66d-Q82PfxzO8gYvHYdi7aEVGxh6s1cQdPafORBp9fmWobQOh0n0CzdsYFCGylSWM9v6EVQrbFanPm7hhZWQI023R-D2JsiZ_CrRZuIEIJ2qIeVCTB_3hExxsQJvkbMhM5ujyIV8N1bMosOrl4znGOF1Trg-8hodRR3hJiOqKAmEixagwoZNBqM_tgKIIoKgPNGKElHASCbeU98nbPo-UmQA1yqH3KTGnB7Pr59nvWyUSD1aSDMfMv4O5guPh1LB4xL_KE5mChxox0Ic3rEGFvMrI18343f9Os1y31XO4vPo2Ib-8B3DigTLMPlw1HOv-yFV790mQVn89qtAoaqFr_09-YLizaWk7JUU8PceqD24b_e3eNczOEsrUuuVwF4&isca=1), there is no `<input />` child.

So I'm guessing Gmail is starting to add the container div first (which triggers our mutation observer) then adds the input element were looking for later (which also triggers our mutation observer). If you you look at the logs, we have a lot of errors with very close timestamps. 

So that's my best guess without actually reproing the issue myself. 🍤  🤷 

As a fix, `getAddressInformationExtractor()` now checks to see if the node it gets is actually the node it needs to extract the info. This solution will still produce errors, but at least now it will properly trigger the event...maybe.