### PR TITLE
chore: reenable class field transforms

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,25 +1,9 @@
-function isBabelRegister(caller) {
-  return !!(caller && caller.name === '@babel/register');
-}
-
 module.exports = (api) => {
-  const isRegister = api.caller(isBabelRegister);
-
   return {
     presets: [
       [
         '@babel/preset-env',
         {
-          ...(!isRegister &&
-            !api.env('test') && {
-              // Until we no longer support Safari 15, prevent ReferenceError issues
-              // by forcing class properties transforms
-              // https://github.com/babel/babel/issues/14289
-              include: [
-                '@babel/plugin-proposal-class-properties',
-                '@babel/plugin-proposal-private-methods',
-              ],
-            }),
           ...(api.env('test') ? { targets: { node: 'current' } } : {}),
         },
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2032,13 +2032,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/source-map@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "@jridgewell/source-map@npm:0.3.2"
+"@jridgewell/source-map@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "@jridgewell/source-map@npm:0.3.3"
   dependencies:
     "@jridgewell/gen-mapping": ^0.3.0
     "@jridgewell/trace-mapping": ^0.3.9
-  checksum: 1b83f0eb944e77b70559a394d5d3b3f98a81fcc186946aceb3ef42d036762b52ef71493c6c0a3b7c1d2f08785f53ba2df1277fe629a06e6109588ff4cdcf7482
+  checksum: ae1302146339667da5cd6541260ecbef46ae06819a60f88da8f58b3e64682f787c09359933d050dea5d2173ea7fa40f40dd4d4e7a8d325c5892cccd99aaf8959
   languageName: node
   linkType: hard
 
@@ -3011,12 +3011,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.1.0, acorn@npm:^8.5.0, acorn@npm:^8.7.1, acorn@npm:^8.8.0, acorn@npm:^8.8.1":
+"acorn@npm:^8.1.0, acorn@npm:^8.7.1, acorn@npm:^8.8.0, acorn@npm:^8.8.1":
   version: 8.8.2
   resolution: "acorn@npm:8.8.2"
   bin:
     acorn: bin/acorn
   checksum: f790b99a1bf63ef160c967e23c46feea7787e531292bb827126334612c234ed489a0dc2c7ba33156416f0ffa8d25bf2b0fdb7f35c2ba60eb3e960572bece4001
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.8.2":
+  version: 8.9.0
+  resolution: "acorn@npm:8.9.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 25dfb94952386ecfb847e61934de04a4e7c2dc21c2e700fc4e2ef27ce78cb717700c4c4f279cd630bb4774948633c3859fc16063ec8573bda4568e0a312e6744
   languageName: node
   linkType: hard
 
@@ -13061,16 +13070,16 @@ __metadata:
   linkType: hard
 
 "terser@npm:^5.16.5":
-  version: 5.16.8
-  resolution: "terser@npm:5.16.8"
+  version: 5.18.2
+  resolution: "terser@npm:5.18.2"
   dependencies:
-    "@jridgewell/source-map": ^0.3.2
-    acorn: ^8.5.0
+    "@jridgewell/source-map": ^0.3.3
+    acorn: ^8.8.2
     commander: ^2.20.0
     source-map-support: ~0.5.20
   bin:
     terser: bin/terser
-  checksum: f4a3ef4848a71f74f637c009395cf5a28660b56237fb8f13532cecfb24d6263e2dfbc1a511a11a94568988898f79cdcbecb9a4d8e104db35a0bea9639b70a325
+  checksum: 50988412533bfd5a07294df002d772ad5b1277a9d1164dd19c8876a2094ced7b78fcf36cb32122a9a5238ba2597d77178a2385dfc6c4d506622309493f613cf4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps to terser@5.18.2 with `yarn up terser`. Should prevent an issue in #934 where we use different versions of terser between remote loaded code and the minified npm build.

terser@5.17.6 includes "fixes to mozilla AST's input and output, for class properties, private properties and static blocks". 

https://github.com/terser/terser/blob/master/CHANGELOG.md#v5176

This should resolve the discrepancy we saw between our downstream project which still has private field transforms enabled and uses currently uses a number of terser versions with `terser@5.16.8` being the max.

Related to #906.