### PR TITLE
fix visual jank on setTitleBarColor()

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -1689,8 +1689,7 @@ class GmailComposeView {
     const elementsToModify = [
       querySelector(this._element, '.nH.Hy.aXJ .pi > .l.o'),
       querySelector(this._element, '.nH.Hy.aXJ .l.m'),
-      querySelector(this._element, '.nH.Hy.aXJ .l.m > .l.n'),
-      querySelector(this._element, '.nH.Hy.aXJ .l.m > .l.n > .k')
+      querySelector(this._element, '.nH.Hy.aXJ .l.m > .l.n')
     ];
 
     buttonParent.classList.add('inboxsdk__compose_customTitleBarColor');


### PR DESCRIPTION
This PR fixes visual jank when calling `setTitleBarColor()`.

The upper right border appears to not have the border radius style applied.  This is caused by setting background-color on a child element that does not have the compose view's right border radius. Simply not applying the color value on the child fixes the issue.

BEFORE
![image](https://user-images.githubusercontent.com/197015/105251183-dfb98500-5b2f-11eb-9abb-602abb3846dd.png)

AFTER
![image](https://user-images.githubusercontent.com/197015/105251107-c0225c80-5b2f-11eb-98d4-22234e099c5d.png)