### PR TITLE
feat: add dark theme api support for panel

### DIFF
--- a/src/platform-implementation-js/namespaces/app-menu.ts
+++ b/src/platform-implementation-js/namespaces/app-menu.ts
@@ -34,6 +34,16 @@ export type AppMenuItemDescriptor = {
   isRouteActive: (routeView: RouteView) => boolean;
 };
 
+/**
+ * In dark themes, Gmail has different colored primary buttons depending on hover or active state
+ */
+type PanelPrimaryButtonThemedIcon =
+  | string
+  | {
+      panelHovered: string;
+      panelDefault: string;
+    };
+
 export type AppMenuItemPanelDescriptor = {
   className?: string;
   /** In the form of HTML as a string.
@@ -44,8 +54,8 @@ export type AppMenuItemPanelDescriptor = {
     name: string;
     onClick: (e: MouseEvent) => void;
     iconUrl?: {
-      darkTheme: string;
-      lightTheme: string;
+      darkTheme?: PanelPrimaryButtonThemedIcon;
+      lightTheme?: PanelPrimaryButtonThemedIcon;
     };
     className?: string;
   };

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1683,6 +1683,10 @@ shows up on our elements preventing them from collapsing.
   background-image: var(--background-image);
 }
 
+.inboxsdk__collapsiblePanel.apV.aJu .T-I.T-I-KE.L3:before {
+  background-image: var(--background-image--hover);
+}
+
 .inboxsdk__appMenuItem.apV .CL.V6:before {
   background-image: var(--background-image--active);
 }

--- a/src/platform-implementation-js/views/collapsible-panel-view.ts
+++ b/src/platform-implementation-js/views/collapsible-panel-view.ts
@@ -149,14 +149,37 @@ export class CollapsiblePanelView extends (EventEmitter as new () => TypedEmitte
     return navItemView;
   }
 
+  #extractPrimaryButtonTheme() {
+    const { iconUrl } = this.panelDescriptor.primaryButton ?? {};
+
+    if (!iconUrl) {
+      return;
+    }
+
+    const themeSelect = GmailElementGetter.isDarkTheme() ? 'dark' : 'light';
+    const theme = iconUrl[`${themeSelect}Theme`];
+
+    if (!theme) {
+      return;
+    }
+
+    if (typeof theme === 'string') {
+      return {
+        panelHovered: theme,
+        panelDefault: theme,
+      };
+    } else {
+      return {
+        panelDefault: theme.panelDefault,
+        panelHovered: theme.panelHovered,
+      };
+    }
+  }
+
   #setupElement() {
     const { panelDescriptor } = this;
     const { loadingIcon } = panelDescriptor;
-    const {
-      iconUrl: themedIcons,
-      className,
-      name = '',
-    } = panelDescriptor?.primaryButton ?? {};
+    const { className, name = '' } = panelDescriptor?.primaryButton ?? {};
     const element = document.createElement('div');
     element.className = cx(ELEMENT_CLASS, this.panelDescriptor.className);
     const primaryButtonClass = cx(PRIMARY_BUTTON_ELEMENT_CLASS, className);
@@ -164,15 +187,8 @@ export class CollapsiblePanelView extends (EventEmitter as new () => TypedEmitte
       [panelLoadingClass]: this.#loading,
     });
 
-    let iconUrl;
-
-    if (themedIcons) {
-      if (GmailElementGetter.isDarkTheme()) {
-        iconUrl = themedIcons.darkTheme;
-      } else {
-        iconUrl = themedIcons.lightTheme;
-      }
-    }
+    const { panelDefault: defaultIconUrl, panelHovered: hoverPanelIconUrl } =
+      this.#extractPrimaryButtonTheme() ?? {};
 
     element.innerHTML = autoHtml`
       <div class="aBO">
@@ -222,7 +238,11 @@ export class CollapsiblePanelView extends (EventEmitter as new () => TypedEmitte
     );
     primaryBtnEl.style.setProperty(
       '--background-image',
-      iconUrl ? `url(${iconUrl})` : 'unset'
+      defaultIconUrl ? `url(${defaultIconUrl})` : 'unset'
+    );
+    primaryBtnEl.style.setProperty(
+      '--background-image--hover',
+      hoverPanelIconUrl ? `url(${hoverPanelIconUrl})` : 'unset'
     );
 
     primaryBtnEl.addEventListener('click', this.#onPrimaryButtonClick);
@@ -258,19 +278,21 @@ export class CollapsiblePanelView extends (EventEmitter as new () => TypedEmitte
       PRIMARY_BUTTON_ELEMENT_SELECTOR
     );
 
-    const { iconUrl, className } = this.panelDescriptor.primaryButton ?? {};
+    const { panelDefault, panelHovered } =
+      this.#extractPrimaryButtonTheme() ?? {};
 
-    if (iconUrl) {
-      const backgroundImage = `url(${
-        GmailElementGetter.isDarkTheme()
-          ? iconUrl.darkTheme
-          : iconUrl.lightTheme
-      })`;
-      iconContainerEl.style.setProperty('--background-image', backgroundImage);
-    } else {
-      iconContainerEl.style.setProperty('--background-image', 'unset');
+    for (const [key, value] of Object.entries({
+      '--background-image--hover': panelHovered,
+      '--background-image': panelDefault,
+    })) {
+      if (value) {
+        iconContainerEl.style.setProperty(key, `url(${value})`);
+      } else {
+        iconContainerEl.style.removeProperty(key);
+      }
     }
 
+    const { className } = this.panelDescriptor.primaryButton ?? {};
     iconContainerEl.className = cx(PRIMARY_BUTTON_ELEMENT_CLASS, className);
   }
 

--- a/src/platform-implementation-js/views/collapsible-panel-view.ts
+++ b/src/platform-implementation-js/views/collapsible-panel-view.ts
@@ -156,8 +156,7 @@ export class CollapsiblePanelView extends (EventEmitter as new () => TypedEmitte
       return;
     }
 
-    const themeSelect = GmailElementGetter.isDarkTheme() ? 'dark' : 'light';
-    const theme = iconUrl[`${themeSelect}Theme`];
+    const theme = GmailElementGetter.isDarkTheme() ? iconUrl.darkTheme : iconUrl.lightTheme;
 
     if (!theme) {
       return;


### PR DESCRIPTION
Incorporates part of the relaxing of required types around `PanelDescriptor.primaryButton.iconUrl` like #857.