### PR TITLE
Feature Request: Emit event when NavItemView is inserted

### DIFF
--- a/src/platform-implementation-js/views/native-nav-item-view.js
+++ b/src/platform-implementation-js/views/native-nav-item-view.js
@@ -39,6 +39,8 @@ export default class NativeNavItemView extends EventEmitter {
       navItemViewDriver
         .getEventStream()
         .onValue((event) => _handleStreamEvent(this, event));
+
+      this.emit('inserted');
     });
   }
 

--- a/src/platform-implementation-js/views/nav-item-view.js
+++ b/src/platform-implementation-js/views/nav-item-view.js
@@ -70,6 +70,8 @@ export default class NavItemView extends EventEmitter {
         .onValue((x) => {
           _handleRouteViewChange(navItemViewDriver, x);
         });
+
+      this.emit('inserted');
     });
   }
 


### PR DESCRIPTION
Instead of using a `setTimeout` or a `MutationObserver`, it would be great to be notified by an event (`inserted` / `created`) when the NavItemView has been inserted in the DOM and when he is queryable with a `querySelector`.

