### PR TITLE
Public sourcemaps

### DIFF
--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -167,7 +167,6 @@ interface BrowserifyTaskOptions {
   // hotPort?: number;
   disableMinification?: boolean;
   afterBuild?: () => Promise<void>;
-  noSourceMapComment?: boolean;
   sourceMappingURLPrefix?: string;
   writeToPackagesCore?: boolean;
 }
@@ -234,9 +233,6 @@ async function browserifyTask(options: BrowserifyTaskOptions): Promise<void> {
         )
       )
       .pipe(sourcemaps.write, args.production ? '.' : null, {
-        // don't include sourcemap comment in the inboxsdk.js file that we
-        // distribute to developers since it'd always be broken.
-        addComment: !options.noSourceMapComment,
         sourceMappingURLPrefix: options.sourceMappingURLPrefix,
       });
 
@@ -327,7 +323,6 @@ if (args.remote) {
       standalone: 'InboxSDK',
       disableMinification: true,
       afterBuild: setupExamples,
-      noSourceMapComment: true,
     });
   });
   gulp.task(
@@ -352,7 +347,6 @@ if (args.remote) {
         standalone: 'InboxSDK',
         // hotPort: 3140,
         afterBuild: setupExamples,
-        noSourceMapComment: Boolean(args.production),
       });
     })
   );
@@ -369,7 +363,6 @@ if (args.remote) {
       standalone: 'InboxSDK',
       // hotPort: 3140,
       afterBuild: setupExamples,
-      noSourceMapComment: Boolean(args.production),
       writeToPackagesCore: true,
     });
   });

--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -107,7 +107,8 @@ async function setupExamples() {
 }
 
 gulp.task('noop', () => {
-  // noop
+  // This task exists so we can run `yarn gulp noop` to check that this
+  // script loads (and yarn-deps-check passes) without any side effects.
 });
 
 async function getVersion(): Promise<string> {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,15 @@
   "description": "Library for building browser extensions for Gmail",
   "main": "inboxsdk.js",
   "author": "Streak",
-  "license": "All Rights Reserved",
+  "license": "(MIT OR Apache-2.0)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/InboxSDK/InboxSDK.git"
+  },
+  "bugs": {
+    "url": "https://github.com/InboxSDK/InboxSDK/issues"
+  },
+  "homepage": "https://www.inboxsdk.com/",
   "private": false,
   "sideEffects": true,
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,10 +9,12 @@
   "sideEffects": true,
   "files": [
     "inboxsdk.js",
+    "inboxsdk.js.map",
     "inboxsdk.d.ts",
     "background.js",
     "background.d.ts",
     "pageWorld.js",
+    "pageWorld.js.map",
     "pageWorld.d.ts"
   ],
   "dependencies": {

--- a/src/inboxsdk-js/loading/platform-implementation-loader.ts
+++ b/src/inboxsdk-js/loading/platform-implementation-loader.ts
@@ -19,19 +19,8 @@ const PlatformImplementationLoader = {
   },
 
   _loadScript: once(function () {
-    let disableSourceMappingURL = true;
-    if (window.localStorage) {
-      try {
-        disableSourceMappingURL =
-          localStorage.getItem('inboxsdk__enable_sourcemap') !== 'true';
-      } catch (err) {
-        console.error(err); //eslint-disable-line no-console
-      }
-    }
-
     return loadScript(process.env.IMPLEMENTATION_URL!, {
       nowrap: true, // platform-implementation has no top-level vars so no need for function wrapping
-      disableSourceMappingURL,
     });
   }),
 

--- a/src/platform-implementation-js/lib/inject-script-EMBEDDED.ts
+++ b/src/platform-implementation-js/lib/inject-script-EMBEDDED.ts
@@ -12,23 +12,8 @@ export function injectScriptEmbedded() {
     'utf8'
   );
 
-  let disableSourceMappingURL = true;
-  try {
-    disableSourceMappingURL =
-      localStorage.getItem('inboxsdk__enable_sourcemap') !== 'true';
-  } catch (err) {
-    console.error(err); //eslint-disable-line no-console
-  }
-
   const codeParts: string[] = [];
-  if (disableSourceMappingURL) {
-    // Don't remove a data: URI sourcemap (used in dev)
-    codeParts.push(
-      originalCode.replace(/\/\/# sourceMappingURL=(?!data:)[^\n]*\n?$/, '')
-    );
-  } else {
-    codeParts.push(originalCode);
-  }
+  codeParts.push(originalCode);
   codeParts.push('\n//# sourceURL=' + url + '\n');
 
   const codeToRun = codeParts.join('');

--- a/src/platform-implementation-js/platform-implementation.js
+++ b/src/platform-implementation-js/platform-implementation.js
@@ -301,18 +301,6 @@ https://www.inboxsdk.com/docs/#RequiredSetup
       logger.eventSdkPassive('load');
     }
 
-    // Enable sourcemaps on future loads by default for Streak employees.
-    try {
-      if (
-        window.localStorage &&
-        /@streak\.com$/.test(driver.getUserEmailAddress()) &&
-        !window.localStorage.getItem('inboxsdk__enable_sourcemap')
-      ) {
-        window.localStorage.setItem('inboxsdk__enable_sourcemap', 'true');
-      }
-    } catch (err) {
-      console.error(err);
-    }
     return pi;
   });
 }


### PR DESCRIPTION
This PR starts including sourcemaps in the MV3 npm release, and also makes sourcemaps be loaded when using the MV2 remote-loaded release.