### PR TITLE
Gmail thread row element taking max-width

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -582,7 +582,7 @@ span.inboxsdk__thread_row_custom_draft_label + div.yW {
   vertical-align: middle;
 }
 
-.xY.inboxsdk__thread_row_attachment_icons_present {
+.zA > .xY.inboxsdk__thread_row_attachment_icons_present {
   max-width: inherit;
 }
 


### PR DESCRIPTION
From https://github.com/StreakYC/GmailSDK/pull/686 the selector `.xY.inboxsdk__thread_row_attachment_icons_present` tried to set `max-width` but sometimes gmail selector `.zA>.yf` will take over the max-width. This PR changes the selector to be more explicit so that our thread row attachment icon max width is applied.


Before fix:
![image](https://user-images.githubusercontent.com/7209644/109074007-ff524900-76ab-11eb-94ef-74a73a3a172e.png)


After fix:
![image](https://user-images.githubusercontent.com/7209644/109073806-c2865200-76ab-11eb-81d6-ed9a9bb3046e.png)


