### PR TITLE
fix(app-menu): update selector for app burger menu collapsed

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -220,12 +220,12 @@ const GmailElementGetter = {
     return (
       document
         .querySelector<HTMLElement>(
-          '.gb_Hc[aria-expanded], .gb_Ic[aria-expanded]'
+          'header[role="banner"] > div > div > div[aria-expanded]'
         )
         ?.getAttribute('aria-expanded') === 'true' ??
       // Default to true if we can't find the element because
       // the majority of users seem to favor that version.
-      true
+      false
     );
   },
 

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -219,8 +219,13 @@ const GmailElementGetter = {
   isAppBurgerMenuOpen() {
     return (
       document
-        .querySelector<HTMLElement>('.gb_Hc[aria-expanded]')
-        ?.getAttribute('aria-expanded') === 'true' ?? false
+        .querySelector<HTMLElement>(
+          '.gb_Hc[aria-expanded], .gb_Ic[aria-expanded]'
+        )
+        ?.getAttribute('aria-expanded') === 'true' ??
+      // Default to true if we can't find the element because
+      // the majority of users seem to favor that version.
+      true
     );
   },
 


### PR DESCRIPTION
And default to the app burger menu being being open, even if the selector is not found.