### PR TITLE
chore: add types for TS consumers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,9 +30,12 @@
     "@babel/runtime": "^7.0.0",
     "@types/kefir": "^3.8.6",
     "@types/node": "*",
+    "@types/transducers.js": "^0.3.0",
     "asap": "^2.0.3",
     "fast-deep-equal": "^3.1.3",
     "kefir-cast": "^3.3.0",
+    "live-set": "^1.0.0",
+    "page-parser-tree": "^0.4.0",
     "sha.js": "^2.4.0",
     "tag-tree": "^1.0.0",
     "typed-emitter": "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,9 +1689,12 @@ __metadata:
     "@babel/runtime": ^7.0.0
     "@types/kefir": ^3.8.6
     "@types/node": "*"
+    "@types/transducers.js": ^0.3.0
     asap: ^2.0.3
     fast-deep-equal: ^3.1.3
     kefir-cast: ^3.3.0
+    live-set: ^1.0.0
+    page-parser-tree: ^0.4.0
     sha.js: ^2.4.0
     tag-tree: ^1.0.0
     typed-emitter: ^2.1.0


### PR DESCRIPTION
`@inboxsdk/core@1.1.4` with Typescript's tsc run on it fails in outside projects. This PR adds the following dependencies for TS types.

- `live-set`
- `page-parser-tree`
- `transducers.js`