### PR TITLE
feat: update app menu icons on theme swap

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-react": "^7.32.1",
     "event-listener-with-options": "^1.0.3",
     "ext-corb-workaround": "^2.0.0",
+    "fast-deep-equal": "^3.1.3",
     "fast-glob": "^3.2.5",
     "flow-bin": "^0.98.1",
     "gulp": "^4.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
     "@types/kefir": "^3.8.6",
     "@types/node": "*",
     "asap": "^2.0.3",
+    "fast-deep-equal": "^3.1.3",
     "kefir-cast": "^3.3.0",
     "sha.js": "^2.4.0",
     "tag-tree": "^1.0.0",

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-app-menu-item.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-app-menu-item.ts
@@ -10,11 +10,13 @@ export async function addAppMenuItem(
 ) {
   const appMenuInjectionContainer = await GmailElementGetter.getAppMenuAsync();
 
-  const gmailAppMenuItemView = new GmailAppMenuItemView(driver);
-  gmailAppMenuItemView.setMenuItemDescriptor(menuItemDescriptor);
+  const gmailAppMenuItemView = new GmailAppMenuItemView(
+    driver,
+    menuItemDescriptor
+  );
 
   try {
-    if (!appMenuInjectionContainer || !gmailAppMenuItemView.element) return;
+    if (!appMenuInjectionContainer) return;
 
     const siblingElement = menuItemDescriptor.insertIndex
       ? appMenuInjectionContainer.childNodes[menuItemDescriptor.insertIndex] ??

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-menu-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-menu-item-view.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from 'events';
 import cx from 'classnames';
 import GmailElementGetter from '../gmail-element-getter';
 import { stylesStream } from '../gmail-driver/track-gmail-styles';
-import { isEqual } from 'lodash';
+import isEqual from 'fast-deep-equal';
 
 export type MessageEvents = {
   click: (e: MouseEvent) => void;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-menu-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-menu-item-view.ts
@@ -5,6 +5,8 @@ import TypedEventEmitter from 'typed-emitter';
 import { EventEmitter } from 'events';
 import cx from 'classnames';
 import GmailElementGetter from '../gmail-element-getter';
+import { stylesStream } from '../gmail-driver/track-gmail-styles';
+import { isEqual } from 'lodash';
 
 export type MessageEvents = {
   click: (e: MouseEvent) => void;
@@ -28,8 +30,8 @@ export class GmailAppMenuItemView extends (EventEmitter as new () => TypedEventE
     ACTIVE: 'apV',
   } as const;
 
-  #menuItemDescriptor?: AppMenuItemDescriptor;
-  #element?: HTMLElement;
+  #menuItemDescriptor: AppMenuItemDescriptor;
+  #element: HTMLElement;
   #destroyed = false;
   #driver;
 
@@ -37,7 +39,7 @@ export class GmailAppMenuItemView extends (EventEmitter as new () => TypedEventE
     return this.#element;
   }
 
-  setMenuItemDescriptor(newMenuItemDescriptor: AppMenuItemDescriptor) {
+  set menuItemDescriptor(newMenuItemDescriptor) {
     this.#menuItemDescriptor = newMenuItemDescriptor;
     this.#update();
   }
@@ -46,10 +48,20 @@ export class GmailAppMenuItemView extends (EventEmitter as new () => TypedEventE
     return this.#menuItemDescriptor;
   }
 
-  constructor(driver: GmailDriver) {
+  constructor(driver: GmailDriver, menuItemDescriptor: AppMenuItemDescriptor) {
     super();
     this.#element = this.#setupElement();
     this.#driver = driver;
+    this.#menuItemDescriptor = menuItemDescriptor;
+    this.#update();
+
+    stylesStream
+      .skipDuplicates((a, b) => isEqual(a, b))
+      .onValue(({ type }) => {
+        if (type === 'theme') {
+          this.#update();
+        }
+      });
 
     driver.getStopper().onValue(() => this.remove());
     this.#element.addEventListener('click', (e) => this.#onClick(e));
@@ -65,25 +77,6 @@ export class GmailAppMenuItemView extends (EventEmitter as new () => TypedEventE
     this.#destroyed = true;
     this.element?.remove();
     this.emit('destroy');
-  }
-
-  /**
-   * @internal
-   */
-  blur() {
-    this.element?.classList.remove(GmailAppMenuItemView.elementCss.HOVER);
-  }
-
-  /**
-   * @internal
-   */
-  hover() {
-    if (
-      this.element?.classList.contains(GmailAppMenuItemView.elementCss.ACTIVE)
-    ) {
-      return;
-    }
-    this.element?.classList.add(GmailAppMenuItemView.elementCss.HOVER);
   }
 
   #setupElement() {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-menu-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-menu-item-view.ts
@@ -123,6 +123,9 @@ export class GmailAppMenuItemView extends (EventEmitter as new () => TypedEventE
       const rawTheme = GmailElementGetter.isDarkTheme()
         ? iconUrl.darkTheme
         : iconUrl.lightTheme;
+
+      if (!rawTheme) return;
+
       const theme = typeof rawTheme === 'string' ? rawTheme : rawTheme.default;
       const activeImg =
         typeof rawTheme === 'string' ? rawTheme : rawTheme.active;

--- a/src/platform-implementation-js/namespaces/app-menu.ts
+++ b/src/platform-implementation-js/namespaces/app-menu.ts
@@ -13,8 +13,8 @@ type ThemedIcon =
 export type AppMenuItemDescriptor = {
   name: string;
   iconUrl?: {
-    darkTheme: ThemedIcon;
-    lightTheme: ThemedIcon;
+    darkTheme?: ThemedIcon;
+    lightTheme?: ThemedIcon;
   };
   className?: string;
   iconClassName?: string;

--- a/src/platform-implementation-js/views/app-menu-item-view.ts
+++ b/src/platform-implementation-js/views/app-menu-item-view.ts
@@ -519,7 +519,7 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
 
   async update(menuItemDescriptor: AppMenuItemDescriptor) {
     const gmailView = await this.#gmailViewPromise;
-    gmailView.setMenuItemDescriptor(menuItemDescriptor);
+    gmailView.menuItemDescriptor = menuItemDescriptor;
     this.#menuItemDescriptor = menuItemDescriptor;
   }
 

--- a/src/platform-implementation-js/views/collapsible-panel-view.ts
+++ b/src/platform-implementation-js/views/collapsible-panel-view.ts
@@ -11,6 +11,8 @@ import GmailElementGetter from '../dom-driver/gmail/gmail-element-getter';
 import GmailDriver from '../dom-driver/gmail/gmail-driver';
 import { NavItemDescriptor } from '../dom-driver/gmail/views/gmail-nav-item-view';
 import NavItemView from './nav-item-view';
+import { stylesStream } from '../dom-driver/gmail/gmail-driver/track-gmail-styles';
+import { isEqual } from 'lodash';
 
 export const NATIVE_CLASS = 'aqn' as const;
 export const INBOXSDK_CLASS = 'inboxsdk__collapsiblePanel' as const;
@@ -69,7 +71,7 @@ export class CollapsiblePanelView extends (EventEmitter as new () => TypedEmitte
     return this.#panelDescriptor;
   }
 
-  set panelDescriptor(panelDescriptor: AppMenuItemPanelDescriptor) {
+  set panelDescriptor(panelDescriptor) {
     this.#panelDescriptor = panelDescriptor;
     this.#update();
   }
@@ -94,6 +96,13 @@ export class CollapsiblePanelView extends (EventEmitter as new () => TypedEmitte
     this.#element.addEventListener('mouseleave', (e: MouseEvent) => {
       this.emit('blur', e);
     });
+    stylesStream
+      .skipDuplicates((a, b) => isEqual(a, b))
+      .onValue(({ type }) => {
+        if (type === 'theme') {
+          this.#update();
+        }
+      });
   }
 
   remove() {

--- a/src/platform-implementation-js/views/collapsible-panel-view.ts
+++ b/src/platform-implementation-js/views/collapsible-panel-view.ts
@@ -12,7 +12,7 @@ import GmailDriver from '../dom-driver/gmail/gmail-driver';
 import { NavItemDescriptor } from '../dom-driver/gmail/views/gmail-nav-item-view';
 import NavItemView from './nav-item-view';
 import { stylesStream } from '../dom-driver/gmail/gmail-driver/track-gmail-styles';
-import { isEqual } from 'lodash';
+import isEqual from 'fast-deep-equal';
 
 export const NATIVE_CLASS = 'aqn' as const;
 export const INBOXSDK_CLASS = 'inboxsdk__collapsiblePanel' as const;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1619,6 +1619,7 @@ __metadata:
     "@types/kefir": ^3.8.6
     "@types/node": "*"
     asap: ^2.0.3
+    fast-deep-equal: ^3.1.3
     kefir-cast: ^3.3.0
     sha.js: ^2.4.0
     tag-tree: ^1.0.0
@@ -7500,6 +7501,7 @@ __metadata:
     eslint-plugin-react: ^7.32.1
     event-listener-with-options: ^1.0.3
     ext-corb-workaround: ^2.0.0
+    fast-deep-equal: ^3.1.3
     fast-glob: ^3.2.5
     flow-bin: ^0.98.1
     gulp: ^4.0.2


### PR DESCRIPTION
When swapping from light <-> dark themes within gmail, update icons in the app menu panel accordingly.