### PR TITLE
Fix issue where custom view will be exited during InboxSDK initialization

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/setup-route-view-driver-stream.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/setup-route-view-driver-stream.js
@@ -83,11 +83,18 @@ export default function setupRouteViewDriverStream(
     customAndCustomListRouteHashChanges,
     revertNativeHashChanges,
 
-    //when native gmail changes main view there's a div that takes on role=main
-    GmailElementGetter.getMainContentElementChangedStream().map(event => ({
-      urlObject: getURLObject(document.location.href),
-      type: 'NATIVE'
-    }))
+    // when native gmail changes main view there's a div that takes on role=main.
+    // getMainContentElementChangedStream doesn't respect custom views so filter
+    // out events from it. This filter is needed if the user is already at a custom
+    // view of another InboxSDK instance while this starts up.
+    GmailElementGetter.getMainContentElementChangedStream()
+      .map(event => ({
+        urlObject: getURLObject(document.location.href),
+        type: 'NATIVE'
+      }))
+      .filter(options =>
+        gmailRouteProcessor.isNativeRoute(options.urlObject.name)
+      )
   ])
     .map(options => {
       const { type, urlObject } = options;


### PR DESCRIPTION
https://streak.slack.com/archives/C02J7RSAUJ0/p1645718277410699?thread_ts=1645040711.999959&cid=C02J7RSAUJ0

This PR fixes the issue where if there is already an InboxSDK instance initialized and the user is at a custom view of it, and then another InboxSDK instance initializes, then it will boot the user back to a Gmail native view.