### PR TITLE
fix: partially bring back older idMap impl

### DIFF
--- a/__tests__/inboxsdk-gmail.ts
+++ b/__tests__/inboxsdk-gmail.ts
@@ -4,8 +4,6 @@ import MockMutationObserver from '../test/lib/mock-mutation-observer';
 import _ from 'lodash';
 import type { InboxSDK as InboxSDKT } from '../src/inboxsdk';
 
-process.env.VERSION = 'beep';
-
 globalThis.MutationObserver = MockMutationObserver as any;
 document.documentElement.innerHTML = `
 <body>

--- a/babel.config.js
+++ b/babel.config.js
@@ -21,7 +21,7 @@ module.exports = (api) => ({
   overrides: [
     {
       test: ['**/*.ts', '**/*.tsx'],
-      presets: ['@babel/preset-typescript'],
+      presets: [['@babel/preset-typescript', { optimizeConstEnums: true }]],
     },
     {
       test: ['**/*.js', '**/*.js.flow'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,9 @@
 'use strict';
 
 module.exports = {
+  globals: {
+    SDK_VERSION: 'beep',
+  },
   moduleNameMapper: {
     '\\.css$': require.resolve('jest-css-modules'),
   },

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,7 +1,9 @@
 // This is in its own file so that updates to the version value don't cause a
 // reload of everything.
 
-export const BUILD_VERSION: string = process.env.VERSION!;
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- SDK_VERSION is injected by webpack
+///@ts-ignore
+export const BUILD_VERSION: string = SDK_VERSION;
 
 if ((module as any).hot) {
   (module as any).hot.accept();

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/index.test.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/index.test.js
@@ -6,10 +6,14 @@ jest.mock('../../../../lib/idMap', () => {
       app_sidebar_content_panel: 'bccbBAHIcfEeHCHf',
     };
 
-    return legacyMapping[key];
+    return legacyMapping[key] ?? key;
   }
 
-  return idMap;
+  return {
+    __esModule: true,
+    default: idMap,
+    legacyIdMap: idMap,
+  };
 });
 
 import idMap from '../../../../lib/idMap';

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.js
@@ -30,6 +30,11 @@ import fakeWindowResize from '../../../../../lib/fake-window-resize';
 import addCompanionThreadIconArea from './add-companion-thread-icon-area';
 import addCompanionGlobalIconArea from './add-companion-global-icon-area';
 import addToIconArea from './add-to-icon-area';
+import cx from 'classnames';
+import {
+  sidebarWaitingPlatformClassName,
+  sidebarWaitingPlatformSelector,
+} from '../../../../../driver-common/sidebar/constants';
 
 const ACTIVE_ADD_ON_ICON_SELECTOR = '.aT5-aOt-I-KO';
 const COMPANION_SIDEBAR_CONTENT_CLOSED_SHADOW_CLASS = 'brC-brG-btc';
@@ -671,11 +676,14 @@ class GmailAppSidebarPrimary {
 
     if (
       !((document.body: any): HTMLElement).querySelector(
-        '.' + idMap('app_sidebar_waiting_platform')
+        sidebarWaitingPlatformSelector
       )
     ) {
       const waitingPlatform = document.createElement('div');
-      waitingPlatform.className = idMap('app_sidebar_waiting_platform');
+      waitingPlatform.className = cx(
+        sidebarWaitingPlatformClassName,
+        idMap('app_sidebar_waiting_platform')
+      );
       ((document.body: any): HTMLElement).appendChild(waitingPlatform);
     }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-sidebar-view.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-sidebar-view.js
@@ -35,11 +35,16 @@ import GmailElementGetter from '../gmail-element-getter';
 
 import addIconArea from './gmail-thread-sidebar-view/add-icon-area';
 import addToIconArea from './gmail-app-sidebar-view/primary/add-to-icon-area';
+import cx from 'classnames';
 
 const ADD_ON_SIDEBAR_CONTENT_SELECTOR = '.J-KU-Jz';
 const ACTIVE_ADD_ON_ICON_SELECTOR = '.J-KU-KO';
 
 import type WidthManager from './gmail-thread-view/width-manager';
+import {
+  sidebarWaitingPlatformSelector,
+  sidebarWaitingPlatformClassName,
+} from '../../../driver-common/sidebar/constants';
 
 class GmailAppSidebarView {
   _stopper = kefirStopper();
@@ -221,11 +226,14 @@ class GmailAppSidebarView {
 
     if (
       !((document.body: any): HTMLElement).querySelector(
-        '.' + idMap('app_sidebar_waiting_platform')
+        sidebarWaitingPlatformSelector
       )
     ) {
       const waitingPlatform = document.createElement('div');
-      waitingPlatform.className = idMap('app_sidebar_waiting_platform');
+      waitingPlatform.className = cx(
+        sidebarWaitingPlatformClassName,
+        idMap('app_sidebar_waiting_platform')
+      );
       ((document.body: any): HTMLElement).appendChild(waitingPlatform);
     }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-sidebar-view.test.js
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-sidebar-view.test.js
@@ -6,10 +6,14 @@ jest.mock('../../../lib/idMap', () => {
       app_sidebar_content_panel: 'bccbBAHIcfEeHCHf',
       sidebar_button_container: 'CdCEaDfbJJbHDEaD',
     };
-    return legacyMapping[key];
+    return legacyMapping[key] ?? key;
   }
 
-  return idMap;
+  return {
+    __esModule: true,
+    default: idMap,
+    legacyIdMap: idMap,
+  };
 });
 
 import _ from 'lodash';

--- a/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.js
+++ b/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.js
@@ -7,8 +7,8 @@ import kefirBus from 'kefir-bus';
 import kefirStopper from 'kefir-stopper';
 import delayAsap from '../../lib/delay-asap';
 import type { Driver } from '../../driver-interfaces/driver';
-import idMap from '../../lib/idMap';
 import querySelector from '../../lib/dom/querySelectorOrFail';
+import { sidebarWaitingPlatformSelector } from './constants';
 
 class ContentPanelViewDriver {
   _driver: Driver;
@@ -65,7 +65,7 @@ class ContentPanelViewDriver {
     let appName;
     const waitingPlatform = querySelector(
       (document.body: any),
-      '.' + idMap('app_sidebar_waiting_platform')
+      sidebarWaitingPlatformSelector
     );
 
     descriptor

--- a/src/platform-implementation-js/driver-common/sidebar/constants.js.flow
+++ b/src/platform-implementation-js/driver-common/sidebar/constants.js.flow
@@ -1,0 +1,4 @@
+/* @flow */
+
+declare export var sidebarWaitingPlatformSelector: string;
+declare export var sidebarWaitingPlatformClassName: string;

--- a/src/platform-implementation-js/driver-common/sidebar/constants.ts
+++ b/src/platform-implementation-js/driver-common/sidebar/constants.ts
@@ -1,0 +1,34 @@
+import cx from 'classnames';
+import { legacyIdMap } from '../../lib/idMap';
+
+const cssGlobal = 'inboxsdk__app_sidebar_waiting_platform';
+
+const enum SidebarClassName {
+  /** v1.1.0 CSS module selector, */
+  v1_1_0 = 'inboxsdk__a0oshmeH6N_2vLtc3DNT',
+  /** v1.1.1 CSS module selector, */
+  v1_1_1 = 'inboxsdk__BV_FA4qVT4qYxs3LbEU4',
+}
+
+export const sidebarWaitingPlatformSelector = [
+  cssGlobal,
+  SidebarClassName.v1_1_0,
+  SidebarClassName.v1_1_1,
+  // Pre CSS module selector <1.1.0
+  legacyIdMap('app_sidebar_waiting_platform'),
+]
+  .map((x) => '.' + x)
+  .join(', ');
+
+/**
+ * The CSS local corresponding to this SDK's classname is intentionally in
+ * this classname. This is because this classname
+ * is used as a selector for disparate bits of code,
+ * and the CSS local is only used for styling.
+ */
+export const sidebarWaitingPlatformClassName = cx(
+  cssGlobal,
+  SidebarClassName.v1_1_0,
+  SidebarClassName.v1_1_1,
+  legacyIdMap('app_sidebar_waiting_platform')
+);

--- a/src/platform-implementation-js/lib/idMap.js.flow
+++ b/src/platform-implementation-js/lib/idMap.js.flow
@@ -4,5 +4,4 @@
 // The returned identifier will only contain alphabetic characters.
 declare export default function idMap(name: string): string;
 
-// Only exposed for tests!
-declare export function _reset(): void;
+declare export function legacyIdMap(name: string): string;

--- a/src/platform-implementation-js/lib/idMap.ts
+++ b/src/platform-implementation-js/lib/idMap.ts
@@ -1,4 +1,46 @@
 import * as s from '../style/gmail.css';
+import Sha256 from 'sha.js/sha256';
+
+const cache: Map<string, string> = new Map();
+let seed: string | null = null;
+
+/**
+ * Pass a name and you'll get a unique identifier associated with that name.
+ * The returned identifier will only contain alphabetic characters.
+ *
+ * @deprecated a holdover from the old idMap runtime implementation. Use `idMap` instead unless you specifically need the same classname as old versions of the InboxSDK used.
+ */
+export function legacyIdMap(name: string): string {
+  const id = cache.get(name);
+  if (id != null) return id;
+
+  if (seed == null) {
+    seed = document.documentElement.getAttribute('data-map-id');
+    if (seed == null) {
+      // Make the seed change every hour: the seed is based on a hash of the
+      // current timestamp in hour resolution.
+      const hasher = new Sha256();
+      hasher.update(
+        'PWVe' + Math.floor(Date.now() / (1000 * 60 * 60)) + 'PYiE0'
+      );
+      seed =
+        hasher.digest('hex').slice(0, 16) +
+        (process.env.NODE_ENV === 'development' ? 'x' : '');
+      document.documentElement.setAttribute('data-map-id', seed);
+    }
+  }
+
+  const hasher = new Sha256();
+  hasher.update('4iYi29W' + name + ':' + seed + 'jn2mPvTG');
+  const newId = hasher
+    .digest('hex')
+    .slice(0, 16)
+    .replace(/[0-9]/g, (match) =>
+      String.fromCharCode('A'.charCodeAt(0) + Number(match))
+    );
+  cache.set(name, newId);
+  return newId;
+}
 
 export default function idMap(id: string) {
   // Uses lazy initialization of style tags from style-loader


### PR DESCRIPTION
Prevents issues where a @inbox/core@>=1.1.0 is unable to find the Gmail sidebar after an older @inbox/core using extension loads. This issue was introduced in #881.

From @Macil:

> ContentPanelViewDriver's constructor expects an element with the classname idMap('app_sidebar_waiting_platform') to exist already. The constructor is called from the addThreadSidebarContentPanel method of GmailAppSidebarView. GmailAppSidebarView's own constructor detects whether it's the first SDK instance, and if it is, constructs GmailAppSidebarPrimary which creates the element.
> 
> So it looks like it is the issue I brought up: if a different SDK loaded first, it will create the idMap('app_sidebar_waiting_platform') element, mark itself as the primary, and then other SDK instances will expect to find an existing idMap('app_sidebar_waiting_platform')  element.

This fix uses the older, rechristened `legacyIdMap` for selectors that are implicitly assumed to be stable across SDK versions. Styles are still associated with the newer CSS module build from #881.