### PR TITLE
feat: add collapseToggled event to AppMenu

### DIFF
--- a/examples/app-menu/content.js
+++ b/examples/app-menu/content.js
@@ -111,4 +111,6 @@ InboxSDK.load(2, 'app-menu').then(async (sdk) => {
       name: 'Nav Item 1',
       onClick: () => sdk.Router.goto('custom-route-3'),
     })
+
+    sdk.AppMenu.events.filter(event => event.type === 'collapseToggled').onValue(event => {console.log('collapseToggled', event)})
 });

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -216,13 +216,15 @@ const GmailElementGetter = {
     }
   }),
 
+  getAppBurgerMenu() {
+    return document.querySelector<HTMLElement>(
+      'header[role="banner"] > div > div > div[aria-expanded]'
+    );
+  },
+
   isAppBurgerMenuOpen() {
     return (
-      document
-        .querySelector<HTMLElement>(
-          'header[role="banner"] > div > div > div[aria-expanded]'
-        )
-        ?.getAttribute('aria-expanded') === 'true' ?? false
+      this.getAppBurgerMenu()?.getAttribute('aria-expanded') === 'true' ?? false
     );
   },
 

--- a/src/platform-implementation-js/views/collapsible-panel-view.ts
+++ b/src/platform-implementation-js/views/collapsible-panel-view.ts
@@ -47,6 +47,7 @@ type MessageEvents = {
  */
 export class CollapsiblePanelView extends (EventEmitter as new () => TypedEmitter<MessageEvents>) {
   static elementSelectors = {
+    /** Custom elements match this selector as well. */
     NATIVE: '.aqn.oy8Mbf',
     CUSTOM: '.inboxsdk__collapsiblePanel',
   } as const;
@@ -57,6 +58,7 @@ export class CollapsiblePanelView extends (EventEmitter as new () => TypedEmitte
     HOVER: 'aJu',
     COLLAPSED_HOVER: 'bym',
     PANEL_LESS: 'a3W',
+    TOGGLE_OPEN_STATE: 'aak',
   } as const;
   #panelDescriptor: AppMenuItemPanelDescriptor;
   #element: HTMLElement;


### PR DESCRIPTION
Allows timing events that require measuring around the width transition in collapsible panels.
