### PR TITLE
chore: split type/src output changes from former #837

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/StreakYC/GmailSDK
     parallelism: 1
     docker:
-      - image: circleci/node:12-browsers
+      - image: cimg/node:18.14-browsers
     steps:
       - checkout
       - restore_cache:

--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,4 @@
 /chromeTestOutput
 /packages/core/inboxsdk.js*
 /packages/core/pageWorld.js*
+/packages/core/src/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,6 +121,7 @@ module.exports = {
         'jest.config.js',
         'jest-puppeteer.config.js',
         'tools/**',
+        'packages/core/**',
       ],
       rules: {
         'flowtype/require-valid-file-annotation': ['off'],

--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,7 @@
 
 [ignore]
 .*/examples/.*/inboxsdk\.js.*
+.*/packages/core.*
 .*/dist/inboxsdk\.js.*
 .*/dist/platform-implementation\.js.*
 .*/dist/injected\.js.*

--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -311,7 +311,7 @@ gulp.task('clean', async () => {
  * Copy handwritten type definitions and plain js to a appease tsc in our mixed TS/flow setup.
  */
 gulp.task('types', async () => {
-  const files = await fg(['./src/**/*.d.ts', './src/**/*.js'], {
+  const files = await fg(['./src/**/*.d.ts'], {
     onlyFiles: true,
     ignore: ['packages/core'],
   });

--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "dir": "overrides"
   },
   "scripts": {
-    "typedefs": "tsc -p tsconfig.declarations.json",
+    "transpile-flow": "babel -d packages/core/src --source-type module --ignore '*.test.js' --no-copy-ignored src",
+    "typedefs": "yarn transpile-flow && tsc -p tsconfig.declarations.json",
     "prepare": "husky install",
     "publish-npm": "gulp clean && gulp --production --minify && yarn workspace @inboxsdk/core npm publish && git push --follow-tags",
     "flow_check": "flow check",

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,0 +1,2 @@
+# declaration map files only make sense when TS source is avaliable. We don't publish TS source yet, so we don't publish declaration maps either.
+*.d.ts.map

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,8 +27,12 @@
     "src"
   ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "@types/kefir": "^3.8.6",
     "@types/node": "*",
+    "asap": "^2.0.3",
+    "kefir-cast": "^3.3.0",
+    "sha.js": "^2.4.0",
     "tag-tree": "^1.0.0",
     "typed-emitter": "^2.1.0"
   }

--- a/tsconfig.declarations.json
+++ b/tsconfig.declarations.json
@@ -2,12 +2,11 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": false,
-    "emitDeclarationOnly": true,
+    "declarationMap": true,
     "noEmit": false,
+    "module": "ES2022",
     "outDir": "packages/core/src",
-    "sourceMap": false,
-    "listEmittedFiles": true
+    "sourceMap": false
   },
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.js", "**/*.test.jsx"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "target": "ES2018",
+    "target": "ES2022",
     "moduleResolution": "node",
     "isolatedModules": true
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1615,8 +1615,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@inboxsdk/core@workspace:packages/core"
   dependencies:
+    "@babel/runtime": ^7.0.0
     "@types/kefir": ^3.8.6
     "@types/node": "*"
+    asap: ^2.0.3
+    kefir-cast: ^3.3.0
+    sha.js: ^2.4.0
     tag-tree: ^1.0.0
     typed-emitter: ^2.1.0
   languageName: unknown


### PR DESCRIPTION
A subset of the changes in #837 related to outputting JS stripped of TS and Flow cruft.