### PR TITLE
add word-wrap for title in modal

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1015,6 +1015,7 @@ isn't visible behind it. */
   -webkit-flex: 1;
   flex: 1;
   width: 0;
+  word-wrap: break-word;
 }
 
 /* end modal */

--- a/src/platform-implementation-js/style/inbox.css
+++ b/src/platform-implementation-js/style/inbox.css
@@ -500,6 +500,7 @@
   -webkit-flex: 1;
   flex: 1;
   width: 0;
+  word-wrap: break-word;
 }
 
 .inboxsdk__attachment_card {


### PR DESCRIPTION
The title in modal was cutting off word if it is too long

before:
![image](https://user-images.githubusercontent.com/1696091/117710207-b5471280-b186-11eb-9724-9ab151519232.png)

after:
![image](https://user-images.githubusercontent.com/1696091/117710222-bbd58a00-b186-11eb-9ed8-23017895194b.png)


Fix for https://www.streak.com/a/boxes/agxzfm1haWxmb29nYWVyNAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRiAgKrz-fb_CAw

MailFoo PR: https://github.com/StreakYC/MailFoo/pull/11416