### PR TITLE
Fix: parse emoji in thread view subject

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
@@ -474,18 +474,17 @@ class GmailThreadView {
 
     if (subjectElement.querySelector('img[data-emoji]')) {
       return Array.from(subjectElement.childNodes)
-        .flatMap((c) => {
+        .map((c) => {
           if (c instanceof HTMLElement && c.nodeName === 'IMG') {
             const maybeEmoji = c.getAttribute('data-emoji');
-            return maybeEmoji ? [maybeEmoji] : [];
+            return maybeEmoji;
           }
 
           if (c.nodeName === '#text') {
-            return [c.wholeText];
+            return (c: any).wholeText;
           }
-
-          return [];
         })
+        .filter((x) => x != null)
         .join('');
     }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.js
@@ -470,9 +470,26 @@ class GmailThreadView {
     var subjectElement = this._element.querySelector('.ha h2');
     if (!subjectElement) {
       return '';
-    } else {
-      return subjectElement.textContent;
     }
+
+    if (subjectElement.querySelector('img[data-emoji]')) {
+      return Array.from(subjectElement.childNodes)
+        .flatMap((c) => {
+          if (c instanceof HTMLElement && c.nodeName === 'IMG') {
+            const maybeEmoji = c.getAttribute('data-emoji');
+            return maybeEmoji ? [maybeEmoji] : [];
+          }
+
+          if (c.nodeName === '#text') {
+            return [c.wholeText];
+          }
+
+          return [];
+        })
+        .join('');
+    }
+
+    return subjectElement.textContent;
   }
 
   getInternalID(): string {


### PR DESCRIPTION
Gmail encodes emoji in a way that allows it to keep emoji on brand.

```html
<img data-emoji="🔧" class="an1" alt="🔧" aria-label="🔧" src="https://fonts.gstatic.com/s/e/notoemoji/15.0/1f527/72.png" loading="lazy">
```

This PR extracts `data-emoji` attributes if present to allow them to be reflected in `ThreadView.prototype.getSubject`.