### PR TITLE
add logic to check for container of inline reply UI

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -1229,12 +1229,7 @@ class GmailComposeView {
   }
 
   getMetadataFormElement(): HTMLElement {
-    let container;
-    if (this.isInlineReplyForm()) {
-      container = this.getBodyElement().closest('.aoP.HM');
-    } else {
-      container = this.getBodyElement().closest('.aoP.aoC');
-    }
+    const container = this.getBodyElement().closest('.aoP');
     if (!container) {
       throw new Error('Could not find compose container');
     }


### PR DESCRIPTION
### Box: [composeView.getMetadataForm() fails to return element for the the Reply UI](https://www.streak.com/a/boxes/agxzfm1haWxmb29nYWVyNAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRiAgOa-_vL-Cgw)

### What's in this PR?
Added logic to find a container if the compose view is a reply.

### Before/After
Tested with the examples/helloworld
Before:
<img width="643" alt="image" src="https://user-images.githubusercontent.com/75385657/181343441-573ce57b-ba44-49ab-a1c5-ddc7e6878e03.png">
After:
<img width="458" alt="image" src="https://user-images.githubusercontent.com/75385657/181343606-e4b4d6fe-9015-47c8-bb37-df46968ce9a2.png">

### Testing steps
Call `getMetadataForm` from a Reply UI and confirm the correct form element is returned. Confirm that `getMetadataForm` still works properly for Compose UI view.