### PR TITLE
chore: drop stale reference to inbox.google.com in examples

### DIFF
--- a/examples/add-route-view-sections/manifest.json
+++ b/examples/add-route-view-sections/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","bacon.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/app-menu/manifest.json
+++ b/examples/app-menu/manifest.json
@@ -4,12 +4,12 @@
   "version": "0.1",
   "content_scripts": [
     {
-      "matches": ["https://mail.google.com/*", "https://inbox.google.com/*"],
+      "matches": ["https://mail.google.com/*"],
       "js": ["inboxsdk.js", "content.js"],
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/", "https://inbox.google.com/"],
+  "permissions": ["https://mail.google.com/"],
   "web_accessible_resources": [
     "inboxsdk.js.map",
     "pageWorld.js",

--- a/examples/attachment-card/manifest.json
+++ b/examples/attachment-card/manifest.json
@@ -4,8 +4,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["kefir.min.js", "react.production.min.js", "react-dom.production.min.js", "inboxsdk.js", "app.js"],
       "css": ["app.css"],
@@ -14,7 +13,6 @@
   ],
   "permissions": [
     "https://mail.google.com/",
-    "https://inbox.google.com/",
     "https://mail-attachment.googleusercontent.com/"
   ],
   "web_accessible_resources": [

--- a/examples/browser-test/manifest.json
+++ b/examples/browser-test/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_start"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/compose-dropdown-button/content.js
+++ b/examples/compose-dropdown-button/content.js
@@ -22,7 +22,7 @@ InboxSDK.load(1, 'simple-example', {
       iconUrl: chrome.runtime.getURL('monkey.png'),
       hasDropdown: true,
       onClick: function(event){
-        if (!composeView.isInlineReplyForm() || document.location.origin !== 'https://inbox.google.com') {
+        if (!composeView.isInlineReplyForm()) {
           composeView.setSubject('foo<b>ar');
         }
         event.dropdown.el.textContent = 'hello world!';

--- a/examples/compose-dropdown-button/manifest.json
+++ b/examples/compose-dropdown-button/manifest.json
@@ -5,8 +5,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "css": ["content.css"],
@@ -14,8 +13,7 @@
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/compose-stream/manifest.json
+++ b/examples/compose-stream/manifest.json
@@ -5,8 +5,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "css": ["content.css"],
       "js": ["inboxsdk.js","bacon.js", "content.js"],
@@ -14,8 +13,7 @@
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/compose-tooltip-button/manifest.json
+++ b/examples/compose-tooltip-button/manifest.json
@@ -5,8 +5,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "css": [
@@ -16,8 +15,7 @@
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/contact-hover-example/manifest.json
+++ b/examples/contact-hover-example/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","app.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map", "monkey-face.jpg",

--- a/examples/custom-thread-list/manifest.json
+++ b/examples/custom-thread-list/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map", "monkey-face.jpg",

--- a/examples/custom-view/manifest.json
+++ b/examples/custom-view/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/header-support/manifest.json
+++ b/examples/header-support/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [ "pageWorld.js" ],
   "background": {

--- a/examples/hello-world/manifest.json
+++ b/examples/hello-world/manifest.json
@@ -5,8 +5,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
@@ -14,7 +13,6 @@
   ],
   "permissions": [
     "https://mail.google.com/",
-    "https://inbox.google.com/"
   ],
   "web_accessible_resources": [ "pageWorld.js" ],
   "background": {

--- a/examples/link-popovers/manifest.json
+++ b/examples/link-popovers/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [ "pageWorld.js" ],
   "background": {

--- a/examples/modal-example/manifest.json
+++ b/examples/modal-example/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/mole-example/manifest.json
+++ b/examples/mole-example/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/nav-menu/manifest.json
+++ b/examples/nav-menu/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/open-compose/manifest.json
+++ b/examples/open-compose/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/override-edit-subject/manifest.json
+++ b/examples/override-edit-subject/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/search-results/manifest.json
+++ b/examples/search-results/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/search-suggestions/manifest.json
+++ b/examples/search-suggestions/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/search-term/manifest.json
+++ b/examples/search-term/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","Bacon.min.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/sidebar-contact-example/manifest.json
+++ b/examples/sidebar-contact-example/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js", "content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
 
   "web_accessible_resources": [ "pageWorld.js" ],

--- a/examples/sidebar-example/manifest.json
+++ b/examples/sidebar-example/manifest.json
@@ -5,8 +5,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","bacon.js", "content.js"],
       "css": ["extension.css"],
@@ -14,8 +13,7 @@
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/thread-rows/manifest.json
+++ b/examples/thread-rows/manifest.json
@@ -5,8 +5,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","kefir.js","content.js"],
       "css": ["content.css"],
@@ -14,8 +13,7 @@
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/thread-test/manifest.json
+++ b/examples/thread-test/manifest.json
@@ -5,8 +5,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "css": [],
       "js": ["inboxsdk.js", "content.js"],
@@ -14,8 +13,7 @@
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",

--- a/examples/toolbar-button/manifest.json
+++ b/examples/toolbar-button/manifest.json
@@ -5,16 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://mail.google.com/*",
-        "https://inbox.google.com/*"
+        "https://mail.google.com/*"
       ],
       "js": ["inboxsdk.js","content.js"],
       "run_at": "document_end"
     }
   ],
   "permissions": [
-    "https://mail.google.com/",
-    "https://inbox.google.com/"
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "inboxsdk.js.map",


### PR DESCRIPTION
Removes references to inbox.google.com in examples that redirect to https://www.google.com/gmail/about/.

Related to #887.