### PR TITLE
fix: add support for new thread selectors

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.js
@@ -362,7 +362,10 @@ class GmailRouteView {
 
     const elementStream = makeElementChildStream(
       threadContainerTableElement
-    ).filter((event) => !!event.el.querySelector('.if'));
+    ).filter(
+      (event) =>
+        !!event.el.querySelector('.if') || !!event.el.querySelector('.PeIF1d')
+    );
 
     this._eventStream.plug(
       elementStream

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
@@ -634,10 +634,24 @@ class GmailThreadView {
     if (
       (toolbarContainerElement: any).parentElement.getAttribute('role') ===
         'main' &&
-      (toolbarContainerElement: any).parentElement.querySelector('.if') &&
-      (toolbarContainerElement: any).parentElement.querySelector('.if')
+      (toolbarContainerElement: any).parentElement.querySelector(
+        '.if, .PeIF1d'
+      ) &&
+      (toolbarContainerElement: any).parentElement.querySelector('.if, .PeIF1d')
         .parentElement === this._element
     ) {
+      var version = toolbarContainerElement.parentElement.querySelector(
+        '.PeIF1d'
+      )
+        ? '2022-10-12'
+        : '2018';
+
+      this._driver
+        .getLogger()
+        .eventSdkPassive('gmailThreadView_isToolbarContainerRelevant', {
+          version,
+        });
+
       return true;
     }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
@@ -640,7 +640,7 @@ class GmailThreadView {
       (toolbarContainerElement: any).parentElement.querySelector('.if, .PeIF1d')
         .parentElement === this._element
     ) {
-      var version = toolbarContainerElement.parentElement.querySelector(
+      var version = (toolbarContainerElement: any).parentElement.querySelector(
         '.PeIF1d'
       )
         ? '2022-10-12'


### PR DESCRIPTION
add `.PeIF1d` selector to monitor thread changes in split mode

fix for https://github.com/InboxSDK/InboxSDK/issues/789