### PR TITLE
reduce minimum height of compose in fullscreen

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/size-fixer.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/size-fixer.js
@@ -137,7 +137,6 @@ export default function sizeFixer(
   let fullScreenComposeEl;
 
   resizeEvents
-    .bufferBy(resizeEvents.flatMap((x) => delayAsap(null)))
     .filter((x) => x.length > 0)
     .merge(makeMutationObserverChunkedStream(scrollBody, { attributes: true }))
     .takeUntilBy(stopper)


### PR DESCRIPTION
https://www.loom.com/share/529fe52f6682420ca011848cce839812

Try to keep fullscreen compose window from falling off the bottom of the viewport.