### PR TITLE
fix: add 'bugfixes: true' for Safari 15 babel class fields codegen

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,7 @@ module.exports = (api) => ({
     [
       '@babel/preset-env',
       {
+        bugfixes: true,
         ...(api.env('test') ? { targets: { node: 'current' } } : {}),
       },
     ],


### PR DESCRIPTION
babel may be generating standards compliant code around class fields, but Safari 15 might have a bug that causes `ReferenceErrors`.

See https://github.com/babel/babel/issues/14289#issuecomment-1374547406 for how class fields could break in Safari 15 codegen.