### PR TITLE
rollback browserlist to Safari v14

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,2 +1,2 @@
 Chrome 100
-Safari 15
+Safari 14


### PR DESCRIPTION
Safari 15 cannot handle this syntax when code is minified

```
import once from 'lodash/once';

class Hello {
  world = once(() => {
    return "hello world";
  });
}
```

the file that fails to be executed in Safari v15 is `src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.js`

the bug was made in the https://github.com/InboxSDK/InboxSDK/pull/881