### PR TITLE
chore: remove stale comment

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -222,10 +222,7 @@ const GmailElementGetter = {
         .querySelector<HTMLElement>(
           'header[role="banner"] > div > div > div[aria-expanded]'
         )
-        ?.getAttribute('aria-expanded') === 'true' ??
-      // Default to true if we can't find the element because
-      // the majority of users seem to favor that version.
-      false
+        ?.getAttribute('aria-expanded') === 'true' ?? false
     );
   },
 


### PR DESCRIPTION
Between fa70a731 and 0ab54548, we had a fallback get flipped from `true` to `false`. Update to rematch the comment with corresponding logic. 