### PR TITLE
Popover fix for cursor behind or ahead of link

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/setupLinkPopovers.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/setupLinkPopovers.ts
@@ -49,7 +49,6 @@ class LinkPopOverSection {
 
 function getSelectedLink(): HTMLAnchorElement | null {
   const focusNode = document.getSelection()?.focusNode;
-
   if (!focusNode) {
     return null;
   }
@@ -58,6 +57,8 @@ function getSelectedLink(): HTMLAnchorElement | null {
       return focusNode.parentElement;
     } else if (focusNode.nextSibling instanceof HTMLAnchorElement) {
       return focusNode.nextSibling;
+    } else if (focusNode.previousSibling instanceof HTMLAnchorElement) {
+      return focusNode.previousSibling;
     }
   }
   return null;


### PR DESCRIPTION
The gmail popover opens if you click right before a link while ours did not.

It also opens on link creation, and there were some cases where the cursor ends up behind the link not within, so catch that as well.