### PR TITLE
chore: remove no-op public typescript accessor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,10 @@ module.exports = {
       files: ['*.ts', '*.tsx'],
       rules: {
         '@typescript-eslint/ban-types': ['off'],
+        '@typescript-eslint/explicit-member-accessibility': [
+          'error',
+          { accessibility: 'no-public' },
+        ],
         '@typescript-eslint/explicit-module-boundary-types': ['off'],
         '@typescript-eslint/indent': ['off'],
         '@typescript-eslint/explicit-function-return-type': ['off'],

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.d.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.d.ts
@@ -31,42 +31,39 @@ type GmailBackdrop = any;
 export default class GmailDriver implements Driver {
   getEnvData(): EnvData;
   getTimings(): { [ix: string]: number | undefined | null };
-  public onready: Promise<void>;
-  public isUsingSyncAPI(): boolean;
-  public getLogger(): Logger;
-  public getAppId(): string;
-  public getOpts(): PiOpts;
-  public getRouteViewDriverStream(): Kefir.Observable<RouteView, any>; // should be a property
-  public getRowListViewDriverStream(): Kefir.Observable<any, any>;
-  public openNewComposeViewDriver(): Promise<GmailComposeView>;
-  public getNextComposeViewDriver(): Promise<GmailComposeView>;
-  public getComposeViewDriverStream(): Kefir.Observable<GmailComposeView, any>;
-  public openDraftByMessageID(messageID: string): Promise<void>;
-  public getThreadViewDriverStream(): Kefir.Observable<GmailThreadView, any>;
-  public getMessageViewDriverStream(): Kefir.Observable<GmailMessageView, any>;
-  public getAttachmentCardViewDriverStream(): Kefir.Observable<
+  onready: Promise<void>;
+  isUsingSyncAPI(): boolean;
+  getLogger(): Logger;
+  getAppId(): string;
+  getOpts(): PiOpts;
+  getRouteViewDriverStream(): Kefir.Observable<RouteView, any>; // should be a property
+  getRowListViewDriverStream(): Kefir.Observable<any, any>;
+  openNewComposeViewDriver(): Promise<GmailComposeView>;
+  getNextComposeViewDriver(): Promise<GmailComposeView>;
+  getComposeViewDriverStream(): Kefir.Observable<GmailComposeView, any>;
+  openDraftByMessageID(messageID: string): Promise<void>;
+  getThreadViewDriverStream(): Kefir.Observable<GmailThreadView, any>;
+  getMessageViewDriverStream(): Kefir.Observable<GmailMessageView, any>;
+  getAttachmentCardViewDriverStream(): Kefir.Observable<
     GmailAttachmentCardView,
     any
   >;
-  public activateShortcut(
+  activateShortcut(
     keyboardShortcutHandle: KeyboardShortcutHandle,
     appName?: string,
     appIconUrl?: string
   ): void;
-  public getTagTree(): TagTree<HTMLElement>;
-  public getPageCommunicator(): GmailPageCommunicator;
-  public getGmailActionToken(): Promise<string>;
-  public getUserEmailAddress(): string;
-  public isConversationViewDisabled(): Promise<boolean>;
-  public getUserLanguage(): string;
-  public getUserContact(): Contact;
-  public getAccountSwitcherContactList(): Contact[];
-  public getThreadRowViewDriverStream(): Kefir.Observable<
-    GmailThreadRowView,
-    any
-  >;
-  public registerThreadButton(options: any): () => void;
-  public addNavItem(
+  getTagTree(): TagTree<HTMLElement>;
+  getPageCommunicator(): GmailPageCommunicator;
+  getGmailActionToken(): Promise<string>;
+  getUserEmailAddress(): string;
+  isConversationViewDisabled(): Promise<boolean>;
+  getUserLanguage(): string;
+  getUserContact(): Contact;
+  getAccountSwitcherContactList(): Contact[];
+  getThreadRowViewDriverStream(): Kefir.Observable<GmailThreadRowView, any>;
+  registerThreadButton(options: any): () => void;
+  addNavItem(
     appId: string,
     navItemDescriptor: any,
     navMenuInjectionContainer?: HTMLElement
@@ -74,38 +71,38 @@ export default class GmailDriver implements Driver {
   addAppMenuItem(
     menuItemDescriptor: AppMenuItemDescriptor
   ): Promise<GmailAppMenuItemView>;
-  public addSupportItem(
+  addSupportItem(
     supportItemDescriptor: SupportItemDescriptor
   ): GmailSupportItemView;
-  public getSentMailNativeNavItem(): Promise<any>;
-  public createLink(a: any, b: any): any;
-  public goto(routeID: string, params: any): Promise<void>;
-  public addCustomRouteID(routeID: string): () => void;
-  public addCustomListRouteID(routeID: string, handler: Function): () => void;
-  public showCustomRouteView(el: HTMLElement): void;
-  public setShowNativeNavMarker(isNative: boolean): any;
-  public setShowNativeAddonSidebar(isNative: boolean): any;
-  public registerSearchSuggestionsProvider(handler: Function): void;
-  public registerSearchQueryRewriter(obj: any): void;
-  public addToolbarButtonForApp(
+  getSentMailNativeNavItem(): Promise<any>;
+  createLink(a: any, b: any): any;
+  goto(routeID: string, params: any): Promise<void>;
+  addCustomRouteID(routeID: string): () => void;
+  addCustomListRouteID(routeID: string, handler: Function): () => void;
+  showCustomRouteView(el: HTMLElement): void;
+  setShowNativeNavMarker(isNative: boolean): any;
+  setShowNativeAddonSidebar(isNative: boolean): any;
+  registerSearchSuggestionsProvider(handler: Function): void;
+  registerSearchQueryRewriter(obj: any): void;
+  addToolbarButtonForApp(
     buttonDescriptor: Kefir.Observable<any, any>
   ): Promise<any>;
-  public addGlobalSidebarContentPanel(
+  addGlobalSidebarContentPanel(
     buttonDescriptor: Kefir.Observable<any, any>
   ): Promise<ContentPanelViewDriver | null | undefined>;
-  public getButterBarDriver(): GmailButterBarDriver;
-  public setButterBar(butterBar: any): void;
-  public isRunningInPageContext(): boolean;
-  public showAppIdWarning(): void;
-  public createModalViewDriver(options: any): any;
-  public createMoleViewDriver(options: any): GmailMoleViewDriver;
-  public createTopMessageBarDriver(options: any): any;
-  public createDrawerViewDriver(options: DrawerViewOptions): DrawerViewDriver;
-  public createBackdrop(zIndex?: number, target?: HTMLElement): GmailBackdrop;
-  public getStopper(): Kefir.Observable<null, never>;
-  public destroy(): void;
+  getButterBarDriver(): GmailButterBarDriver;
+  setButterBar(butterBar: any): void;
+  isRunningInPageContext(): boolean;
+  showAppIdWarning(): void;
+  createModalViewDriver(options: any): any;
+  createMoleViewDriver(options: any): GmailMoleViewDriver;
+  createTopMessageBarDriver(options: any): any;
+  createDrawerViewDriver(options: DrawerViewOptions): DrawerViewDriver;
+  createBackdrop(zIndex?: number, target?: HTMLElement): GmailBackdrop;
+  getStopper(): Kefir.Observable<null, never>;
+  destroy(): void;
 
-  public getSelectedThreadRowViewDrivers(): ReadonlyArray<GmailThreadRowView>;
-  public registerThreadRowViewSelectionHandler(handler: () => any): () => void;
-  public getLoadEventDetails(): any;
+  getSelectedThreadRowViewDrivers(): ReadonlyArray<GmailThreadRowView>;
+  registerThreadRowViewSelectionHandler(handler: () => any): () => void;
+  getLoadEventDetails(): any;
 }

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-page-communicator.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-page-communicator.ts
@@ -9,7 +9,7 @@ import Kefir from 'kefir';
 // if you have an instance of this, then the injected script is present and this
 // will work.
 export default class GmailPageCommunicator extends CommonPageCommunicator {
-  public async getMessageDate(
+  async getMessageDate(
     threadId: string,
     message: HTMLElement
   ): Promise<number | null> {
@@ -21,7 +21,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     );
   }
 
-  public async getMessageRecipients(
+  async getMessageRecipients(
     threadId: string,
     message: HTMLElement
   ): Promise<Array<{
@@ -76,9 +76,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     else return null;
   }
 
-  public getThreadIdForThreadRowByDatabase(
-    threadRow: HTMLElement
-  ): string | null {
+  getThreadIdForThreadRowByDatabase(threadRow: HTMLElement): string | null {
     let threadid = threadRow.getAttribute('data-inboxsdk-threadid');
     if (!threadid) {
       threadRow.dispatchEvent(
@@ -93,7 +91,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     return threadid;
   }
 
-  public getThreadIdForThreadRowByClick(threadRow: HTMLElement): string | null {
+  getThreadIdForThreadRowByClick(threadRow: HTMLElement): string | null {
     let threadid = threadRow.getAttribute('data-inboxsdk-threadid');
     if (!threadid) {
       threadRow.dispatchEvent(
@@ -108,7 +106,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     return threadid;
   }
 
-  public getCurrentThreadID(
+  getCurrentThreadID(
     threadContainerElement: HTMLElement,
     isPreviewedThread: boolean = false
   ): string {
@@ -127,23 +125,23 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     return s;
   }
 
-  public getUserOriginalPreviewPaneMode(): string | null {
+  getUserOriginalPreviewPaneMode(): string | null {
     return document.head.getAttribute('data-inboxsdk-user-preview-pane-mode');
   }
 
-  public getActionTokenValue(): string {
+  getActionTokenValue(): string {
     const s = document.head.getAttribute('data-inboxsdk-action-token-value');
     if (s == null) throw new Error('Failed to read value');
     return s;
   }
 
-  public isUsingSyncAPI(): boolean {
+  isUsingSyncAPI(): boolean {
     const s = document.head.getAttribute('data-inboxsdk-using-sync-api');
     if (s == null) throw new Error('Failed to read value');
     return s === 'true';
   }
 
-  public isConversationViewDisabled(): Promise<boolean> {
+  isConversationViewDisabled(): Promise<boolean> {
     return new Promise((resolve) => {
       Kefir.fromEvents<any, never>(document, 'inboxSDKgmonkeyResponse')
         .take(1)
@@ -161,7 +159,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     });
   }
 
-  public registerSuggestionsModifier(providerID: string) {
+  registerSuggestionsModifier(providerID: string) {
     document.dispatchEvent(
       new CustomEvent('inboxSDKregisterSuggestionsModifier', {
         bubbles: false,
@@ -171,7 +169,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     );
   }
 
-  public provideAutocompleteSuggestions(
+  provideAutocompleteSuggestions(
     providerID: string,
     query: string,
     suggestions: AutocompleteSearchResultWithId[]
@@ -190,7 +188,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     );
   }
 
-  public setupCustomListResultsQuery(query: string) {
+  setupCustomListResultsQuery(query: string) {
     document.dispatchEvent(
       new CustomEvent('inboxSDKcustomListRegisterQuery', {
         bubbles: false,
@@ -200,7 +198,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     );
   }
 
-  public setCustomListNewQuery(detail: {
+  setCustomListNewQuery(detail: {
     query: string;
     start: number;
     newQuery: string;
@@ -215,7 +213,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     );
   }
 
-  public setCustomListResults(query: string, newResults: string | null) {
+  setCustomListResults(query: string, newResults: string | null) {
     document.dispatchEvent(
       new CustomEvent('inboxSDKcustomListResults', {
         bubbles: false,
@@ -225,7 +223,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     );
   }
 
-  public createCustomSearchTerm(term: string) {
+  createCustomSearchTerm(term: string) {
     document.dispatchEvent(
       new CustomEvent('inboxSDKcreateCustomSearchTerm', {
         bubbles: false,
@@ -235,7 +233,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     );
   }
 
-  public setSearchQueryReplacement(query: string, newQuery: string) {
+  setSearchQueryReplacement(query: string, newQuery: string) {
     document.dispatchEvent(
       new CustomEvent('inboxSDKsearchReplacementReady', {
         bubbles: false,
@@ -245,7 +243,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     );
   }
 
-  public registerComposeRequestModifier(keyId: string, appId: string): string {
+  registerComposeRequestModifier(keyId: string, appId: string): string {
     const modifierId = new Date().getTime() + '_' + appId + '_' + Math.random();
 
     const detail: any = { modifierId };
@@ -266,7 +264,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     return modifierId;
   }
 
-  public unregisterComposeRequestModifier(keyId: string, modifierId: string) {
+  unregisterComposeRequestModifier(keyId: string, modifierId: string) {
     document.dispatchEvent(
       new CustomEvent('inboxSDKunregisterComposeRequestModifier', {
         detail: { keyId, modifierId },
@@ -276,11 +274,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     );
   }
 
-  public modifyComposeRequest(
-    keyId: string,
-    modifierId: string,
-    composeParams: any
-  ) {
+  modifyComposeRequest(keyId: string, modifierId: string, composeParams: any) {
     const detail: any = { modifierId, composeParams };
     if (this.isUsingSyncAPI()) detail.draftID = keyId;
     else detail.composeid = keyId;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.d.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.d.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../driver-interfaces/compose-view-driver';
 
 export default class GmailComposeView implements ComposeViewDriver {
-  public constructor(
+  constructor(
     element: HTMLElement,
     xhrInterceptorStream: Kefir.Observable<any, any>,
     driver: GmailDriver,
@@ -20,50 +20,50 @@ export default class GmailComposeView implements ComposeViewDriver {
       isStandalone: boolean;
     }
   );
-  public getGmailDriver(): GmailDriver;
-  public getStatusArea(): HTMLElement;
+  getGmailDriver(): GmailDriver;
+  getStatusArea(): HTMLElement;
 
   // interface methods
-  public getEventStream(): Kefir.Observable<any, any>;
-  public getStopper(): Kefir.Observable<any, never>;
-  public getElement(): HTMLElement;
-  public insertBodyTextAtCursor(text: string): null | undefined | HTMLElement;
-  public insertBodyHTMLAtCursor(html: string): null | undefined | HTMLElement;
-  public insertLinkIntoBody(
+  getEventStream(): Kefir.Observable<any, any>;
+  getStopper(): Kefir.Observable<any, never>;
+  getElement(): HTMLElement;
+  insertBodyTextAtCursor(text: string): null | undefined | HTMLElement;
+  insertBodyHTMLAtCursor(html: string): null | undefined | HTMLElement;
+  insertLinkIntoBody(
     text: string,
     href: string
   ): null | undefined | HTMLElement;
-  public insertLinkChipIntoBody(options: {
+  insertLinkChipIntoBody(options: {
     iconUrl?: string;
     url: string;
     text: string;
   }): HTMLElement;
-  public setSubject(text: string): void;
-  public setBodyHTML(html: string): void;
-  public setBodyText(text: string): void;
-  public setToRecipients(emails: ReadonlyArray<string>): void;
-  public setCcRecipients(emails: ReadonlyArray<string>): void;
-  public setBccRecipients(emails: ReadonlyArray<string>): void;
-  public getFromContact(): Contact;
-  public getFromContactChoices(): ReadonlyArray<Contact>;
-  public setFromEmail(email: string): void;
-  public focus(): void;
-  public close(): void;
-  public send(options: { sendAndArchive: boolean }): void;
-  public discard(): void;
-  public popOut(): void;
-  public replaceSendButton(el: HTMLElement): () => void;
-  public hideDiscardButton(): () => void;
-  public registerRequestModifier(modifier: object): void;
-  public attachFiles(files: Blob[]): Promise<void>;
-  public attachInlineFiles(files: Blob[]): Promise<void>;
-  public isFullscreen(): boolean;
-  public setFullscreen(fullscreen: boolean): void;
-  public isMinimized(): boolean;
-  public setMinimized(minimized: boolean): void;
-  public setTitleBarColor(color: string): () => void;
-  public setTitleBarText(text: string): () => void;
-  public addButton(
+  setSubject(text: string): void;
+  setBodyHTML(html: string): void;
+  setBodyText(text: string): void;
+  setToRecipients(emails: ReadonlyArray<string>): void;
+  setCcRecipients(emails: ReadonlyArray<string>): void;
+  setBccRecipients(emails: ReadonlyArray<string>): void;
+  getFromContact(): Contact;
+  getFromContactChoices(): ReadonlyArray<Contact>;
+  setFromEmail(email: string): void;
+  focus(): void;
+  close(): void;
+  send(options: { sendAndArchive: boolean }): void;
+  discard(): void;
+  popOut(): void;
+  replaceSendButton(el: HTMLElement): () => void;
+  hideDiscardButton(): () => void;
+  registerRequestModifier(modifier: object): void;
+  attachFiles(files: Blob[]): Promise<void>;
+  attachInlineFiles(files: Blob[]): Promise<void>;
+  isFullscreen(): boolean;
+  setFullscreen(fullscreen: boolean): void;
+  isMinimized(): boolean;
+  setMinimized(minimized: boolean): void;
+  setTitleBarColor(color: string): () => void;
+  setTitleBarText(text: string): () => void;
+  addButton(
     buttonDescriptor: Kefir.Observable<
       null | undefined | ComposeButtonDescriptor,
       any
@@ -71,49 +71,49 @@ export default class GmailComposeView implements ComposeViewDriver {
     groupOrderHint: string,
     extraOnClickOptions: object
   ): Promise<null | undefined | object>;
-  public addRecipientRow(
+  addRecipientRow(
     options: Kefir.Observable<null | undefined | object, any>
   ): () => void;
-  public forceRecipientRowsOpen(): () => void;
-  public hideNativeRecipientRows(): () => void;
-  public hideRecipientArea(): () => void;
-  public ensureFormattingToolbarIsHidden(): void;
-  public ensureAppButtonToolbarsAreClosed(): void;
+  forceRecipientRowsOpen(): () => void;
+  hideNativeRecipientRows(): () => void;
+  hideRecipientArea(): () => void;
+  ensureFormattingToolbarIsHidden(): void;
+  ensureAppButtonToolbarsAreClosed(): void;
   // addOuterSidebar(options: {title: string, el: HTMLElement}): void;
   // addInnerSidebar(options: {el: HTMLElement}): void;
-  public addComposeNotice(options?: { orderHint?: number }): ComposeNotice;
-  public addStatusBar(options?: {
+  addComposeNotice(options?: { orderHint?: number }): ComposeNotice;
+  addStatusBar(options?: {
     height?: number;
     orderHint?: number;
     addAboveNativeStatusBar?: boolean;
   }): StatusBar;
-  public hideNativeStatusBar(): () => void;
-  public isForward(): boolean;
-  public isReply(): boolean;
-  public isInlineReplyForm(): boolean;
-  public getBodyElement(): HTMLElement;
-  public getMetadataFormElement(): HTMLElement;
-  public getSubjectInput(): null | undefined | HTMLInputElement;
-  public getHTMLContent(): string;
-  public getTextContent(): string;
-  public getSelectedBodyHTML(): null | undefined | string;
-  public getSelectedBodyText(): null | undefined | string;
-  public getLastSelectionRange(): Range | undefined;
-  public getSubject(): string;
-  public getToRecipients(): ReadonlyArray<Contact>;
-  public getCcRecipients(): ReadonlyArray<Contact>;
-  public getBccRecipients(): ReadonlyArray<Contact>;
-  public getComposeID(): string;
-  public getInitialMessageID(): null | undefined | string;
-  public getMessageID(): null | undefined | string;
-  public getThreadID(): null | undefined | string;
-  public getCurrentDraftID(): Promise<null | string>;
-  public getDraftID(): Promise<null | string>;
-  public addTooltipToButton(
+  hideNativeStatusBar(): () => void;
+  isForward(): boolean;
+  isReply(): boolean;
+  isInlineReplyForm(): boolean;
+  getBodyElement(): HTMLElement;
+  getMetadataFormElement(): HTMLElement;
+  getSubjectInput(): null | undefined | HTMLInputElement;
+  getHTMLContent(): string;
+  getTextContent(): string;
+  getSelectedBodyHTML(): null | undefined | string;
+  getSelectedBodyText(): null | undefined | string;
+  getLastSelectionRange(): Range | undefined;
+  getSubject(): string;
+  getToRecipients(): ReadonlyArray<Contact>;
+  getCcRecipients(): ReadonlyArray<Contact>;
+  getBccRecipients(): ReadonlyArray<Contact>;
+  getComposeID(): string;
+  getInitialMessageID(): null | undefined | string;
+  getMessageID(): null | undefined | string;
+  getThreadID(): null | undefined | string;
+  getCurrentDraftID(): Promise<null | string>;
+  getDraftID(): Promise<null | string>;
+  addTooltipToButton(
     buttonViewController: object,
     buttonDescriptor: object,
     tooltipDescriptor: TooltipDescriptor
   ): void;
-  public closeButtonTooltip(buttonViewController: object): void;
-  public setupLinkPopOvers(): void;
+  closeButtonTooltip(buttonViewController: object): void;
+  setupLinkPopOvers(): void;
 }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-status-bar.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-status-bar.ts
@@ -62,7 +62,7 @@ class StatusBar extends SimpleElementView implements IStatusBar {
   private _prependContainer: null | undefined | HTMLElement = null;
   private _stopper = kefirStopper();
 
-  public constructor(
+  constructor(
     gmailComposeView: GmailComposeView,
     height: number,
     orderHint: number,
@@ -80,7 +80,7 @@ class StatusBar extends SimpleElementView implements IStatusBar {
     this.setHeight(height);
   }
 
-  public destroy() {
+  destroy() {
     if (this.destroyed) {
       return;
     }
@@ -97,7 +97,7 @@ class StatusBar extends SimpleElementView implements IStatusBar {
     this._updateTotalHeight();
   }
 
-  public setHeight(newHeight: number) {
+  setHeight(newHeight: number) {
     this.el.style.height = newHeight + 'px';
     this._updateTotalHeight();
   }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/gmail-compose-button-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/gmail-compose-button-view.ts
@@ -31,7 +31,7 @@ export default class GmailComposeButtonView implements ButtonViewI {
   private _keyboardShortcutHandle: null | undefined | KeyboardShortcutHandle;
   private _eventStream: Bus<any, any>;
 
-  public constructor(options: ButtonViewOptions) {
+  constructor(options: ButtonViewOptions) {
     this._isEnabled = options.enabled !== false;
 
     this._iconClass = options.iconClass;
@@ -54,47 +54,47 @@ export default class GmailComposeButtonView implements ButtonViewI {
     }
   }
 
-  public destroy() {
+  destroy() {
     this._element.remove();
     this._eventStream.end();
   }
 
-  public getElement(): HTMLElement {
+  getElement(): HTMLElement {
     return this._element;
   }
-  public getEventStream(): Kefir.Observable<any, any> {
+  getEventStream(): Kefir.Observable<any, any> {
     return this._eventStream;
   }
 
-  public activate() {
+  activate() {
     this.addClass('inboxsdk__composeButton_active');
   }
 
-  public deactivate() {
+  deactivate() {
     this.removeClass('inboxsdk__composeButton_active');
   }
 
-  public addClass(className: string) {
+  addClass(className: string) {
     this._element.classList.add(className);
   }
 
-  public removeClass(className: string) {
+  removeClass(className: string) {
     this._element.classList.remove(className);
   }
 
-  public simulateHover() {
+  simulateHover() {
     simulateHover(this._element);
   }
 
-  public setEnabled(value: boolean) {
+  setEnabled(value: boolean) {
     this._setEnabled(value);
   }
 
-  public isEnabled(): boolean {
+  isEnabled(): boolean {
     return this._isEnabled;
   }
 
-  public update(options: any) {
+  update(options: any) {
     if (!options) {
       this._element.style.display = 'none';
       return;

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/button-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/button-view.ts
@@ -40,7 +40,7 @@ export default class ButtonView implements ButtonViewI {
   private _keyboardShortcutHandle: KeyboardShortcutHandle | null | undefined;
   private _eventStream: Bus<any, any>;
 
-  public constructor(options: ButtonViewOptions) {
+  constructor(options: ButtonViewOptions) {
     this._hasDropdown = false;
     this._isEnabled = options.enabled !== false;
 
@@ -66,49 +66,49 @@ export default class ButtonView implements ButtonViewI {
     }
   }
 
-  public destroy() {
+  destroy() {
     this._element.remove();
     this._eventStream.end();
   }
 
-  public getElement(): HTMLElement {
+  getElement(): HTMLElement {
     return this._element;
   }
-  public getEventStream(): Kefir.Observable<any, any> {
+  getEventStream(): Kefir.Observable<any, any> {
     return this._eventStream;
   }
 
-  public activate() {
+  activate() {
     this.addClass(BUTTON_COLOR_CLASSES[this._buttonColor].ACTIVE_CLASS);
     this.addClass(BUTTON_COLOR_CLASSES[this._buttonColor].HOVER_CLASS);
   }
 
-  public deactivate() {
+  deactivate() {
     this.removeClass(BUTTON_COLOR_CLASSES[this._buttonColor].ACTIVE_CLASS);
     this.removeClass(BUTTON_COLOR_CLASSES[this._buttonColor].HOVER_CLASS);
   }
 
-  public addClass(className: string) {
+  addClass(className: string) {
     this._element.classList.add(className);
   }
 
-  public removeClass(className: string) {
+  removeClass(className: string) {
     this._element.classList.remove(className);
   }
 
-  public simulateHover() {
+  simulateHover() {
     simulateHover(this._element);
   }
 
-  public setEnabled(value: boolean) {
+  setEnabled(value: boolean) {
     this._setEnabled(value);
   }
 
-  public isEnabled(): boolean {
+  isEnabled(): boolean {
     return this._isEnabled;
   }
 
-  public update(options: any) {
+  update(options: any) {
     if (!options) {
       this._element.style.display = 'none';
       return;

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/create-accessory-button-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/create-accessory-button-view.ts
@@ -8,39 +8,39 @@ export default class CreateAccessoryButtonView implements ButtonViewI {
   private _eventStream = kefirBus<any, any>();
   private _stopper = kefirStopper();
 
-  public constructor() {
+  constructor() {
     this._setupElement();
     this._setupEventStream();
   }
 
-  public update() {
+  update() {
     // noop
   }
 
-  public setEnabled() {
+  setEnabled() {
     throw new Error('not implemented');
   }
 
-  public destroy() {
+  destroy() {
     this._eventStream.end();
     this._stopper.destroy();
     this._element.remove();
   }
 
-  public getElement(): HTMLElement {
+  getElement(): HTMLElement {
     return this._element;
   }
 
-  public getEventStream(): Kefir.Observable<any, any> {
+  getEventStream(): Kefir.Observable<any, any> {
     return this._eventStream;
   }
 
-  public activate() {
+  activate() {
     const innerButtonElement = this._element.firstElementChild;
     if (innerButtonElement) innerButtonElement.classList.add('aj1');
   }
 
-  public deactivate() {
+  deactivate() {
     const innerButtonElement = this._element.firstElementChild;
     if (innerButtonElement) innerButtonElement.classList.remove('aj1');
   }

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/create-parent-accessory-button-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/create-parent-accessory-button-view.ts
@@ -8,44 +8,44 @@ export default class CreateParentAccessoryButtonView implements ButtonViewI {
   private _eventStream = kefirBus<any, any>();
   private _stopper = kefirStopper();
 
-  public constructor() {
+  constructor() {
     this._setupElement();
     this._setupEventStream();
   }
 
-  public activate() {
+  activate() {
     const innerButtonElement = this._element.firstElementChild;
     if (innerButtonElement) {
       innerButtonElement.classList.add('aj1');
     }
   }
 
-  public deactivate() {
+  deactivate() {
     const innerButtonElement = this._element.firstElementChild;
     if (innerButtonElement) {
       innerButtonElement.classList.remove('aj1');
     }
   }
 
-  public destroy() {
+  destroy() {
     this._element.remove();
     this._eventStream.end();
     this._stopper.destroy();
   }
 
-  public getElement(): HTMLElement {
+  getElement(): HTMLElement {
     return this._element;
   }
 
-  public getEventStream(): Kefir.Observable<any, any> {
+  getEventStream(): Kefir.Observable<any, any> {
     return this._eventStream;
   }
 
-  public setEnabled() {
+  setEnabled() {
     throw new Error('not implemented');
   }
 
-  public update() {
+  update() {
     // noop
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/modal-button-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/modal-button-view.ts
@@ -20,7 +20,7 @@ export default class ModalButtonView implements ButtonViewI {
   private _eventStream = kefirBus<any, any>();
   private _isEnabled: boolean;
 
-  public constructor(options: ButtonViewOptions) {
+  constructor(options: ButtonViewOptions) {
     this._isEnabled = options.enabled !== false;
 
     this._title = options.text || options.title;
@@ -34,27 +34,27 @@ export default class ModalButtonView implements ButtonViewI {
     this._setupEventStream();
   }
 
-  public destroy() {
+  destroy() {
     this._element.remove();
     this._eventStream.end();
   }
 
-  public getElement(): HTMLElement {
+  getElement(): HTMLElement {
     return this._element;
   }
-  public getEventStream(): Kefir.Observable<any, any> {
+  getEventStream(): Kefir.Observable<any, any> {
     return this._eventStream;
   }
 
-  public setEnabled(value: boolean) {
+  setEnabled(value: boolean) {
     this._setEnabled(value);
   }
 
-  public update() {
+  update() {
     throw new Error('not implemented');
   }
 
-  public isEnabled(): boolean {
+  isEnabled(): boolean {
     return this._isEnabled;
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/more-parent-accessory-button-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/buttons/more-parent-accessory-button-view.ts
@@ -1,7 +1,7 @@
 import CreateParentAccessoryButtonView from './create-parent-accessory-button-view';
 
 export default class MoreParentAccessoryButtonView extends CreateParentAccessoryButtonView {
-  public constructor() {
+  constructor() {
     super();
 
     // New Gmail left nav does not have a "more" parent level accessory icon (only "create").

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-dropdown-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-dropdown-view.ts
@@ -4,7 +4,7 @@ export default class GmailDropdownView {
   private _containerElement: HTMLElement;
   private _contentElement: HTMLElement;
 
-  public constructor() {
+  constructor() {
     this._containerElement = document.createElement('div');
     this._containerElement.setAttribute('class', 'inboxsdk__menu');
 
@@ -16,15 +16,15 @@ export default class GmailDropdownView {
     blockAndReemiteKeyboardEvents(this._containerElement);
   }
 
-  public destroy() {
+  destroy() {
     this._containerElement.remove();
   }
 
-  public getContainerElement() {
+  getContainerElement() {
     return this._containerElement;
   }
 
-  public getContentElement() {
+  getContentElement() {
     return this._contentElement;
   }
 }

--- a/src/platform-implementation-js/lib/ErrorCollector.ts
+++ b/src/platform-implementation-js/lib/ErrorCollector.ts
@@ -11,11 +11,11 @@ export default class ErrorCollector {
   private _errorLogs: Array<ErrorLog> = [];
   private _hasReported: boolean = false;
 
-  public constructor(name: string) {
+  constructor(name: string) {
     this._name = name;
   }
 
-  public run<T>(name: string, cb: () => T): T | null {
+  run<T>(name: string, cb: () => T): T | null {
     if (this._hasReported) {
       throw new Error('Has already reported');
     }
@@ -31,7 +31,7 @@ export default class ErrorCollector {
     }
   }
 
-  public report(errorDataCb: () => any) {
+  report(errorDataCb: () => any) {
     if (this._hasReported) {
       throw new Error('Has already reported');
     }
@@ -44,15 +44,15 @@ export default class ErrorCollector {
     }
   }
 
-  public getErrorLogs(): ReadonlyArray<ErrorLog> {
+  getErrorLogs(): ReadonlyArray<ErrorLog> {
     return this._errorLogs;
   }
 
-  public runCount(): number {
+  runCount(): number {
     return this._runCount;
   }
 
-  public errorCount(): number {
+  errorCount(): number {
     return this._errorLogs.length;
   }
 }

--- a/src/platform-implementation-js/lib/Membrane.test.ts
+++ b/src/platform-implementation-js/lib/Membrane.test.ts
@@ -4,8 +4,8 @@ import Membrane, { Mapper } from './Membrane';
 
 class FooDriver {}
 class Foo {
-  public fooDriver: FooDriver;
-  public constructor(fooDriver: FooDriver) {
+  fooDriver: FooDriver;
+  constructor(fooDriver: FooDriver) {
     this.fooDriver = fooDriver;
   }
 }

--- a/src/platform-implementation-js/lib/Membrane.ts
+++ b/src/platform-implementation-js/lib/Membrane.ts
@@ -12,11 +12,11 @@ export default class Membrane {
   private _mappers: Map<any, MapperFn<any>>;
   private _map: WeakMap<any, any> = new WeakMap();
 
-  public constructor(mappers: Array<Mapper<any>>) {
+  constructor(mappers: Array<Mapper<any>>) {
     this._mappers = new Map(mappers);
   }
 
-  public get(wet: any): any {
+  get(wet: any): any {
     let dry = this._map.get(wet);
     if (!dry) {
       const mapperFn = this._mappers.get(wet.constructor);

--- a/src/platform-implementation-js/lib/ScrollableContainByScreen.ts
+++ b/src/platform-implementation-js/lib/ScrollableContainByScreen.ts
@@ -9,7 +9,7 @@ export default class ScrollableContainByScreen {
   private _manualRepositions = kefirBus<null, any>();
   private _stopper = kefirStopper();
 
-  public constructor(
+  constructor(
     element: HTMLElement,
     anchorPoint: HTMLElement,
     options: Options
@@ -29,11 +29,11 @@ export default class ScrollableContainByScreen {
       });
   }
 
-  public reposition() {
+  reposition() {
     this._manualRepositions.emit(null);
   }
 
-  public destroy() {
+  destroy() {
     this._stopper.destroy();
   }
 }

--- a/src/platform-implementation-js/lib/common-page-communicator.ts
+++ b/src/platform-implementation-js/lib/common-page-communicator.ts
@@ -5,28 +5,28 @@ import Logger from './logger';
 import { CommonAjaxOpts } from '../../common/ajax';
 
 export default class CommonPageCommunicator {
-  public ajaxInterceptStream: Kefir.Observable<any, never>;
+  ajaxInterceptStream: Kefir.Observable<any, never>;
 
-  public constructor() {
+  constructor() {
     this.ajaxInterceptStream = Kefir.fromEvents<any, never>(
       document,
       'inboxSDKajaxIntercept'
     ).map((x) => x.detail);
   }
 
-  public getUserEmailAddress(): string {
+  getUserEmailAddress(): string {
     const s = document.head.getAttribute('data-inboxsdk-user-email-address');
     if (typeof s !== 'string') throw new Error('should not happen');
     return s;
   }
 
-  public getUserLanguage(): string {
+  getUserLanguage(): string {
     const s = document.head.getAttribute('data-inboxsdk-user-language');
     if (typeof s !== 'string') throw new Error('should not happen');
     return s;
   }
 
-  public getIkValue(): string {
+  getIkValue(): string {
     const ownIk = document.head.getAttribute('data-inboxsdk-ik-value');
     if (ownIk) {
       return ownIk;
@@ -45,11 +45,11 @@ export default class CommonPageCommunicator {
     throw new Error("Failed to look up 'ik' value");
   }
 
-  public isUsingSyncAPI(): boolean {
+  isUsingSyncAPI(): boolean {
     return false;
   }
 
-  public async getXsrfToken(): Promise<string> {
+  async getXsrfToken(): Promise<string> {
     const existingHeader = document.head.getAttribute(
       'data-inboxsdk-xsrf-token'
     );
@@ -67,7 +67,7 @@ export default class CommonPageCommunicator {
     }
   }
 
-  public async getBtaiHeader(): Promise<string> {
+  async getBtaiHeader(): Promise<string> {
     const existingHeader = document.head.getAttribute(
       'data-inboxsdk-btai-header'
     );
@@ -85,13 +85,13 @@ export default class CommonPageCommunicator {
     }
   }
 
-  public resolveUrlRedirects(url: string): Promise<string> {
+  resolveUrlRedirects(url: string): Promise<string> {
     return this.pageAjax({ url, method: 'HEAD' }).then(
       (result) => result.responseURL
     );
   }
 
-  public pageAjax(
+  pageAjax(
     opts: CommonAjaxOpts
   ): Promise<{ text: string; responseURL: string }> {
     const id = `${Date.now()}-${Math.random()}`;
@@ -128,7 +128,7 @@ export default class CommonPageCommunicator {
     return promise;
   }
 
-  public silenceGmailErrorsForAMoment(): () => void {
+  silenceGmailErrorsForAMoment(): () => void {
     document.dispatchEvent(
       new CustomEvent('inboxSDKsilencePageErrors', {
         bubbles: false,
@@ -158,7 +158,7 @@ export default class CommonPageCommunicator {
     return unsilence;
   }
 
-  public registerAllowedHashLinkStartTerm(term: string) {
+  registerAllowedHashLinkStartTerm(term: string) {
     document.dispatchEvent(
       new CustomEvent('inboxSDKregisterAllowedHashLinkStartTerm', {
         bubbles: false,

--- a/src/platform-implementation-js/lib/handler-registry.ts
+++ b/src/platform-implementation-js/lib/handler-registry.ts
@@ -9,7 +9,7 @@ export default class HandlerRegistry<T> {
   private _pendingHandlers: Array<Handler<T>> = [];
   private _handlers: Array<Handler<T>> = [];
 
-  public registerHandler(handler: Handler<T>): () => void {
+  registerHandler(handler: Handler<T>): () => void {
     if (this._pendingHandlers.indexOf(handler) === -1) {
       this._pendingHandlers.push(handler);
 
@@ -33,7 +33,7 @@ export default class HandlerRegistry<T> {
     };
   }
 
-  public addTarget(target: T) {
+  addTarget(target: T) {
     this._targets.push(target);
 
     // TODO should we error if an object without an .on method is added?
@@ -50,11 +50,11 @@ export default class HandlerRegistry<T> {
     this._informHandlersOfTarget(target);
   }
 
-  public removeTarget(target: T) {
+  removeTarget(target: T) {
     remove(this._targets, (t) => t === target);
   }
 
-  public dumpHandlers() {
+  dumpHandlers() {
     this._pendingHandlers = [];
     this._handlers = [];
   }

--- a/src/platform-implementation-js/lib/logger.ts
+++ b/src/platform-implementation-js/lib/logger.ts
@@ -63,7 +63,7 @@ export default class Logger {
   private _appId: string;
   private _isMaster: boolean;
 
-  public constructor(
+  constructor(
     appId: string,
     opts: any,
     loaderVersion: string,
@@ -113,22 +113,22 @@ export default class Logger {
     }
   }
 
-  public setUserEmailAddress(email: string) {
+  setUserEmailAddress(email: string) {
     _extensionUserEmailHash = hashEmail(email);
   }
 
-  public shouldTrackEverything(): boolean {
+  shouldTrackEverything(): boolean {
     return (
       _extensionUserEmailHash ===
       'ca05afe92819df590a4196c31814fdb24050e8f49d8a41613f3d6cfb5729c785'
     );
   }
 
-  public setIsUsingSyncAPI(isUsing: boolean) {
+  setIsUsingSyncAPI(isUsing: boolean) {
     _isUsingSyncAPI = isUsing;
   }
 
-  public static run<T>(cb: () => T, details?: any): T {
+  static run<T>(cb: () => T, details?: any): T {
     try {
       return cb();
     } catch (err) {
@@ -137,7 +137,7 @@ export default class Logger {
     }
   }
 
-  public run<T>(cb: () => T, details?: any): T {
+  run<T>(cb: () => T, details?: any): T {
     try {
       return cb();
     } catch (err) {
@@ -146,19 +146,19 @@ export default class Logger {
     }
   }
 
-  public static error(err: Error | unknown, details?: any) {
+  static error(err: Error | unknown, details?: any) {
     _logError(err, details, undefined, false);
   }
 
-  public error(err: Error | unknown, details?: any) {
+  error(err: Error | unknown, details?: any) {
     _logError(err, details, this._appId, false);
   }
 
-  public errorApp(err: Error | unknown, details?: any) {
+  errorApp(err: Error | unknown, details?: any) {
     _logError(err, details, this._appId, true);
   }
 
-  public errorSite(err: Error | unknown, details?: any) {
+  errorSite(err: Error | unknown, details?: any) {
     // Only the first logger instance reports Site errors.
     if (!this._isMaster) {
       return;
@@ -167,13 +167,13 @@ export default class Logger {
   }
 
   // Should only be used by the InboxSDK users for their own app events.
-  public eventApp(name: string, details?: any) {
+  eventApp(name: string, details?: any) {
     _trackEvent(this._appId, 'app', name, details);
   }
 
   // For tracking app events that are possibly triggered by the user. Extensions
   // can opt out of this with a flag passed to InboxSDK.load().
-  public eventSdkActive(name: string, details?: any) {
+  eventSdkActive(name: string, details?: any) {
     if (!_extensionUseEventTracking) {
       return;
     }
@@ -183,7 +183,7 @@ export default class Logger {
   // Track events unrelated to user activity about how the app uses the SDK.
   // Examples include the app being initialized, and calls to any of the
   // register___ViewHandler functions.
-  public eventSdkPassive(name: string, details?: any, sensitive?: boolean) {
+  eventSdkPassive(name: string, details?: any, sensitive?: boolean) {
     if (sensitive && !isStreakAppId(this._appId)) {
       // do not log events if they were marked as sensitive
       return;
@@ -193,7 +193,7 @@ export default class Logger {
   }
 
   // Track Site events.
-  public eventSite(name: string, details?: any) {
+  eventSite(name: string, details?: any) {
     // Only the first logger instance reports Site events.
     if (!this._isMaster) {
       return;
@@ -201,7 +201,7 @@ export default class Logger {
     _trackEvent(this._appId, 'gmail', name, details);
   }
 
-  public deprecationWarning(name: string, suggestion?: string) {
+  deprecationWarning(name: string, suggestion?: string) {
     console.warn(
       `InboxSDK: ${name} is deprecated.` +
         (suggestion ? ` Please use ${suggestion} instead.` : '')
@@ -214,14 +214,14 @@ export default class Logger {
     }
   }
 
-  public getAppLogger(): AppLogger {
+  getAppLogger(): AppLogger {
     return {
       error: (err, details) => this.errorApp(err, details),
       event: (name, details) => this.eventApp(name, details),
     };
   }
 
-  public trackFunctionPerformance(
+  trackFunctionPerformance(
     fn: Function,
     sampleRate: number,
     details: { type: string }

--- a/src/platform-implementation-js/lib/persistent-queue.ts
+++ b/src/platform-implementation-js/lib/persistent-queue.ts
@@ -7,7 +7,7 @@ export default class PersistentQueue<T> {
   private _fallbackQueue: T[] = [];
   private _sid: string;
 
-  public constructor(id: string) {
+  constructor(id: string) {
     this._sid = 'inboxsdk__persistentqueue_' + id;
   }
 
@@ -27,7 +27,7 @@ export default class PersistentQueue<T> {
     localStorage.removeItem(this._sid);
   }
 
-  public add(val: T) {
+  add(val: T) {
     let success = false;
     if (typeof localStorage !== 'undefined') {
       try {
@@ -44,7 +44,7 @@ export default class PersistentQueue<T> {
     }
   }
 
-  public remove(): T | undefined {
+  remove(): T | undefined {
     let ret;
     if (typeof localStorage !== 'undefined') {
       try {
@@ -64,7 +64,7 @@ export default class PersistentQueue<T> {
     return ret;
   }
 
-  public removeAll(): T[] {
+  removeAll(): T[] {
     let ret: any[] | void = undefined;
     if (typeof localStorage !== 'undefined') {
       try {
@@ -83,7 +83,7 @@ export default class PersistentQueue<T> {
     return ret;
   }
 
-  public peekAll(): T[] {
+  peekAll(): T[] {
     let ret: any[] | void = undefined;
     if (typeof localStorage !== 'undefined') {
       try {
@@ -99,7 +99,7 @@ export default class PersistentQueue<T> {
     return ret;
   }
 
-  public clear() {
+  clear() {
     if (typeof localStorage !== 'undefined') {
       try {
         this._clearSavedQueue();

--- a/src/platform-implementation-js/lib/safe-event-emitter.ts
+++ b/src/platform-implementation-js/lib/safe-event-emitter.ts
@@ -7,7 +7,7 @@ import Logger from './logger';
 // Version of EventEmitter where any exceptions thrown by event handlers are
 // caught. This is used to catch exceptions from application code.
 export default class SafeEventEmitter extends EventEmitter {
-  public emit(event: string, ...args: Array<any>): boolean {
+  emit(event: string, ...args: Array<any>): boolean {
     try {
       return super.emit.apply(this, arguments as any);
     } catch (e) {

--- a/src/platform-implementation-js/lib/stopper-pool.ts
+++ b/src/platform-implementation-js/lib/stopper-pool.ts
@@ -8,11 +8,9 @@ export default class StopperPool<V, E> {
   private _streamCount: number = 0;
   private _ended: boolean = false;
   private _pool = Kefir.pool<V, E>();
-  public stream: Kefir.Observable<V, E>;
+  stream: Kefir.Observable<V, E>;
 
-  public constructor(
-    streams: Kefir.Observable<V, E> | Kefir.Observable<V, E>[]
-  ) {
+  constructor(streams: Kefir.Observable<V, E> | Kefir.Observable<V, E>[]) {
     this.stream = this._pool
       .filter(() => {
         this._streamCount--;
@@ -34,7 +32,7 @@ export default class StopperPool<V, E> {
     this.add(streams);
   }
 
-  public add(newStreams: Kefir.Observable<V, E> | Kefir.Observable<V, E>[]) {
+  add(newStreams: Kefir.Observable<V, E> | Kefir.Observable<V, E>[]) {
     if (this._ended) {
       throw new Error('Tried to add a stream to a stopped StopperPool');
     }
@@ -45,7 +43,7 @@ export default class StopperPool<V, E> {
     );
   }
 
-  public getSize(): number {
+  getSize(): number {
     return this._streamCount;
   }
 }

--- a/src/platform-implementation-js/namespaces/butter-bar.test.ts
+++ b/src/platform-implementation-js/namespaces/butter-bar.test.ts
@@ -11,10 +11,10 @@ class MockButterBarDriver {
   private _currentMessage: any = null;
   private _hideGmailMessageCount: number = 0;
 
-  public getNoticeAvailableStream() {
+  getNoticeAvailableStream() {
     return this._openBus;
   }
-  public showMessage(options: any) {
+  showMessage(options: any) {
     const num = ++this._showMessageCount;
     this._currentMessage = options;
     return {
@@ -26,13 +26,13 @@ class MockButterBarDriver {
       },
     };
   }
-  public getSharedMessageQueue() {
+  getSharedMessageQueue() {
     return _.cloneDeep(this._queue);
   }
-  public setSharedMessageQueue(queue: any[]) {
+  setSharedMessageQueue(queue: any[]) {
     this._queue = _.cloneDeep(queue);
   }
-  public hideGmailMessage() {
+  hideGmailMessage() {
     this._hideGmailMessageCount++;
   }
 }

--- a/src/platform-implementation-js/namespaces/butter-bar.ts
+++ b/src/platform-implementation-js/namespaces/butter-bar.ts
@@ -25,7 +25,7 @@ const memberMap = new WeakMap<
 
 // documented in src/docs/
 export default class ButterBar {
-  public constructor(appId: string, driver: Driver) {
+  constructor(appId: string, driver: Driver) {
     const members = {
       driver,
       messagesByKey: new Map(),
@@ -34,7 +34,7 @@ export default class ButterBar {
     memberMap.set(this, members);
   }
 
-  public showMessage(options: any): ButterBarMessage {
+  showMessage(options: any): ButterBarMessage {
     defaults(options, {
       priority: 0,
       time: 15 * 1000,
@@ -128,7 +128,7 @@ export default class ButterBar {
     return message;
   }
 
-  public showLoading(options: any = {}): ButterBarMessage {
+  showLoading(options: any = {}): ButterBarMessage {
     defaults(options, {
       text: 'Loading...',
       priority: -3,
@@ -142,7 +142,7 @@ export default class ButterBar {
     return this.showMessage(options);
   }
 
-  public showError(options: any): ButterBarMessage {
+  showError(options: any): ButterBarMessage {
     defaults(options, {
       priority: 100,
       className: 'inboxsdk__butterbar_error',
@@ -150,7 +150,7 @@ export default class ButterBar {
     return this.showMessage(options);
   }
 
-  public showSaving(options: any = {}): any {
+  showSaving(options: any = {}): any {
     defaults(options, {
       text: 'Saving...',
       confirmationText: 'Saved',
@@ -185,7 +185,7 @@ export default class ButterBar {
     return deferred;
   }
 
-  public hideMessage(messageKey: any | string) {
+  hideMessage(messageKey: any | string) {
     if (messageKey) {
       const members = get(memberMap, this);
       const message = members.messagesByKey.get(messageKey);
@@ -195,7 +195,7 @@ export default class ButterBar {
     }
   }
 
-  public hideGmailMessage() {
+  hideGmailMessage() {
     const members = get(memberMap, this);
     const butterBarDriver = members.driver.getButterBarDriver();
 

--- a/src/platform-implementation-js/views/SimpleElementView.ts
+++ b/src/platform-implementation-js/views/SimpleElementView.ts
@@ -1,15 +1,15 @@
 import SafeEventEmitter from '../lib/safe-event-emitter';
 
 export default class SimpleElementView extends SafeEventEmitter {
-  public el: HTMLElement;
-  public destroyed: boolean = false;
+  el: HTMLElement;
+  destroyed: boolean = false;
 
-  public constructor(el: HTMLElement) {
+  constructor(el: HTMLElement) {
     super();
     this.el = el;
   }
 
-  public destroy() {
+  destroy() {
     if (this.destroyed) return;
     this.destroyed = true;
     this.emit('destroy');

--- a/src/platform-implementation-js/views/compose-button-view.ts
+++ b/src/platform-implementation-js/views/compose-button-view.ts
@@ -25,9 +25,9 @@ const memberMap = new WeakMap<
 >();
 
 export default class ComposeButtonView extends EventEmitter {
-  public destroyed: boolean = false;
+  destroyed: boolean = false;
 
-  public constructor(
+  constructor(
     optionsPromise: Promise<Options | null | undefined>,
     composeViewDriver: ComposeViewDriver,
     driver: Driver
@@ -48,7 +48,7 @@ export default class ComposeButtonView extends EventEmitter {
     });
   }
 
-  public showTooltip(tooltipDescriptor: TooltipDescriptor) {
+  showTooltip(tooltipDescriptor: TooltipDescriptor) {
     const members = get(memberMap, this);
     members.driver
       .getLogger()
@@ -65,7 +65,7 @@ export default class ComposeButtonView extends EventEmitter {
     });
   }
 
-  public closeTooltip() {
+  closeTooltip() {
     const members = get(memberMap, this);
     members.optionsPromise.then((options) => {
       if (!options) return;

--- a/src/platform-implementation-js/views/compose-view.ts
+++ b/src/platform-implementation-js/views/compose-view.ts
@@ -20,9 +20,9 @@ const memberMap = ud.defonce(module, () => new WeakMap());
 
 // documented in src/docs/
 export default class ComposeView extends EventEmitter {
-  public destroyed: boolean = false;
+  destroyed: boolean = false;
 
-  public constructor(
+  constructor(
     driver: Driver,
     composeViewImplementation: ComposeViewDriver,
     membrane: Membrane
@@ -81,7 +81,7 @@ export default class ComposeView extends EventEmitter {
     });
   }
 
-  public addButton(buttonDescriptor: any) {
+  addButton(buttonDescriptor: any) {
     const members = get(memberMap, this);
     const buttonDescriptorStream = kefirCast(Kefir, buttonDescriptor);
 
@@ -109,7 +109,7 @@ export default class ComposeView extends EventEmitter {
 	}
 	*/
 
-  public addComposeNotice(composeNoticeDescriptor?: {
+  addComposeNotice(composeNoticeDescriptor?: {
     height?: number;
     orderHint?: number;
   }): ComposeNotice {
@@ -118,7 +118,7 @@ export default class ComposeView extends EventEmitter {
     );
   }
 
-  public addStatusBar(statusBarDescriptor?: {
+  addStatusBar(statusBarDescriptor?: {
     height?: number;
     orderHint?: number;
     addAboveNativeStatusBar?: boolean;
@@ -128,11 +128,11 @@ export default class ComposeView extends EventEmitter {
     );
   }
 
-  public hideNativeStatusBar(): () => void {
+  hideNativeStatusBar(): () => void {
     return get(memberMap, this).composeViewImplementation.hideNativeStatusBar();
   }
 
-  public addRecipientRow(options: any): { destroy(): void } {
+  addRecipientRow(options: any): { destroy(): void } {
     return {
       destroy: get(memberMap, this).composeViewImplementation.addRecipientRow(
         kefirCast(Kefir, options)
@@ -140,56 +140,56 @@ export default class ComposeView extends EventEmitter {
     };
   }
 
-  public forceRecipientRowsOpen(): () => void {
+  forceRecipientRowsOpen(): () => void {
     return get(
       memberMap,
       this
     ).composeViewImplementation.forceRecipientRowsOpen();
   }
 
-  public hideNativeRecipientRows(): () => void {
+  hideNativeRecipientRows(): () => void {
     return get(
       memberMap,
       this
     ).composeViewImplementation.hideNativeRecipientRows();
   }
 
-  public hideRecipientArea(): () => void {
+  hideRecipientArea(): () => void {
     return get(memberMap, this).composeViewImplementation.hideRecipientArea();
   }
 
-  public close() {
+  close() {
     get(memberMap, this).composeViewImplementation.close();
   }
 
-  public send(
+  send(
     { sendAndArchive }: { sendAndArchive: boolean } = { sendAndArchive: false }
   ) {
     get(memberMap, this).composeViewImplementation.send({ sendAndArchive });
   }
 
-  public discard() {
+  discard() {
     get(memberMap, this).composeViewImplementation.discard();
   }
 
-  public getMetadataForm(): HTMLElement {
+  getMetadataForm(): HTMLElement {
     return get(
       memberMap,
       this
     ).composeViewImplementation.getMetadataFormElement();
   }
 
-  public getSubjectInput(): HTMLInputElement {
+  getSubjectInput(): HTMLInputElement {
     return get(memberMap, this).composeViewImplementation.getSubjectInput();
   }
 
-  public getBodyElement(): HTMLElement {
+  getBodyElement(): HTMLElement {
     return get(memberMap, this).composeViewImplementation.getBodyElement();
   }
 
   // NOT DOCUMENTED BECAUSE NOT SURE IF API USERS NEED THIS
   // TODO remove?
-  public getComposeID(): string {
+  getComposeID(): string {
     const { driver, composeViewImplementation } = get(memberMap, this);
     driver.getLogger().deprecationWarning('composeView.getComposeID');
     if (driver.getOpts().REQUESTED_API_VERSION !== 1) {
@@ -198,12 +198,12 @@ export default class ComposeView extends EventEmitter {
     return composeViewImplementation.getComposeID();
   }
 
-  public getInitialMessageID(): string {
+  getInitialMessageID(): string {
     return get(memberMap, this).composeViewImplementation.getInitialMessageID();
   }
 
   /* deprecated */
-  public getMessageID(): string {
+  getMessageID(): string {
     const { driver, composeViewImplementation } = get(memberMap, this);
     driver
       .getLogger()
@@ -214,69 +214,69 @@ export default class ComposeView extends EventEmitter {
     return composeViewImplementation.getMessageID();
   }
 
-  public getThreadID(): string {
+  getThreadID(): string {
     return get(memberMap, this).composeViewImplementation.getThreadID();
   }
 
-  public getDraftID(): Promise<string | null | void> {
+  getDraftID(): Promise<string | null | void> {
     return get(memberMap, this).composeViewImplementation.getDraftID();
   }
 
-  public getCurrentDraftID(): Promise<string | null | void> {
+  getCurrentDraftID(): Promise<string | null | void> {
     return get(memberMap, this).composeViewImplementation.getCurrentDraftID();
   }
 
-  public getHTMLContent(): string {
+  getHTMLContent(): string {
     return get(memberMap, this).composeViewImplementation.getHTMLContent();
   }
 
-  public getSelectedBodyHTML(): string | null | void {
+  getSelectedBodyHTML(): string | null | void {
     return (
       get(memberMap, this).composeViewImplementation.getSelectedBodyHTML() || ''
     );
   }
 
-  public getSelectedBodyText(): string | null | void {
+  getSelectedBodyText(): string | null | void {
     return (
       get(memberMap, this).composeViewImplementation.getSelectedBodyText() || ''
     );
   }
 
-  public getSubject(): string {
+  getSubject(): string {
     return get(memberMap, this).composeViewImplementation.getSubject();
   }
 
-  public getTextContent(): string {
+  getTextContent(): string {
     return get(memberMap, this).composeViewImplementation.getTextContent();
   }
 
-  public getToRecipients(): Contact[] {
+  getToRecipients(): Contact[] {
     return get(memberMap, this).composeViewImplementation.getToRecipients();
   }
 
-  public getCcRecipients(): Contact[] {
+  getCcRecipients(): Contact[] {
     return get(memberMap, this).composeViewImplementation.getCcRecipients();
   }
 
-  public getBccRecipients(): Contact[] {
+  getBccRecipients(): Contact[] {
     return get(memberMap, this).composeViewImplementation.getBccRecipients();
   }
 
-  public insertTextIntoBodyAtCursor(text: string): HTMLElement | null | void {
+  insertTextIntoBodyAtCursor(text: string): HTMLElement | null | void {
     return get(
       memberMap,
       this
     ).composeViewImplementation.insertBodyTextAtCursor(text);
   }
 
-  public insertHTMLIntoBodyAtCursor(html: string): HTMLElement | null | void {
+  insertHTMLIntoBodyAtCursor(html: string): HTMLElement | null | void {
     return get(
       memberMap,
       this
     ).composeViewImplementation.insertBodyHTMLAtCursor(html);
   }
 
-  public insertLinkChipIntoBodyAtCursor(
+  insertLinkChipIntoBodyAtCursor(
     text: string,
     url: string,
     iconUrl: string
@@ -300,7 +300,7 @@ export default class ComposeView extends EventEmitter {
     });
   }
 
-  public insertLinkIntoBodyAtCursor(
+  insertLinkIntoBodyAtCursor(
     text: string,
     url: string
   ): HTMLElement | null | void {
@@ -310,41 +310,41 @@ export default class ComposeView extends EventEmitter {
     );
   }
 
-  public isForward(): boolean {
+  isForward(): boolean {
     return get(memberMap, this).composeViewImplementation.isForward();
   }
 
-  public isInlineReplyForm(): boolean {
+  isInlineReplyForm(): boolean {
     return get(memberMap, this).composeViewImplementation.isInlineReplyForm();
   }
 
-  public isFullscreen(): boolean {
+  isFullscreen(): boolean {
     return get(memberMap, this).composeViewImplementation.isFullscreen();
   }
 
-  public setFullscreen(fullscreen: boolean) {
+  setFullscreen(fullscreen: boolean) {
     get(memberMap, this).composeViewImplementation.setFullscreen(fullscreen);
   }
 
-  public isMinimized(): boolean {
+  isMinimized(): boolean {
     return get(memberMap, this).composeViewImplementation.isMinimized();
   }
 
-  public setMinimized(minimized: boolean) {
+  setMinimized(minimized: boolean) {
     get(memberMap, this).composeViewImplementation.setMinimized(minimized);
   }
 
-  public setTitleBarColor(color: string): () => void {
+  setTitleBarColor(color: string): () => void {
     return get(memberMap, this).composeViewImplementation.setTitleBarColor(
       color
     );
   }
 
-  public setTitleBarText(text: string): () => void {
+  setTitleBarText(text: string): () => void {
     return get(memberMap, this).composeViewImplementation.setTitleBarText(text);
   }
 
-  public async popOut(): Promise<ComposeView> {
+  async popOut(): Promise<ComposeView> {
     const nextComposeViewDriverPromise = get(
       memberMap,
       this
@@ -354,50 +354,50 @@ export default class ComposeView extends EventEmitter {
     return get(memberMap, this).membrane.get(nextComposeViewDriver);
   }
 
-  public isReply(): boolean {
+  isReply(): boolean {
     return get(memberMap, this).composeViewImplementation.isReply();
   }
 
-  public setToRecipients(emails: string[]) {
+  setToRecipients(emails: string[]) {
     get(memberMap, this).composeViewImplementation.setToRecipients(emails);
   }
 
-  public setCcRecipients(emails: string[]) {
+  setCcRecipients(emails: string[]) {
     get(memberMap, this).composeViewImplementation.setCcRecipients(emails);
   }
 
-  public setBccRecipients(emails: string[]) {
+  setBccRecipients(emails: string[]) {
     get(memberMap, this).composeViewImplementation.setBccRecipients(emails);
   }
 
-  public getFromContact(): Contact {
+  getFromContact(): Contact {
     return get(memberMap, this).composeViewImplementation.getFromContact();
   }
 
-  public getFromContactChoices(): Contact[] {
+  getFromContactChoices(): Contact[] {
     return get(
       memberMap,
       this
     ).composeViewImplementation.getFromContactChoices();
   }
 
-  public setFromEmail(email: string) {
+  setFromEmail(email: string) {
     get(memberMap, this).composeViewImplementation.setFromEmail(email);
   }
 
-  public setSubject(text: string) {
+  setSubject(text: string) {
     get(memberMap, this).composeViewImplementation.setSubject(text);
   }
 
-  public setBodyHTML(html: string) {
+  setBodyHTML(html: string) {
     get(memberMap, this).composeViewImplementation.setBodyHTML(html);
   }
 
-  public setBodyText(text: string) {
+  setBodyText(text: string) {
     get(memberMap, this).composeViewImplementation.setBodyText(text);
   }
 
-  public async attachFiles(files: Blob[]): Promise<void> {
+  async attachFiles(files: Blob[]): Promise<void> {
     if (files.length === 0) {
       return;
     }
@@ -409,7 +409,7 @@ export default class ComposeView extends EventEmitter {
     );
   }
 
-  public async attachInlineFiles(files: Blob[]): Promise<void> {
+  async attachInlineFiles(files: Blob[]): Promise<void> {
     if (files.length === 0) {
       return;
     }
@@ -422,7 +422,7 @@ export default class ComposeView extends EventEmitter {
   }
 
   // Old alias that we should keep around until we're sure no one is using it.
-  public dragFilesIntoCompose(files: Blob[]): Promise<void> {
+  dragFilesIntoCompose(files: Blob[]): Promise<void> {
     const { driver } = get(memberMap, this);
     driver
       .getLogger()
@@ -437,11 +437,11 @@ export default class ComposeView extends EventEmitter {
   }
 
   //NOT DOCUMENTED BECAUSE STREAK-ONLY FOR NOW
-  public getElement(): HTMLElement {
+  getElement(): HTMLElement {
     return get(memberMap, this).composeViewImplementation.getElement();
   }
 
-  public registerRequestModifier(
+  registerRequestModifier(
     modifier: (composeParams: {
       body: string;
     }) => { body: string } | Promise<{ body: string }>
@@ -451,22 +451,22 @@ export default class ComposeView extends EventEmitter {
     );
   }
 
-  public replaceSendButton({ el }: { el: HTMLElement }): () => void {
+  replaceSendButton({ el }: { el: HTMLElement }): () => void {
     return get(memberMap, this).composeViewImplementation.replaceSendButton(el);
   }
 
-  public hideDiscardButton(): () => void {
+  hideDiscardButton(): () => void {
     return get(memberMap, this).composeViewImplementation.hideDiscardButton();
   }
 
-  public ensureFormattingToolbarIsHidden() {
+  ensureFormattingToolbarIsHidden() {
     get(
       memberMap,
       this
     ).composeViewImplementation.ensureFormattingToolbarIsHidden();
   }
 
-  public ensureAppButtonToolbarsAreClosed() {
+  ensureAppButtonToolbarsAreClosed() {
     get(
       memberMap,
       this
@@ -474,7 +474,7 @@ export default class ComposeView extends EventEmitter {
   }
 
   // TODO remove
-  public overrideEditSubject() {
+  overrideEditSubject() {
     const { driver, composeViewImplementation } = get(memberMap, this);
     driver.getLogger().deprecationWarning('composeView.overrideEditSubject');
     if (driver.getOpts().REQUESTED_API_VERSION !== 1) {

--- a/src/platform-implementation-js/views/keyboard-shortcut-handle.ts
+++ b/src/platform-implementation-js/views/keyboard-shortcut-handle.ts
@@ -2,16 +2,16 @@ import EventEmitter from '../lib/safe-event-emitter';
 
 // documented in src/docs/
 export default class KeyboardShortcutHandle extends EventEmitter {
-  public chord: string;
-  public description: string;
+  chord: string;
+  description: string;
 
-  public constructor(chord: string, description: string) {
+  constructor(chord: string, description: string) {
     super();
     this.chord = chord;
     this.description = description;
   }
 
-  public remove() {
+  remove() {
     this.emit('destroy');
   }
 }

--- a/src/platform-implementation-js/widgets/buttons/basic-button-view-controller.ts
+++ b/src/platform-implementation-js/widgets/buttons/basic-button-view-controller.ts
@@ -21,7 +21,7 @@ export default class BasicButtonViewController {
   private _view: ButtonViewI;
   private _stopper = kefirStopper();
 
-  public constructor(options: Options) {
+  constructor(options: Options) {
     this._activateFunction = options.activateFunction || options.onClick;
     this._view = options.buttonView;
 
@@ -33,32 +33,32 @@ export default class BasicButtonViewController {
       });
   }
 
-  public getStopper(): Kefir.Observable<null, never> {
+  getStopper(): Kefir.Observable<null, never> {
     return this._stopper;
   }
 
-  public destroy() {
+  destroy() {
     this._activateFunction = null;
     this._view.destroy();
     this._stopper.destroy();
   }
 
-  public update(options: Options) {
+  update(options: Options) {
     this.getView().update(options);
     this.setActivateFunction(
       options && (options.activateFunction || options.onClick)
     );
   }
 
-  public getView(): ButtonViewI {
+  getView(): ButtonViewI {
     return this._view;
   }
 
-  public setActivateFunction(f: null | undefined | ((event: any) => void)) {
+  setActivateFunction(f: null | undefined | ((event: any) => void)) {
     this._activateFunction = f;
   }
 
-  public activate() {
+  activate() {
     if (this._activateFunction) {
       this._activateFunction({});
     }

--- a/src/platform-implementation-js/widgets/buttons/dropdown-view.ts
+++ b/src/platform-implementation-js/widgets/buttons/dropdown-view.ts
@@ -15,8 +15,8 @@ interface Options {
 // documented in src/docs/
 export default class DropdownView extends EventEmitter {
   private _dropdownViewDriver: any;
-  public destroyed: boolean = false;
-  /*deprecated*/ public closed: boolean = false;
+  destroyed: boolean = false;
+  /*deprecated*/ closed: boolean = false;
   private _options: Options;
   private _userPlacementOptions: ContainByScreenOptions = { hAlign: 'left' };
   private _scrollableContainByScreen:
@@ -24,9 +24,9 @@ export default class DropdownView extends EventEmitter {
     | null
     | undefined = null;
   private _didInsertContainerEl: boolean;
-  public el: HTMLElement;
+  el: HTMLElement;
 
-  public constructor(
+  constructor(
     dropdownViewDriver: any,
     anchorElement: HTMLElement,
     options: Options | null | undefined
@@ -124,7 +124,7 @@ export default class DropdownView extends EventEmitter {
     });
   }
 
-  public setPlacementOptions(options: ContainByScreenOptions) {
+  setPlacementOptions(options: ContainByScreenOptions) {
     if (this._options.manualPosition) {
       // eslint-disable-next-line no-console
       console.error(
@@ -136,7 +136,7 @@ export default class DropdownView extends EventEmitter {
     this.emit('_placementOptionsUpdated');
   }
 
-  public close() {
+  close() {
     if (!this.destroyed) {
       this.destroyed = this.closed = true;
       if (this._scrollableContainByScreen) {
@@ -150,7 +150,7 @@ export default class DropdownView extends EventEmitter {
     }
   }
 
-  public reposition() {
+  reposition() {
     if (this._scrollableContainByScreen) {
       this._scrollableContainByScreen.reposition();
     }

--- a/test/lib/mock-element-parent.ts
+++ b/test/lib/mock-element-parent.ts
@@ -3,17 +3,17 @@ import EventEmitter from 'events';
 
 // Mock element suitable for use with MockMutationObserver
 export default class MockElementParent extends EventEmitter {
-  public children: any[];
-  public _emitsMutations = true;
-  public nodeType = 1;
+  children: any[];
+  _emitsMutations = true;
+  nodeType = 1;
 
-  public constructor(children: any[] = []) {
+  constructor(children: any[] = []) {
     super();
     assert(Array.isArray(children), 'children must be array');
     this.children = children;
   }
 
-  public appendAndRemoveChildren(toAdd: any[] = [], toRemove: any[] = []) {
+  appendAndRemoveChildren(toAdd: any[] = [], toRemove: any[] = []) {
     const presentTargets = [];
     for (const target of toRemove) {
       const ix = this.children.indexOf(target);
@@ -35,19 +35,19 @@ export default class MockElementParent extends EventEmitter {
     });
   }
 
-  public appendChildren(targets: any[]) {
+  appendChildren(targets: any[]) {
     return this.appendAndRemoveChildren(targets, undefined);
   }
 
-  public removeChildren(targets: any[]) {
+  removeChildren(targets: any[]) {
     return this.appendAndRemoveChildren(undefined, targets);
   }
 
-  public appendChild(target: any) {
+  appendChild(target: any) {
     return this.appendChildren([target]);
   }
 
-  public removeChild(target: any) {
+  removeChild(target: any) {
     return this.removeChildren([target]);
   }
 }

--- a/test/lib/mock-mutation-observer.ts
+++ b/test/lib/mock-mutation-observer.ts
@@ -8,11 +8,11 @@ export default class MockMutationObserver {
   private _updateQueued: boolean = false;
   private _stopper = kefirBus();
 
-  public constructor(callback: (mutations: MutationRecord[]) => void) {
+  constructor(callback: (mutations: MutationRecord[]) => void) {
     this._callback = callback;
   }
 
-  public observe(element: Node, options: MutationObserverInit) {
+  observe(element: Node, options: MutationObserverInit) {
     assert(element);
     assert(options);
 
@@ -41,18 +41,18 @@ export default class MockMutationObserver {
     }
   }
 
-  public disconnect() {
+  disconnect() {
     this._stopper.emit('stop');
     this.takeRecords();
   }
 
-  public takeRecords() {
+  takeRecords() {
     const records = this._records;
     this._records = [];
     return records;
   }
 
-  public _queueMutation(mutation: MutationRecord) {
+  _queueMutation(mutation: MutationRecord) {
     this._records.push(mutation);
     if (!this._updateQueued) {
       this._updateQueued = true;


### PR DESCRIPTION
Ports ESLint rule from upstream used to pave the way for d.ts -> js.flow conversions.