### PR TITLE
log whether gmail integrated view is on

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.d.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.d.ts
@@ -94,4 +94,5 @@ export default class GmailDriver implements Driver {
 
   public getSelectedThreadRowViewDrivers(): ReadonlyArray<GmailThreadRowView>;
   public registerThreadRowViewSelectionHandler(handler: () => any): () => void;
+  public getLoadEventDetails(): any;
 }

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.js
@@ -974,6 +974,17 @@ class GmailDriver {
       this._threadRowViewSelectionChanges.offValue(handler);
     };
   }
+
+  getLoadEventDetails(): any {
+    let isGmailIntegratedView = null;
+    const nav = document.querySelector('div[role=navigation]');
+    if (nav) {
+      isGmailIntegratedView = !nav.classList.contains('nn');
+    }
+    return {
+      isGmailIntegratedView
+    };
+  }
 }
 
 export default defn(module, GmailDriver);

--- a/src/platform-implementation-js/dom-driver/inbox/inbox-driver.js
+++ b/src/platform-implementation-js/dom-driver/inbox/inbox-driver.js
@@ -1158,6 +1158,10 @@ class InboxDriver {
   registerThreadRowViewSelectionHandler(handler: () => any): () => void {
     return () => {};
   }
+
+  getLoadEventDetails(): any {
+    return {};
+  }
 }
 
 export default defn(module, InboxDriver);

--- a/src/platform-implementation-js/driver-interfaces/driver.d.ts
+++ b/src/platform-implementation-js/driver-interfaces/driver.d.ts
@@ -120,6 +120,8 @@ export interface Driver {
 
   getSelectedThreadRowViewDrivers(): ReadonlyArray<ThreadRowViewDriver>;
   registerThreadRowViewSelectionHandler(handler: () => any): () => void;
+
+  getLoadEventDetails(): any;
 }
 
 export interface ButterBarDriver {

--- a/src/platform-implementation-js/driver-interfaces/driver.js
+++ b/src/platform-implementation-js/driver-interfaces/driver.js
@@ -106,7 +106,9 @@ export type Driver = {
   destroy(): void,
 
   getSelectedThreadRowViewDrivers(): $ReadOnlyArray<ThreadRowViewDriver>,
-  registerThreadRowViewSelectionHandler(handler: () => any): () => void
+  registerThreadRowViewSelectionHandler(handler: () => any): () => void,
+
+  getLoadEventDetails(): any
 };
 
 export type ButterBarDriver = {

--- a/src/platform-implementation-js/platform-implementation.js
+++ b/src/platform-implementation-js/platform-implementation.js
@@ -298,7 +298,9 @@ https://www.inboxsdk.com/docs/#RequiredSetup
     }
     if (!loadedAppIds.has(appId)) {
       loadedAppIds.add(appId);
-      logger.eventSdkPassive('load');
+      logger.eventSdkPassive('load', {
+        ...driver.getLoadEventDetails()
+      });
     }
 
     // Enable sourcemaps on future loads by default for Streak employees.


### PR DESCRIPTION
The sdk's "load" event now has a property named `isGmailIntegratedView` which is true if the user is opted into the new Gmail integrated view, false if they aren't, and null if there's some kind of issue detecting which is active.