### PR TITLE
fix: prevent FOUC when (de-)?activating menu items

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-menu-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-menu-item-view.ts
@@ -119,6 +119,8 @@ export class GmailAppMenuItemView extends (EventEmitter as new () => TypedEventE
     headingElement.textContent = this.#menuItemDescriptor?.name ?? '';
   }
 
+  static #preloadedIcons = new Set<string>();
+
   #updateIcon(element: HTMLElement) {
     const iconContainerEl = querySelector(element, ICON_ELEMENT_SELECTOR);
 
@@ -131,6 +133,19 @@ export class GmailAppMenuItemView extends (EventEmitter as new () => TypedEventE
       const theme = typeof rawTheme === 'string' ? rawTheme : rawTheme.default;
       const activeImg =
         typeof rawTheme === 'string' ? rawTheme : rawTheme.active;
+
+      // alleviate FOUC when switching between active and default icons
+      // https://stackoverflow.com/a/68521953/1924257
+      for (const url of [theme, activeImg]) {
+        if (GmailAppMenuItemView.#preloadedIcons.has(url)) continue;
+
+        var link = document.createElement('link');
+        link.rel = 'preload';
+        link.as = 'image';
+        link.href = url;
+        document.head.appendChild(link);
+      }
+
       iconContainerEl.style.setProperty('--background-image', `url(${theme})`);
       iconContainerEl.style.setProperty(
         '--background-image--active',

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-menu-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-menu-item-view.ts
@@ -138,6 +138,7 @@ export class GmailAppMenuItemView extends (EventEmitter as new () => TypedEventE
       // https://stackoverflow.com/a/68521953/1924257
       for (const url of [theme, activeImg]) {
         if (GmailAppMenuItemView.#preloadedIcons.has(url)) continue;
+        GmailAppMenuItemView.#preloadedIcons.add(url);
 
         var link = document.createElement('link');
         link.rel = 'preload';


### PR DESCRIPTION
When switching between default and active menu items in the experimental app menu work, we would flash as the browser redownloaded each image. This change exploits the fact that after #836, we only support [browsers that support preload](https://caniuse.com/link-rel-preload). 