### PR TITLE
fix: Add alternate selector for subject container

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
@@ -190,7 +190,9 @@ class GmailThreadView {
   addNoticeBar(): SimpleElementView {
     const el = document.createElement('div');
     el.className = idMap('thread_noticeBar');
-    const subjectContainer = this._element.querySelector('.if > .nH');
+    const subjectContainer = this._element.querySelector(
+      '.if > .nH, .PeIF1d > .nH'
+    );
     if (!subjectContainer) throw new Error('Failed to find subject container');
     subjectContainer.insertAdjacentElement('afterend', el);
     const view = new SimpleElementView(el);

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
@@ -190,10 +190,14 @@ class GmailThreadView {
   addNoticeBar(): SimpleElementView {
     const el = document.createElement('div');
     el.className = idMap('thread_noticeBar');
-    const subjectContainer = this._element.querySelector(
-      '.if > .nH, .PeIF1d > .nH'
-    );
+    const selector_2018 = this._element.querySelector('.if > .nH');
+    const selector_2022_10_12 = this._element.querySelector('.PeIF1d > .nH');
+    const subjectContainer = selector_2018 || selector_2022_10_12;
+
     if (!subjectContainer) throw new Error('Failed to find subject container');
+    this._driver.getLogger().eventSdkPassive('addNoticeBar subjectContainer', {
+      version: selector_2018 ? '2018' : '2022-10-12',
+    });
     subjectContainer.insertAdjacentElement('afterend', el);
     const view = new SimpleElementView(el);
 


### PR DESCRIPTION
Keep `GmailThreadView.prototype.addNoticeBar` from throwing.

![Screen Shot 2022-10-12 at 13 54 12](https://user-images.githubusercontent.com/5156873/195413908-b67eb3b0-b268-4c1c-960a-722929e3e9eb.png)
