### PR TITLE
Fix wrong link sometimes getting attached to popover

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/setupLinkPopovers.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/setupLinkPopovers.ts
@@ -55,10 +55,12 @@ function getSelectedLink(): HTMLAnchorElement | null {
   if (focusNode instanceof Text) {
     if (focusNode.parentElement instanceof HTMLAnchorElement) {
       return focusNode.parentElement;
-    } else if (focusNode.nextSibling instanceof HTMLAnchorElement) {
-      return focusNode.nextSibling;
-    } else if (focusNode.previousSibling instanceof HTMLAnchorElement) {
+    } else if (focusNode.previousSibling instanceof HTMLAnchorElement && document.getSelection()?.anchorOffset === 0) {
+      // For capturing link creation cases where the cursor ends up behind the link
       return focusNode.previousSibling;
+    } else if (focusNode.nextSibling instanceof HTMLAnchorElement) {
+      // google's popover appears when clicking just in front of a link as well
+      return focusNode.nextSibling;
     }
   }
   return null;

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -2386,8 +2386,9 @@ table[role='presentation'].inboxsdk__thread_view_with_custom_view > tr {
 .inboxsdk__linkPopOver_section {
   width: 100%;
   background: #fff;
-  border: 1px solid #a8a8a8;
-  font: 13px arial,sans-serif;
+  border: 1px solid;
+  border-color: #bbb #bbb #a8a8a8;
+  font: 13px arial, sans-serif;
   padding: 5px 8px;
   margin-bottom: 5px;
   box-sizing: border-box;


### PR DESCRIPTION
Logic was too dumb before, now more specific for the link creation case where the cursor ends up outside next to the link.

Also tweaked the border style of the default section because it wasn't quiiiite right.