### PR TITLE
Fix issue that causes new-recipients-compose to resize

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -69,6 +69,7 @@ import getDiscardStream from '../../../driver-common/compose/getDiscardStream';
 import updateInsertMoreAreaLeft from './gmail-compose-view/update-insert-more-area-left';
 import getFormattingAreaOffsetLeft from './gmail-compose-view/get-formatting-area-offset-left';
 import overrideEditSubject from './gmail-compose-view/override-edit-subject';
+import detectClassicRecipientsArea from './gmail-compose-view/detectClassicRecipientsArea';
 import censorHTMLtree from '../../../../common/censorHTMLtree';
 import {
   makePageParser,
@@ -498,6 +499,8 @@ class GmailComposeView {
     } else {
       this._removedFromDOMStopper.onValue(() => this._destroy());
     }
+
+    detectClassicRecipientsArea();
   }
 
   destroy() {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/detectClassicRecipientsArea.js.flow
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/detectClassicRecipientsArea.js.flow
@@ -1,0 +1,3 @@
+/* @flow */
+
+declare export default function detectClassicRecipientsArea(): void;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/detectClassicRecipientsArea.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/detectClassicRecipientsArea.ts
@@ -1,0 +1,48 @@
+import once from 'lodash/once';
+
+export default once(function detectClassicRecipientsArea() {
+  const styleSheetWithComposeRules = [...document.styleSheets].find(s => {
+    try {
+      if (s.cssRules) {
+        // Both classic and new recipients Gmail should have this rule
+        return [...s.cssRules].find(
+          rule =>
+            rule instanceof CSSStyleRule &&
+            rule.selectorText === '.aoI' &&
+            rule.style.fontSize &&
+            rule.style.color
+        );
+      }
+    } catch (e) {
+      // Some stylesheets are crossorigin and throw if we try to access
+      // their rules. Don't worry about them.
+    }
+    return false;
+  });
+  if (styleSheetWithComposeRules) {
+    // Check if we don't have any of these specific rules.
+    // If so, we're on classic recipients Gmail.
+    const hasOverflowYVisibleRule = [
+      ...styleSheetWithComposeRules.cssRules
+    ].some(
+      rule =>
+        rule instanceof CSSStyleRule &&
+        rule.selectorText === '.aoI' &&
+        rule.style.overflowY === 'visible'
+    );
+    if (hasOverflowYVisibleRule) {
+      return;
+    }
+    const hasOverflowYAutoRule = [...styleSheetWithComposeRules.cssRules].some(
+      rule =>
+        rule instanceof CSSStyleRule &&
+        rule.selectorText === '.aaZ > .M9 > .aoI' &&
+        rule.style.overflowY === 'auto'
+    );
+    if (hasOverflowYAutoRule) {
+      return;
+    }
+
+    document.body.classList.add('inboxsdk__classic_gmail_recipients_area');
+  }
+});

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -792,6 +792,15 @@ table + .inboxsdk__compose_statusbar {
   margin-top: -8px;
 }
 
+/* Necessary in pre-new-recipients-area Gmail to stop the compose body
+from resizing and pushing the statusbars off-screen when the recipients
+area is focused. */
+body.inboxsdk__classic_gmail_recipients_area
+  .inboxsdk__compose_statusbarActive
+  .aoI {
+  height: auto !important;
+}
+
 .inboxsdk__compose_statusbarActive .aDl {
   z-index: unset;
 }


### PR DESCRIPTION
When you're in Gmail with the new compose recipients area, a compose view has a status bar, and you focus the recipients area, the compose view would immediately shrink a bit, possibly causing the compose to minimize if the mouse click ends up landing on the titlebar.

This issue was caused by a previous CSS fix for status bars no longer being applicable to new-recipients-area Gmail. We now only enable that CSS fix if we detect that we're on classic-recipients-area Gmail.