### PR TITLE
Use the right method

### DIFF
--- a/examples/hello-world/content.js
+++ b/examples/hello-world/content.js
@@ -22,7 +22,7 @@ InboxSDK.load(2, 'Hello World!').then(function(sdk){
 			},
 		});
 
-    const metaForm = composeView.getMetadataFormElement();
+    const metaForm = composeView.getMetadataForm();
     if (metaForm) {
       const bb = metaForm.getBoundingClientRect();
       const div = document.createElement('div');
@@ -37,7 +37,7 @@ InboxSDK.load(2, 'Hello World!').then(function(sdk){
       div.style.zIndex = 999;
       div.style.left = (bb.left - div.clientWidth - 20) + "px";
       div.style.top = bb.top + "px";
-      
+
       const btn = document.createElement('button');
       btn.textContent = "Close";
       btn.onclick = (e) => {


### PR DESCRIPTION
the example extension is using the wrong method `getMetadataFormElement`, the compose view interface is actually exposing `getMetadataForm`. See doc: https://inboxsdk.github.io/inboxsdk-docs/compose/#getmetadataform too.

Before fix:
![image](https://user-images.githubusercontent.com/7209644/152073642-076b7806-6d99-448c-813d-2b977c5eba91.png)


After fix:
![image](https://user-images.githubusercontent.com/7209644/152073581-76bbdc55-142b-4db8-93bb-83ebcc1c2c43.png)
