### PR TITLE
chore: remove unused eslint disable directives

### DIFF
--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 import fs from 'fs';
 import path from 'path';
 const packageJson = JSON.parse(

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "prepare": "husky install",
     "publish-npm": "gulp clean && gulp --production --minify && yarn workspace @inboxsdk/core npm publish && git push --follow-tags",
     "flow_check": "flow check",
-    "lint": "eslint .",
+    "lint": "eslint . --report-unused-disable-directives",
     "lint-fix": "eslint . --ext js,jsx,ts,tsx,flow --fix",
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",

--- a/src/common/load-script.ts
+++ b/src/common/load-script.ts
@@ -150,7 +150,6 @@ export default function loadScript(
     pr = addScriptToPage(url, true).catch(() => {
       // Only show the warning if we successfully load the script on retry.
       return addScriptToPage(url, false).then(() => {
-        // eslint-disable-next-line no-console
         console.warn(
           'Script ' +
             url +

--- a/src/common/log-error.ts
+++ b/src/common/log-error.ts
@@ -41,7 +41,6 @@ export default function logError(
     }
 
     if (!(err instanceof Error)) {
-      // eslint-disable-next-line no-console
       console.warn(
         'First parameter to Logger.error was not an error object:',
         err
@@ -89,7 +88,6 @@ export default function logError(
     stuffToLog.push('\nInboxSDK Implementation Version:', implVersion);
     stuffToLog.push('\nIs Using Sync API:', isUsingSyncAPI);
 
-    // eslint-disable-next-line no-console
     console.error(...stuffToLog);
 
     const report = {
@@ -153,7 +151,6 @@ const _extensionSeenErrors: {
         try {
           return !!(e as any).__inboxsdk_extensionHasSeenError;
         } catch (err) {
-          // eslint-disable-next-line no-console
           console.error(err);
           return false;
         }
@@ -179,7 +176,6 @@ const _extensionSeenErrors: {
             value: true,
           });
         } catch (err) {
-          // eslint-disable-next-line no-console
           console.error(err);
         }
       }
@@ -223,8 +219,7 @@ const sendError = rateLimit(
 );
 
 function tooManyErrors(err2: unknown, originalArgs: any) {
-  // eslint-disable-next-line no-console
   console.error('ERROR REPORTING ERROR', err2);
-  // eslint-disable-next-line no-console
+
   console.error('ORIGINAL ERROR', originalArgs);
 }

--- a/src/injected-js/gmail/setup-gmail-interceptor.test.ts
+++ b/src/injected-js/gmail/setup-gmail-interceptor.test.ts
@@ -9,7 +9,6 @@ import MockServer from '../../../test/lib/MockServer';
 jest.mock('../injected-logger', () => {
   return {
     error(err: Error, details?: any) {
-      // eslint-disable-next-line no-console
       console.error(err, details);
       throw err;
     },

--- a/src/injected-js/injected-logger.ts
+++ b/src/injected-js/injected-logger.ts
@@ -2,7 +2,7 @@ export function error(err: Error | unknown, details?: any) {
   if (!err) {
     err = new Error('No error given');
   }
-  console.error('Error in injected script', err, details); //eslint-disable-line no-console
+  console.error('Error in injected script', err, details);
   try {
     JSON.stringify(details);
   } catch (e) {

--- a/src/injected-js/setup-error-silencer.js
+++ b/src/injected-js/setup-error-silencer.js
@@ -9,7 +9,7 @@ export default function setupErrorSilencer() {
       oldErrorHandlers.push(window.onerror);
       window.onerror = function (...args) {
         if (process.env.NODE_ENV !== 'production') {
-          console.error('(Silenced in production) Page error:', ...args); //eslint-disable-line no-console
+          console.error('(Silenced in production) Page error:', ...args);
         }
         return true;
       };

--- a/src/injected-js/xhr-proxy-factory.js
+++ b/src/injected-js/xhr-proxy-factory.js
@@ -377,7 +377,6 @@ export default function XHRProxyFactory(
 
                 for (let responseTextChanger of this._responseTextChangers) {
                   const longRunWarningTimer = setTimeout(() => {
-                    // eslint-disable-next-line no-console
                     console.warn(
                       'responseTextChanger is taking too long',
                       responseTextChanger,
@@ -533,7 +532,6 @@ export default function XHRProxyFactory(
   XHRProxy.prototype.setRequestHeader = function (name, value) {
     var self = this;
     if (this.readyState != 1) {
-      // eslint-disable-next-line no-console
       console.warn(
         'setRequestHeader improperly called at readyState ' + this.readyState
       );
@@ -683,7 +681,6 @@ export default function XHRProxyFactory(
         let modifiedRequest = request;
         for (let requestChanger of this._requestChangers) {
           const longRunWarningTimer = setTimeout(() => {
-            // eslint-disable-next-line no-console
             console.warn(
               'requestChanger is taking too long',
               requestChanger,

--- a/src/injected-js/xhr-proxy-factory.test.js
+++ b/src/injected-js/xhr-proxy-factory.test.js
@@ -14,7 +14,7 @@ function logError(error, label) {
   if (error === testError) {
     logErrorTestCalls++;
   } else {
-    console.error('logError:', label, error); // eslint-disable-line no-console
+    console.error('logError:', label, error);
     throw error || new Error(label);
   }
 }

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
@@ -216,7 +216,6 @@ class GmailDriver implements Driver {
           'inboxsdk__cached_gmail_and_inbox_message_ids_2'
         );
       } catch (err) {
-        // eslint-disable-next-line no-console
         console.error(err);
       }
       const gmailMessageIdForSyncMessageIdCache = new BiMapCache({

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/getSyncThreadForOldGmailThreadId.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/getSyncThreadForOldGmailThreadId.ts
@@ -19,7 +19,7 @@ export default async function getSyncThreadForOldGmailThreadId(
   );
   const firstThread = threadDescriptors[0];
   if (firstThread == null) {
-    console.error(`Thread with ID ${oldGmailThreadId} not found by Gmail`); //eslint-disable-line
+    console.error(`Thread with ID ${oldGmailThreadId} not found by Gmail`);
     const isStreak = isStreakAppId(driver.getAppId());
     const err = new Error(
       'Thread not found by getSyncThreadForOldGmailThreadId'

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.test.ts
@@ -27,7 +27,6 @@ class ShowCustomThreadListTester {
     isUsingSyncAPI: () => true,
     getLogger: once(() => ({
       error(e: any) {
-        // eslint-disable-next-line no-console
         console.error(e);
         throw e;
       },

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.ts
@@ -95,7 +95,7 @@ function copyAndOmitExcessThreads(
 }
 
 function _findIdFailure(id: string, err: Error) {
-  console.log('Failed to find id for thread', id, err); //eslint-disable-line no-console
+  console.log('Failed to find id for thread', id, err);
   return null;
 }
 

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-response-processor.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-response-processor.ts
@@ -494,7 +494,6 @@ it all back together.
           if (item[6]) {
             item[6][0] = [query, 1];
           } else {
-            // eslint-disable-next-line no-console
             console.error('replaceThreadsInResponse(): Missing item[6]');
           }
         }

--- a/src/platform-implementation-js/dom-driver/gmail/makePageParserTree.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/makePageParserTree.ts
@@ -33,7 +33,7 @@ export default function makePageParserTree(
 
   const page = new PageParserTree(root, transformOptions(pageParserOptions));
   pageParserOptionsStream.changes().onValue((pageParserOptions) => {
-    console.log('replacing PageParserTree options'); //eslint-disable-line no-console
+    console.log('replacing PageParserTree options');
     page.replaceOptions(transformOptions(pageParserOptions));
   });
   return page;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/index.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/index.js
@@ -76,7 +76,7 @@ class GmailAppSidebarView {
         String(open)
       );
     } catch (err) {
-      console.error('error saving', err); //eslint-disable-line no-console
+      console.error('error saving', err);
     }
   }
 
@@ -98,7 +98,7 @@ class GmailAppSidebarView {
         String(open)
       );
     } catch (err) {
-      console.error('error saving', err); //eslint-disable-line no-console
+      console.error('error saving', err);
     }
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/index.test.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/index.test.js
@@ -122,7 +122,7 @@ function makeDriver(appId, opts): any {
       return {
         eventSdkPassive() {},
         error(err, details) {
-          console.error('logger.error called:', err, details); //eslint-disable-line no-console
+          console.error('logger.error called:', err, details);
           throw err;
         },
       };

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.js
@@ -79,7 +79,7 @@ class GmailAppSidebarPrimary {
           global.localStorage.getItem('inboxsdk__sidebar_ordering') || 'null'
         );
       } catch (err) {
-        console.error('failed to read sidebar order data', err); //eslint-disable-line no-console
+        console.error('failed to read sidebar order data', err);
       }
     },
     set(data) {
@@ -89,7 +89,7 @@ class GmailAppSidebarPrimary {
           JSON.stringify(data)
         );
       } catch (err) {
-        console.error('failed to set sidebar order data', err); //eslint-disable-line no-console
+        console.error('failed to set sidebar order data', err);
       }
     },
   });
@@ -136,7 +136,7 @@ class GmailAppSidebarPrimary {
         String(open)
       );
     } catch (err) {
-      console.error('error saving', err); //eslint-disable-line no-console
+      console.error('error saving', err);
     }
   }
 
@@ -155,7 +155,7 @@ class GmailAppSidebarPrimary {
         String(open)
       );
     } catch (err) {
-      console.error('error saving', err); //eslint-disable-line no-console
+      console.error('error saving', err);
     }
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-attachment-card-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-attachment-card-view.js
@@ -159,7 +159,7 @@ class GmailAttachmentCardView {
             finalUrl
           )
         ) {
-          console.error('getDownloadURL returned unexpected url', finalUrl); //eslint-disable-line
+          console.error('getDownloadURL returned unexpected url', finalUrl);
           const err = new Error('getDownloadURL returned unexpected url');
           this._driver.getLogger().error(err, {
             finalUrlCensored: finalUrl.replace(/\?[^/]+$/, '?[...]'),

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.js
@@ -1031,7 +1031,6 @@ class GmailComposeView {
 
   close() {
     if (this.isInlineReplyForm()) {
-      // eslint-disable-next-line no-console
       console.warn("Trying to close an inline reply which doesn't work.");
       return;
     }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.js
@@ -499,7 +499,7 @@ class GmailMessageView {
     const attachmentIcon = new AttachmentIcon();
 
     if (!this._element) {
-      console.warn('addDateIcon called on destroyed message'); //eslint-disable-line no-console
+      console.warn('addDateIcon called on destroyed message');
       return attachmentIcon;
     }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
@@ -225,7 +225,6 @@ export default class GmailNavItemView {
         localStorage.removeItem(storageKey);
       }
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error('Caught error', e);
     }
   }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.js
@@ -1,5 +1,4 @@
 /* @flow */
-/* eslint-disable no-console */
 
 import once from 'lodash/once';
 import flatten from 'lodash/flatten';

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-sidebar-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-sidebar-view.js
@@ -100,7 +100,7 @@ class GmailAppSidebarView {
         String(open)
       );
     } catch (err) {
-      console.error('error saving', err); //eslint-disable-line no-console
+      console.error('error saving', err);
     }
   }
 
@@ -248,7 +248,7 @@ class GmailAppSidebarView {
             global.localStorage.getItem('inboxsdk__sidebar_ordering') || 'null'
           );
         } catch (err) {
-          console.error('failed to read sidebar order data', err); //eslint-disable-line no-console
+          console.error('failed to read sidebar order data', err);
         }
       },
       set(data) {
@@ -258,7 +258,7 @@ class GmailAppSidebarView {
             JSON.stringify(data)
           );
         } catch (err) {
-          console.error('failed to set sidebar order data', err); //eslint-disable-line no-console
+          console.error('failed to set sidebar order data', err);
         }
       },
     });

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-sidebar-view.test.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-sidebar-view.test.js
@@ -310,7 +310,7 @@ function makeDriver(appId, opts): any {
       return {
         eventSdkPassive() {},
         error(err, details) {
-          console.error('logger.error called:', err, details); //eslint-disable-line no-console
+          console.error('logger.error called:', err, details);
           throw err;
         },
       };

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-toolbar-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-toolbar-view.js
@@ -118,7 +118,7 @@ class GmailToolbarView {
 
   getThreadRowViewDrivers() {
     if (!this._rowListViewDriver) {
-      console.error('missing this._rowListViewDriver'); //eslint-disable-line no-console
+      console.error('missing this._rowListViewDriver');
       return new Set();
     }
     return this._rowListViewDriver.getThreadRowViewDrivers();

--- a/src/platform-implementation-js/dom-driver/inbox/inbox-driver.js
+++ b/src/platform-implementation-js/dom-driver/inbox/inbox-driver.js
@@ -769,7 +769,6 @@ class InboxDriver {
     appName: ?string,
     appIconUrl: ?string
   ): void {
-    // eslint-disable-next-line no-console
     console.warn('activateShortcut not implemented');
   }
 
@@ -812,7 +811,6 @@ class InboxDriver {
   }
 
   getAccountSwitcherContactList(): Contact[] {
-    // eslint-disable-next-line no-console
     console.log('getAccountSwitcherContactList not implemented');
     return [this.getUserContact()];
   }
@@ -832,7 +830,6 @@ class InboxDriver {
       if (inboxToolbarView.isForThread()) {
         if (!options.positions || includes(options.positions, 'THREAD')) {
           if (options.threadSection === 'OTHER') {
-            // eslint-disable-next-line no-console
             console.warn(
               'registerThreadButton does not support OTHER section items in Inbox yet.'
             );
@@ -857,7 +854,6 @@ class InboxDriver {
       } else if (inboxToolbarView.isForRowList()) {
         if (!options.positions || includes(options.positions, 'LIST')) {
           if (options.listSection === 'OTHER') {
-            // eslint-disable-next-line no-console
             console.warn(
               'registerThreadButton does not support OTHER section items in Inbox yet.'
             );
@@ -963,7 +959,6 @@ class InboxDriver {
   }
 
   addCustomListRouteID(routeID: string, handler: Function): () => void {
-    // eslint-disable-next-line no-console
     console.log('addCustomListRouteID not implemented');
     return () => {};
   }
@@ -1061,7 +1056,6 @@ class InboxDriver {
   }
 
   registerSearchQueryRewriter(obj: Object) {
-    // eslint-disable-next-line no-console
     console.log('registerSearchQueryRewriter not implemented');
   }
 

--- a/src/platform-implementation-js/dom-driver/inbox/makePageParserTree.js
+++ b/src/platform-implementation-js/dom-driver/inbox/makePageParserTree.js
@@ -35,7 +35,7 @@ export default function makePageParserTree(
 
   const page = new PageParserTree(root, transformOptions(pageParserOptions));
   pageParserOptionsStream.changes().onValue((pageParserOptions) => {
-    console.log('replacing PageParserTree options'); //eslint-disable-line no-console
+    console.log('replacing PageParserTree options');
     page.replaceOptions(transformOptions(pageParserOptions));
   });
   return page;

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-app-sidebar-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-app-sidebar-view.js
@@ -99,7 +99,7 @@ class InboxAppSidebarView {
     try {
       localStorage.setItem('inboxsdk__app_sidebar_should_open', String(open));
     } catch (err) {
-      console.error('error saving', err); //eslint-disable-line no-console
+      console.error('error saving', err);
     }
   }
 
@@ -171,7 +171,7 @@ class InboxAppSidebarView {
             localStorage.getItem('inboxsdk__sidebar_ordering') || 'null'
           );
         } catch (err) {
-          console.error('failed to read sidebar order data', err); //eslint-disable-line no-console
+          console.error('failed to read sidebar order data', err);
         }
       },
       set(data) {
@@ -181,7 +181,7 @@ class InboxAppSidebarView {
             JSON.stringify(data)
           );
         } catch (err) {
-          console.error('failed to set sidebar order data', err); //eslint-disable-line no-console
+          console.error('failed to set sidebar order data', err);
         }
       },
     });

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-compose-view.js
@@ -794,7 +794,7 @@ class InboxComposeView {
     return addRecipientRow(this, options);
   }
   forceRecipientRowsOpen(): () => void {
-    console.warn('ComposeView.forceRecipientRowsOpen() is a no-op in Inbox'); // eslint-disable-line no-console
+    console.warn('ComposeView.forceRecipientRowsOpen() is a no-op in Inbox');
     return () => {};
   }
   hideNativeRecipientRows(): () => void {

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-message-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-message-view.js
@@ -194,7 +194,6 @@ class InboxMessageView {
       throw new Error('Failed to find message id');
     }
     if (/^msg-a:/.test(inboxMessageId)) {
-      // eslint-disable-next-line no-console
       console.warn(
         'MessageView.getMessageID() returned an incorrect message ID. This method will be deprecated soon. Use getMessageIDAsync() instead which does not have this problem.'
       );
@@ -251,7 +250,6 @@ class InboxMessageView {
     throw new Error('not implemented yet');
   }
   addAttachmentIcon(options: Object): SafeEventEmitter & {} {
-    // eslint-disable-next-line no-console
     console.warn(
       'MessageView.addAttachmentIcon is not implemented yet in Inbox'
     );

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-thread-row-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-thread-row-view.js
@@ -101,7 +101,7 @@ class InboxThreadRowView {
 
   addImage(icon: Object) {
     if (this._isDestroyed) {
-      console.warn('addImage called on destroyed thread row'); //eslint-disable-line no-console
+      console.warn('addImage called on destroyed thread row');
       return;
     }
 
@@ -168,7 +168,7 @@ class InboxThreadRowView {
 
   addLabel(label: Object) {
     if (this._isDestroyed) {
-      console.warn('addLabel called on destroyed thread row'); //eslint-disable-line no-console
+      console.warn('addLabel called on destroyed thread row');
       return;
     }
 
@@ -303,7 +303,7 @@ class InboxThreadRowView {
 
   replaceDraftLabel(label: Object) {
     if (this._isDestroyed) {
-      console.warn('addLabel called on destroyed thread row'); //eslint-disable-line no-console
+      console.warn('addLabel called on destroyed thread row');
       return;
     }
 

--- a/src/platform-implementation-js/dom-driver/inbox/views/inbox-thread-view.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inbox-thread-view.js
@@ -119,7 +119,6 @@ class InboxThreadView {
       throw new Error('Failed to find thread id');
     }
     if (/^msg-a:/.test(inboxThreadId)) {
-      // eslint-disable-next-line no-console
       console.warn(
         'ThreadView.getThreadID() returned an incorrect thread ID. This method will be deprecated soon. Use getThreadIDAsync() instead which does not have this problem.'
       );

--- a/src/platform-implementation-js/dom-driver/inbox/views/inboxNavItemView.js
+++ b/src/platform-implementation-js/dom-driver/inbox/views/inboxNavItemView.js
@@ -54,7 +54,7 @@ export default class InboxNavItemView {
     };
 
     if (this._level > 2) {
-      console.warn('Adding NavItems more than 3 levels deep is not supported'); //eslint-disable-line no-console
+      console.warn('Adding NavItems more than 3 levels deep is not supported');
     }
 
     this._stopper = this._eventStream

--- a/src/platform-implementation-js/driver-common/sidebar/AppSidebar.js
+++ b/src/platform-implementation-js/driver-common/sidebar/AppSidebar.js
@@ -130,7 +130,7 @@ export default class AppSidebar extends React.Component<Props, State> {
           'null'
       );
     } catch (err) {
-      console.error('Failed to read sidebar settings', err); //eslint-disable-line no-console
+      console.error('Failed to read sidebar settings', err);
     }
     if (data) return data;
     return { apps: {} };
@@ -158,7 +158,7 @@ export default class AppSidebar extends React.Component<Props, State> {
         JSON.stringify(data)
       );
     } catch (err) {
-      console.error('Failed to save sidebar settings', err); //eslint-disable-line no-console
+      console.error('Failed to save sidebar settings', err);
     }
   }
   render() {

--- a/src/platform-implementation-js/lib/copyAndValidateAutocompleteResults.ts
+++ b/src/platform-implementation-js/lib/copyAndValidateAutocompleteResults.ts
@@ -40,7 +40,6 @@ export default function copyAndValidateAutocompleteResults(
         if (driver.getOpts().REQUESTED_API_VERSION === 1) {
           resultCopy.iconUrl = iconURL;
         } else {
-          // eslint-disable-next-line no-console
           console.error(
             'Support for iconURL property was dropped after API version 1'
           );

--- a/src/platform-implementation-js/lib/dom/make-element-stream-merger.ts
+++ b/src/platform-implementation-js/lib/dom/make-element-stream-merger.ts
@@ -12,7 +12,6 @@ export default function makeElementStreamMerger<T>(): (
     let stopperPool = knownElementStopperPools.get(event.el);
     if (stopperPool) {
       if (stopperPool.getSize() > 1) {
-        // eslint-disable-next-line no-console
         console.warn(
           'element is part of multiple element streams',
           stopperPool.getSize(),

--- a/src/platform-implementation-js/lib/dom/outsideClicksAndEscape.ts
+++ b/src/platform-implementation-js/lib/dom/outsideClicksAndEscape.ts
@@ -42,7 +42,6 @@ export default function outsideClicksAndEscape(
       if (process.env.NODE_ENV !== 'production') {
         const allElsStillInPage = elements.every((el) => document.contains(el));
         if (!allElsStillInPage) {
-          // eslint-disable-next-line no-console
           console.error(
             'outsideClicksAndEscape not unsubscribed from when elements were removed from the page'
           );

--- a/src/platform-implementation-js/lib/logger.ts
+++ b/src/platform-implementation-js/lib/logger.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 import Sha256 from 'sha.js/sha256';
 import ajax from '../../common/ajax';
 import getExtensionId from '../../common/get-extension-id';
@@ -325,7 +323,7 @@ function _extensionLoggerSetup(
             let loggedFn = args[1].__inboxsdk_logged;
             if (!loggedFn) {
               loggedFn = makeLoggedFunction(args[1], 'event listener');
-              // eslint-disable-next-line
+
               (args[1] as any).__inboxsdk_logged = loggedFn;
             }
             args[1] = loggedFn;

--- a/src/platform-implementation-js/lib/waitForAsync.ts
+++ b/src/platform-implementation-js/lib/waitForAsync.ts
@@ -20,6 +20,6 @@ export default async function waitForAsync<T>(
       throw timeoutError;
     }
   }
-  // eslint-disable-next-line no-unreachable
+
   throw new Error();
 }

--- a/src/platform-implementation-js/main-INTEGRATED-PAGEWORLD.js
+++ b/src/platform-implementation-js/main-INTEGRATED-PAGEWORLD.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation, no-undef */
+/* eslint-disable flowtype/require-valid-file-annotation */
 
 const { injectScriptEmbedded } = require('./lib/inject-script-EMBEDDED');
 require('./lib/inject-script').setInjectScriptImplementation(

--- a/src/platform-implementation-js/namespaces/keyboard.js
+++ b/src/platform-implementation-js/namespaces/keyboard.js
@@ -1,5 +1,4 @@
 /* @flow */
-/* eslint-disable no-console */
 
 import * as ud from 'ud';
 import get from '../../common/get-or-fail';

--- a/src/platform-implementation-js/platform-implementation.js
+++ b/src/platform-implementation-js/platform-implementation.js
@@ -1,5 +1,4 @@
 /* @flow */
-/* eslint-disable no-console */
 
 import SafeEventEmitter from './lib/safe-event-emitter';
 import { BUILD_VERSION } from '../common/version';

--- a/src/platform-implementation-js/views/compose-view.ts
+++ b/src/platform-implementation-js/views/compose-view.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 import EventEmitter from '../lib/safe-event-emitter';
 import Kefir from 'kefir';
 import kefirCast from 'kefir-cast';

--- a/src/platform-implementation-js/widgets/buttons/dropdown-view.ts
+++ b/src/platform-implementation-js/widgets/buttons/dropdown-view.ts
@@ -126,7 +126,6 @@ export default class DropdownView extends EventEmitter {
 
   setPlacementOptions(options: ContainByScreenOptions) {
     if (this._options.manualPosition) {
-      // eslint-disable-next-line no-console
       console.error(
         'DropdownView.setPlacementOptions() was called on a manually-positioned DropdownView.'
       );

--- a/test/lib/MockServer.ts
+++ b/test/lib/MockServer.ts
@@ -129,7 +129,6 @@ export default class MockServer {
   XMLHttpRequest: typeof XMLHttpRequest;
 
   constructor() {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const server = this;
 
     this.XMLHttpRequest = class XMLHttpRequest {
@@ -202,7 +201,7 @@ export default class MockServer {
         async: boolean | undefined = undefined
       ) {
         if (this._server._verbose) {
-          console.log('Connection opened', method, path); //eslint-disable-line no-console
+          console.log('Connection opened', method, path);
         }
         this._terminate();
         this._sendFlag = false;

--- a/tools/deserialize.js
+++ b/tools/deserialize.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env babel-node
 /* @flow */
-/* eslint-disable no-console */
 
 import concatStream from 'concat-stream';
 import { deserialize } from '../src/platform-implementation-js/dom-driver/gmail/gmail-response-processor';


### PR DESCRIPTION
I kept running into these in #881.

Adds `--report-unused-disable-directives` to the lint step to avoid adding new unused directives as well. These were auto fixed.