### PR TITLE
Update event and error tracking URLs

### DIFF
--- a/src/common/log-error.ts
+++ b/src/common/log-error.ts
@@ -205,7 +205,7 @@ const sendError = rateLimit(
   function (report: object) {
     try {
       ajax({
-        url: 'https://www.inboxsdk.com/api/v2/errors',
+        url: 'https://api.inboxsdk.com/api/v2/errors',
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/platform-implementation-js/lib/logger.ts
+++ b/src/platform-implementation-js/lib/logger.ts
@@ -495,7 +495,7 @@ async function retrieveNewEventsAccessToken(): Promise<{
   expirationDate: number;
 }> {
   const { text } = await ajax({
-    url: 'https://www.inboxsdk.com/api/v2/events/oauth',
+    url: 'https://api.inboxsdk.com/api/v2/events/oauth',
     // Work around CORB for extensions that have permissions to inboxsdk.com
     XMLHttpRequest: getXMLHttpRequest(),
   });


### PR DESCRIPTION
We're changing some of our event and error tracking infrastructure and updating the URLs the InboxSDK hits for these.