### PR TITLE
Compose workaround: handle discard button not being found

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -558,12 +558,17 @@ class GmailComposeView {
         sendAndArchive: this.getSendAndArchiveButton(),
       })
     );
-    this._eventStream.plug(
-      getDiscardStream({
-        element: this.getElement(),
-        discardButton: this.getDiscardButton(),
-      })
-    );
+    try {
+      this._eventStream.plug(
+        getDiscardStream({
+          element: this.getElement(),
+          discardButton: this.getDiscardButton(),
+        })
+      );
+    } catch (err) {
+      // handle failures of this.getDiscardButton()
+      this._driver.getLogger().errorSite(err);
+    }
 
     this._eventStream.plug(
       Kefir.fromEvents(this.getElement(), 'inboxSDKsendCanceled').map(() => ({

--- a/src/platform-implementation-js/driver-common/compose/getDiscardStream.js
+++ b/src/platform-implementation-js/driver-common/compose/getDiscardStream.js
@@ -15,7 +15,7 @@ const dispatchCancel = (element) =>
     )
   );
 
-export default function ({
+export default function getDiscardStream({
   element,
   discardButton,
 }: {


### PR DESCRIPTION
Work around https://rollbar.com/Streak/Streak-Extension/items/36930/ (seemingly related to https://rollbar.com/Streak/Streak-Extension/items/25755/?) until we know what the new compose HTML looks like.