### PR TITLE
Fix set{Cc,Bcc}Recipients on fresh compose

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/set-recipients.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/set-recipients.ts
@@ -94,8 +94,7 @@ export default function setRecipients(
 
     // On fresh composes, if set_Recipients is called immediately, then
     // Gmail asynchronously resets the recipients field. Detect this and
-    // put our change back. Fresh composes lack a style attribute on the
-    // div.anm[name] element.
+    // put our change back.
     const nameEl = contactRow.closest('div.anm[name]');
     if (
       emailAddresses.length > 0 &&


### PR DESCRIPTION
Gmail seems to fight us and remove our changes when set_Recipients is called immediately on a fresh compose view. We had code to work around this, but it seems like with the last PR that code needed to be adjusted.