### PR TITLE
Fix ComposeView.attachFiles() by avoiding variable shadowing

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -1142,17 +1142,17 @@ class GmailComposeView {
     const endDrag = once(() => simulateDragEnd(this._element, files));
     try {
       let firstLoop = true;
-      for (let files of t.partition(files, 3)) {
+      for (let partitionedFiles of t.partition(files, 3)) {
         if (firstLoop) {
           firstLoop = false;
         } else {
           await delay(500);
         }
 
-        simulateDragOver(this._element, files);
+        simulateDragOver(this._element, partitionedFiles);
         await waitFor(() => this._dropzonesVisible(), 20 * 1000);
         const dropzone = this._findDropzoneForThisCompose(inline);
-        simulateDrop(dropzone, files);
+        simulateDrop(dropzone, partitionedFiles);
         endDrag();
         await waitFor(() => !this._dropzonesVisible(), 20 * 1000);
       }


### PR DESCRIPTION
Hello,

As suggested by @aleemstreak in https://github.com/InboxSDK/InboxSDK/issues/842#issuecomment-1430076502 , I made a PR to fix #842.

The problem was well described in the bug issue and the JS error is straightforward. The code was trying to access a variable before the initialization. I couldn't figure out _why_ this happened only now, but the issue was a name shadowing that should have worked but somehow in the minified version it confused the name.

The fix is simple, we just use another variable name to avoid the variable shadowing. I could reproduce the issue locally using the `main` branch and changing the name fixed it.