### PR TITLE
Fix: TS type output

### DIFF
--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -307,6 +307,22 @@ gulp.task('clean', async () => {
   }
 });
 
+/**
+ * Copy handwritten type definitions and plain js to a appease tsc in our mixed TS/flow setup.
+ */
+gulp.task('types', async () => {
+  const files = await fg(['./src/**/*.d.ts', './src/**/*.js'], {
+    onlyFiles: true,
+    ignore: ['packages/core'],
+  });
+  for (const f of files) {
+    const newPath = path.join('./packages/core', f);
+    await fs.promises.mkdir(path.dirname(newPath), { recursive: true });
+    await fs.promises.copyFile(f, newPath);
+  }
+  await exec('yarn typedefs');
+});
+
 if (args.remote) {
   gulp.task('sdk', () => {
     return browserifyTask({
@@ -345,22 +361,10 @@ if (args.remote) {
   gulp.task('remote', () => {
     throw new Error('No separate remote bundle in non-remote bundle mode');
   });
-  gulp.task('default', gulp.parallel('sdk'));
+  gulp.task('default', gulp.parallel('sdk', 'types'));
 } else {
   // standard npm non-remote bundle
   gulp.task('sdk', async () => {
-    // Copy handwritten type definitions and plain js to a appease tsc in our mixed TS/flow setup.
-    const files = await fg(['./src/**/*.d.ts', './src/**/*.js'], {
-      onlyFiles: true,
-      ignore: ['packages/core'],
-    });
-    for (const f of files) {
-      const newPath = path.join('./packages/core', f);
-      await fs.promises.mkdir(path.dirname(newPath), { recursive: true });
-      await fs.promises.copyFile(f, newPath);
-    }
-    await exec('yarn typedefs');
-
     return browserifyTask({
       entry: './src/inboxsdk-js/inboxsdk-NONREMOTE',
       destName: sdkFilename,
@@ -373,7 +377,7 @@ if (args.remote) {
   gulp.task('remote', () => {
     throw new Error('No separate remote bundle in non-remote bundle mode');
   });
-  gulp.task('default', gulp.parallel('sdk', 'pageWorld'));
+  gulp.task('default', gulp.parallel('sdk', 'pageWorld', 'types'));
 }
 
 gulp.task(

--- a/packages/core/inboxsdk.d.ts
+++ b/packages/core/inboxsdk.d.ts
@@ -1,0 +1,1 @@
+export * from './src/inboxsdk';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
   "files": [
     "inboxsdk.js",
     "inboxsdk.js.map",
+    "inboxsdk.d.ts",
     "background.js",
     "background.d.ts",
     "pageWorld.js",
@@ -28,6 +29,7 @@
   "dependencies": {
     "@types/kefir": "^3.8.6",
     "@types/node": "*",
+    "tag-tree": "^1.0.0",
     "typed-emitter": "^2.1.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,6 @@
     "target": "ES2018",
     "moduleResolution": "node",
     "isolatedModules": true
-  }
+  },
+  "exclude": ["packages/core"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,6 +1617,7 @@ __metadata:
   dependencies:
     "@types/kefir": ^3.8.6
     "@types/node": "*"
+    tag-tree: ^1.0.0
     typed-emitter: ^2.1.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
In #834, we were missing a few bits: 

- @Macil had pointed out that we might want handwritten `.d.ts` files included in the published package.
- In work on #837, @dmy7r0 noted that types weren't updating as expected when using `yarn link -r` with the `@inboxsdk/core`'s folder.
- Including a barrel file that reexports `src/inboxsdk.d.ts` at the same level as `inboxsdk.js` appears to patch up issues with `yarn link` and `tsc`. 