### PR TITLE
fix: reapply Safari 15 min

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,2 +1,2 @@
 Chrome 100
-Safari 14
+Safari 15

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,32 +1,50 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-module.exports = (api) => ({
-  presets: [
-    [
-      '@babel/preset-env',
+function isBabelRegister(caller) {
+  return !!(caller && caller.name === '@babel/register');
+}
+
+module.exports = (api) => {
+  const isRegister = api.caller(isBabelRegister);
+
+  return {
+    presets: [
+      [
+        '@babel/preset-env',
+        {
+          ...(!isRegister &&
+            !api.env('test') && {
+              // Until we no longer support Safari 15, prevent ReferenceError issues
+              // by forcing class properties transforms
+              // https://github.com/babel/babel/issues/14289
+              include: [
+                '@babel/plugin-proposal-class-properties',
+                '@babel/plugin-proposal-private-methods',
+              ],
+            }),
+          ...(api.env('test') ? { targets: { node: 'current' } } : {}),
+        },
+      ],
+      '@babel/preset-react',
+    ],
+    plugins: [
+      [
+        '@babel/plugin-transform-runtime',
+        {
+          regenerator: false,
+        },
+      ],
+    ],
+    overrides: [
       {
-        ...(api.env('test') ? { targets: { node: 'current' } } : {}),
+        test: ['**/*.ts', '**/*.tsx'],
+        presets: [['@babel/preset-typescript', { optimizeConstEnums: true }]],
+      },
+      {
+        test: ['**/*.js', '**/*.js.flow'],
+        presets: ['@babel/preset-flow'],
+        plugins: [],
       },
     ],
-    '@babel/preset-react',
-  ],
-  plugins: [
-    [
-      '@babel/plugin-transform-runtime',
-      {
-        regenerator: false,
-      },
-    ],
-  ],
-  overrides: [
-    {
-      test: ['**/*.ts', '**/*.tsx'],
-      presets: [['@babel/preset-typescript', { optimizeConstEnums: true }]],
-    },
-    {
-      test: ['**/*.js', '**/*.js.flow'],
-      presets: ['@babel/preset-flow'],
-      plugins: [],
-    },
-  ],
-});
+  };
+};


### PR DESCRIPTION
Fix for #904. Our usage of CJS inside of ESM exports seems to generate a ReferenceError with our stack in Safari 15 when coupled with a class that's being assigned to `module.exports` within a ud defn function.

Swapping our browserslist default creates quite a bit of noise in our error logging, as it changes stack trace locations and increases stack size. ~It also increases our output code size by roughly 10%.~ _edit: bundlephobia doesn't rounds the two output sizes together, but we're in the ~1% range minified._

~Longer term, I'd like to remove the remainder of ud in its entirety as it doesn't work with TS and is thus blocking moving off flow.~ _See #910._