### PR TITLE
chore: drop check-requirements

### DIFF
--- a/src/inboxsdk-js/check-requirements.js
+++ b/src/inboxsdk-js/check-requirements.js
@@ -1,7 +1,0 @@
-/* @flow */
-
-export default function checkRequirements(opts: Object) {
-  if (!opts.TEMPORARY_INTERNAL_skipWeakMapRequirement && !global.WeakMap) {
-    throw new Error('Browser does not support WeakMap');
-  }
-}

--- a/src/inboxsdk-js/inboxsdk.js
+++ b/src/inboxsdk-js/inboxsdk.js
@@ -3,7 +3,6 @@
 import logError from '../common/log-error';
 
 import PlatformImplementationLoader from './loading/platform-implementation-loader';
-import checkRequirements from './check-requirements';
 import { BUILD_VERSION } from '../common/version';
 import _loadScript from '../common/load-script';
 
@@ -23,8 +22,6 @@ export function load(version: any, appId: string, opts: ?Object) {
       REQUESTED_API_VERSION: version,
     }
   );
-
-  checkRequirements(opts);
 
   return PlatformImplementationLoader.load(appId, opts);
 }


### PR DESCRIPTION
The SDK only supports browsers that support WeakMap. If someone tries to use the SDK in an older browser, SyntaxErrors would stop it long before it got to this check.