### PR TITLE
Fix custom view sizing

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.js
@@ -267,9 +267,16 @@ class GmailRouteView {
     const gtalkButtons = GmailElementGetter.getGtalkButtons();
     const customViewEl = this._customViewElement;
     if (!leftNav || !customViewEl) throw new Error('Should not happen');
+
+    const contentSectionElement = GmailElementGetter.getContentSectionElement();
+    const contentSectionElementBottomMargin = contentSectionElement
+      ? parseInt(getComputedStyle(contentSectionElement).marginBottom, 10)
+      : 0;
+
     customViewEl.style.height = `${
       parseInt(leftNav.style.height, 10) +
-      (gtalkButtons ? gtalkButtons.offsetHeight : 0)
+      (gtalkButtons ? gtalkButtons.offsetHeight : 0) -
+      contentSectionElementBottomMargin
     }px`;
   }
 


### PR DESCRIPTION
This PR fixes the issues where custom views don't have the proper 16px margin at the bottom of the screen like native views, causing the page to be made too tall which causes HTMLElement.scrollIntoView() calls to scroll document.body itself, which isn't normally scrollable and causes content at the top of the page to be irreversibly scrolled out of view.