### PR TITLE
filter on container and child input

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/get-address-changes-stream.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/get-address-changes-stream.js
@@ -59,7 +59,11 @@ function _makeSubAddressStream(
         .transduce(
           t.compose(
             t.mapcat(e => Array.from(e.addedNodes)),
-            t.filter(_isRecipientNode),
+            t.filter(
+              n =>
+                _doesRecipientNodeHaveInput(n, addressType) ||
+                _isRecipientNodeInput(n, addressType)
+            ),
             t.map(
               getAddressInformationExtractor(addressType, gmailComposeView)
             ),
@@ -84,6 +88,19 @@ function _makeSubAddressStream(
 function _isRecipientNode(node) {
   // We want to filter non-element nodes out too.
   return node.classList && node.classList.contains('vR');
+}
+
+function _doesRecipientNodeHaveInput(node, addressType) {
+  return (
+    _isRecipientNode(node) && node.querySelector(`input[name='${addressType}']`)
+  );
+}
+
+function _isRecipientNodeInput(node, addressType) {
+  return (
+    node instanceof HTMLInputElement &&
+    node.getAttribute('name') === addressType
+  );
 }
 
 function _groupChangeEvents(event) {


### PR DESCRIPTION
This PR adds to https://github.com/StreakYC/GmailSDK/pull/694, by fixing the filter on the stream.

As mutations happen, it now checks to see if added nodes has the `input` element we're looking for _or_ if it's the `input` itself. 

Also the assumptions outlined in linked PR are correct. 



