### PR TITLE
fix: getDensity method

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/track-gmail-styles.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/track-gmail-styles.ts
@@ -5,25 +5,15 @@ import GmailElementGetter from '../gmail-element-getter';
 
 const RGB_REGEX = /^rgb\s*\(\s*(\d+),\s*(\d+),\s*(\d+)\s*\)/;
 
-function getDensity(): string {
-  // get the padding amount on the left-nav-menu entries to find the active
-  // density setting value.
-  const navItemOuter = document.querySelector('.TO .TN');
-  if (!navItemOuter) {
-    Logger.error(new Error('Failed to find nav item outer element'));
-    return 'compact';
+function getDensity(): 'compact' | 'default' {
+  const navItemElement = document.querySelector('.aim')
+  if (!navItemElement) {
+    Logger.error(new Error('Failed to find a nav item element'));
+    return 'default'
   }
-  const padding = parseInt(
-    getComputedStyle(navItemOuter).getPropertyValue('padding-top'),
-    10
-  );
-  if (padding >= 6) {
-    return 'comfortable';
-  } else if (padding >= 3) {
-    return 'cozy';
-  } else {
-    return 'compact';
-  }
+
+  const rect = navItemElement.getBoundingClientRect()
+  return rect?.height === 24 ? 'compact' : 'default'
 }
 
 const navItemSelector = '.aio' as const;

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/track-gmail-styles.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/track-gmail-styles.ts
@@ -6,14 +6,14 @@ import GmailElementGetter from '../gmail-element-getter';
 const RGB_REGEX = /^rgb\s*\(\s*(\d+),\s*(\d+),\s*(\d+)\s*\)/;
 
 function getDensity(): 'compact' | 'default' {
-  const navItemElement = document.querySelector('.aim')
+  const navItemElement = document.querySelector('.aim');
   if (!navItemElement) {
     Logger.error(new Error('Failed to find a nav item element'));
-    return 'default'
+    return 'default';
   }
 
-  const rect = navItemElement.getBoundingClientRect()
-  return rect?.height === 24 ? 'compact' : 'default'
+  const rect = navItemElement.getBoundingClientRect();
+  return rect?.height === 24 ? 'compact' : 'default';
 }
 
 const navItemSelector = '.aio' as const;


### PR DESCRIPTION
Hi,
I've recently found that the class `inboxsdk__gmail_density_compact` was always set on the body even if the actual density setting was set to "Default" or "Comfortable".

I've made the changes in the method `getDensity` to detect if the density was set to Compact or Default/Comfortable.
Sadly, they are no visual/class changes between "Default" and "Comfortable" density!

I've used the key `default` for the default density, but it can be `cozy` to keep better retro compatibility, but `default` looks more relevant with the setting's name.

Steps to reproduce:
1. Load any extension using the InboxSDK
2. In the Gmail "Quick settings" switch the density from Compact to Default, the class `inboxsdk__gmail_density_compact` will always be on the body element