### PR TITLE
Remove outdated CSS rule for compose status bars that breaks things now

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -792,10 +792,6 @@ table + .inboxsdk__compose_statusbar {
   margin-top: -8px;
 }
 
-.inboxsdk__compose_statusbarActive .aoI {
-  height: auto !important;
-}
-
 .inboxsdk__compose_statusbarActive .aDl {
   z-index: unset;
 }


### PR DESCRIPTION
This PR removes an outdated CSS rule we added to the page. When this rule is present and a status bar has ever been added to a compose, then clicking into the recipients area when there are any recipients already causes the composeview to change height. This height change during click sometimes causes the compose to minimize (if the final click lands on the titlebar).