### PR TITLE
Readme tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Check out the [Quickstart](https://inboxsdk.github.io/inboxsdk-docs/#quick-start
 The most basic example of adding a button to a Gmail compose window:
 
 ```javascript
-InboxSDK.load(2, 'YOUR_APP_ID_HERE').then(function (sdk) {
+InboxSDK.load(2, 'YOUR_APP_ID_HERE').then((sdk) => {
   // the SDK has been loaded, now do something with it!
-  sdk.Compose.registerComposeViewHandler(function (composeView) {
+  sdk.Compose.registerComposeViewHandler((composeView) => {
     // a compose view has come into existence, do something with it!
     composeView.addButton({
       title: 'My Nifty Button!',
       iconUrl: 'https://example.com/foo.png',
-      onClick: function (event) {
+      onClick(event) {
         event.composeView.insertTextIntoBodyAtCursor('Hello World!');
       },
     });


### PR DESCRIPTION
Minor fixups to https://github.com/InboxSDK/InboxSDK/pull/777

- run prettier on the readme so it's more consistent and the prettier check in CI stops failing. (The formatter runs automatically on commit when file is edited locally and the dependencies are installed with yarn, but it doesn't happen when the web editor in Github is used to edit the file.)
- use arrow functions and method definition shorthand in readme example