### PR TITLE
Remove too specific class for toolbar fix

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -2402,6 +2402,6 @@ table[role='presentation'].inboxsdk__thread_view_with_custom_view > tr {
  when the gmail setting "Button labels" is set to "text"
 */
 
-.T-I.J-J5-Ji.T-I-ax7.T-I-Js-IF.inboxsdk__button .asa::after {
+.T-I.J-J5-Ji.T-I-ax7.inboxsdk__button .asa::after {
   width: auto;
 }


### PR DESCRIPTION
After testing with streak realized that this was a little too specific.