### PR TITLE
fix issue where range was incorrect when inserting mail merge vars

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/monitor-selection-range.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/monitor-selection-range.js
@@ -1,12 +1,16 @@
 /* @flow */
 
-var Kefir = require('kefir');
+import Kefir from 'kefir';
+
+import fromEventTargetCapture from '../../../../lib/from-event-target-capture';
+
 import type GmailComposeView from '../gmail-compose-view';
 
 export default function(gmailComposeView: GmailComposeView) {
   Kefir.merge([
-    Kefir.fromEvents((document.body: any), 'mousedown'),
-    Kefir.fromEvents(gmailComposeView.getBodyElement(), 'keydown')
+    fromEventTargetCapture((document.body: any), 'mousedown'),
+    fromEventTargetCapture(gmailComposeView.getBodyElement(), 'keydown'),
+    gmailComposeView.getEventStream().filter(e => e.eventName === 'bodyChanged')
   ])
     .takeUntilBy(gmailComposeView.getStopper())
     .onValue(event => {


### PR DESCRIPTION
Related Box: [Mail Merge/Drip var insertion jumping/jank](https://mail.google.com/mail/u/0/#box/agxzfm1haWxmb29nYWVyNAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRiAgKqNioKOCQw)
Related PR: https://github.com/StreakYC/GmailSDK/pull/700
Slack background: https://streak.slack.com/archives/C014Q51JSSW/p1614372385067100

This PR fixes range offset being off by 1 when inserting vars in mail merge via compose status bar.