### PR TITLE
better isGmailIntegratedView check

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.js
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.js
@@ -979,7 +979,8 @@ class GmailDriver {
     let isGmailIntegratedView = null;
     const nav = document.querySelector('div[role=navigation]');
     if (nav) {
-      isGmailIntegratedView = !nav.classList.contains('nn');
+      isGmailIntegratedView =
+        nav.firstElementChild && nav.firstElementChild.classList.contains('Xa');
     }
     return {
       isGmailIntegratedView


### PR DESCRIPTION
Follow-up to https://github.com/InboxSDK/InboxSDK/pull/741. Fixes issue where isGmailIntegratedView: true would be mistakenly reported if classic hangouts was enabled.