### PR TITLE
Fix for toolbar buttons showing text hover state

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -2397,7 +2397,10 @@ table[role='presentation'].inboxsdk__thread_view_with_custom_view > tr {
 
 /* end compose popover */
 
-/* toolbar button style fix */
+/*
+ Toolbar/Thread button style fix for
+ when the gmail setting "Button labels" is set to "text"
+*/
 
 .T-I.J-J5-Ji.T-I-ax7.T-I-Js-IF.inboxsdk__button .asa::after {
   width: auto;


### PR DESCRIPTION
For [this bug](https://www.streak.com/a/boxes/agxzfm1haWxmb29nYWVyNAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRiAgMa847noCQw)

Not totally sure where to put this style or exactly how specific it needs to be. It's pretty strange. 