### PR TITLE
feat: Center align navitem icon on custom panel button

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1605,6 +1605,18 @@ shows up on our elements preventing them from collapsing.
   padding-left: 0;
 }
 
+/* app menu panel nav item reshaping */
+.inboxsdk__collapsiblePanel .inboxsdk__navItem > .TO .TN.aik {
+  padding-left: 18px;
+}
+
+/* Tweak alignment of  */
+.inboxsdk__collapsiblePanel .inboxsdk__navItem > .TO .qj {
+  margin-right: 14px;
+}
+
+/* end app menu panel nav item reshaping */
+
 .inboxsdk__navItem > .TO.n4 .qj > .G-asx {
   margin-right: 0;
 }


### PR DESCRIPTION
# Before
<img width="70" alt="Screenshot 2023-03-01 at 10 14 03" src="https://user-images.githubusercontent.com/5156873/222181426-4027ae5f-e178-4cf6-90f6-0162e8ec9d6e.png">

# After
<img width="330" alt="Screenshot 2023-03-01 at 10 10 29" src="https://user-images.githubusercontent.com/5156873/222181423-4887a190-bd41-4ec4-aebd-8b7a09eca677.png">
