### PR TITLE
Fix clicking toolbar buttons

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/button-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/button-view.ts
@@ -152,7 +152,7 @@ export default class ButtonView implements ButtonViewI {
   private _setupMainElement(options: ButtonViewOptions) {
     this._element.setAttribute(
       'class',
-      'T-I J-J5-Ji ar7 L3 inboxsdk__button ' +
+      'T-I J-J5-Ji ar7 inboxsdk__button ' +
         BUTTON_COLOR_CLASSES[this._buttonColor].INACTIVE_CLASS
     );
     if (options.tooltip) {

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1295,6 +1295,11 @@ body[dir='rtl'] .idm5_container_app_sidebar_no_icons.no[dir='ltr'] {
   margin-right: 0px !important;
 }
 
+/* quickfix, TODO investigate removing ar7 class from our buttons */
+.inboxsdk__button.ar7 {
+  pointer-events: all !important;
+}
+
 .container_app_sidebar_in_use .bkK.nn,
 .IDMAP_container_app_sidebar_no_icons .bkK.nn {
   width: auto !important;


### PR DESCRIPTION
A gmail classname ("ar7") we used on our buttons was updated to have "pointer-events: none" on it which is bad for our buttons. I think the ar7 classname now refers to something entirely different than what it used to. We should purge our use of Gmail classnames.