### PR TITLE
chore: turn off minification for npm published builds by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ yarn-debug.log
 /.inboxsdk_test_secret
 yarn-error.log
 /packages/core/inboxsdk.js*
-packages/core/inboxsdk.min.js
+/packages/core/inboxsdk.min.js
 /packages/core/pageWorld.js*
 /packages/core/platform-implementation.js*
 /packages/core/src/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ yarn-debug.log
 /.inboxsdk_test_secret
 yarn-error.log
 /packages/core/inboxsdk.js*
+packages/core/inboxsdk.min.js
 /packages/core/pageWorld.js*
 /packages/core/platform-implementation.js*
 /packages/core/src/

--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -381,8 +381,26 @@ if (args.remote) {
     return webpackTask({
       entry: './src/inboxsdk-js/inboxsdk-NONREMOTE',
       destName: sdkFilename,
+      disableMinification: true,
       standalone: 'InboxSDK',
-      afterBuild: setupExamples,
+      afterBuild: async () => {
+        const { minify } = await import('terser');
+
+        const sourceOutput = await fs.promises.readFile(
+          'packages/core/inboxsdk.js',
+          'utf8'
+        );
+
+        const minified = await minify(sourceOutput);
+        await fs.promises.writeFile(
+          'packages/core/inboxsdk.min.js',
+          minified.code!,
+          {
+            encoding: 'utf8',
+          }
+        );
+        setupExamples();
+      },
     });
   });
   gulp.task('remote', () => {

--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -384,6 +384,7 @@ if (args.remote) {
       disableMinification: true,
       standalone: 'InboxSDK',
       afterBuild: async () => {
+        setupExamples();
         const { minify } = await import('terser');
 
         const sourceOutput = await fs.promises.readFile(
@@ -399,7 +400,6 @@ if (args.remote) {
             encoding: 'utf8',
           }
         );
-        setupExamples();
       },
     });
   });

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "jest-environment-jsdom": "^29.5.0",
     "raw-loader": "^4.0.2",
     "style-loader": "^3.3.2",
+    "terser": "^5.18.1",
     "webpack": "^5.76.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2042,6 +2042,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/source-map@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "@jridgewell/source-map@npm:0.3.3"
+  dependencies:
+    "@jridgewell/gen-mapping": ^0.3.0
+    "@jridgewell/trace-mapping": ^0.3.9
+  checksum: ae1302146339667da5cd6541260ecbef46ae06819a60f88da8f58b3e64682f787c09359933d050dea5d2173ea7fa40f40dd4d4e7a8d325c5892cccd99aaf8959
+  languageName: node
+  linkType: hard
+
 "@jridgewell/sourcemap-codec@npm:1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.10":
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
@@ -3017,6 +3027,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: f790b99a1bf63ef160c967e23c46feea7787e531292bb827126334612c234ed489a0dc2c7ba33156416f0ffa8d25bf2b0fdb7f35c2ba60eb3e960572bece4001
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.8.2":
+  version: 8.9.0
+  resolution: "acorn@npm:8.9.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 25dfb94952386ecfb847e61934de04a4e7c2dc21c2e700fc4e2ef27ce78cb717700c4c4f279cd630bb4774948633c3859fc16063ec8573bda4568e0a312e6744
   languageName: node
   linkType: hard
 
@@ -7536,6 +7555,7 @@ __metadata:
     stylelint-config-standard: ^33.0.0
     synchd: ^1.0.1
     tag-tree: ^1.0.0
+    terser: ^5.18.1
     thirty-two: ^1.0.1
     transducers.js: ^0.3.2
     typed-emitter: ^2.1.0
@@ -13071,6 +13091,20 @@ __metadata:
   bin:
     terser: bin/terser
   checksum: f4a3ef4848a71f74f637c009395cf5a28660b56237fb8f13532cecfb24d6263e2dfbc1a511a11a94568988898f79cdcbecb9a4d8e104db35a0bea9639b70a325
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.18.1":
+  version: 5.18.1
+  resolution: "terser@npm:5.18.1"
+  dependencies:
+    "@jridgewell/source-map": ^0.3.3
+    acorn: ^8.8.2
+    commander: ^2.20.0
+    source-map-support: ~0.5.20
+  bin:
+    terser: bin/terser
+  checksum: 15d1af05aae451ce844f7dc3627db09ec79f842fa9a3cf2b40221a639249d70fcd91fd3baa9c970842d75e1dd2fb957eb1afd8a0fcfc9b2a3296076a4e72528a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
If you're not using a bundler, using `inboxsdk.min.js` instead of `inboxsdk.js` should mirror the old behavior.

Related to debugging #933.

Without #938, note that with this change the minified `inboxsdk.min.js` is using terser@5.18.2, while the remote loaded SDK is using terser@5.16.