### PR TITLE
fix: remote build source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "css-loader": "^6.7.3",
     "jest-css-modules": "^2.1.0",
     "jest-environment-jsdom": "^29.5.0",
-    "raw-loader": "^4.0.2",
     "style-loader": "^3.3.2",
     "terser": "^5.18.1",
     "webpack": "^5.76.3"

--- a/src/platform-implementation-js/lib/inject-script-EMBEDDED.ts
+++ b/src/platform-implementation-js/lib/inject-script-EMBEDDED.ts
@@ -1,18 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 export function injectScriptEmbedded() {
-  const url = 'https://www.inboxsdk.com/build/pageWorld.js';
-
   const script = document.createElement('script');
   script.type = 'text/javascript';
 
-  const originalCode = require('raw-loader!../../../packages/core/pageWorld.js');
+  const originalCode = require('../../injected-js/main?raw');
 
-  const codeParts: string[] = [];
-  codeParts.push(originalCode.default);
-  codeParts.push('\n//# sourceURL=' + url + '\n');
-
-  const codeToRun = codeParts.join('');
-  script.text = codeToRun;
+  script.text = originalCode;
 
   document.head.appendChild(script).parentNode!.removeChild(script);
 }

--- a/src/platform-implementation-js/lib/inject-script-EMBEDDED.ts
+++ b/src/platform-implementation-js/lib/inject-script-EMBEDDED.ts
@@ -3,7 +3,7 @@ export function injectScriptEmbedded() {
   const script = document.createElement('script');
   script.type = 'text/javascript';
 
-  const originalCode = require('../../injected-js/main?raw');
+  const originalCode = require('../../../packages/core/pageWorld?raw');
 
   script.text = originalCode;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3770,13 +3770,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"big.js@npm:^5.2.2":
-  version: 5.2.2
-  resolution: "big.js@npm:5.2.2"
-  checksum: b89b6e8419b097a8fb4ed2399a1931a68c612bce3cfd5ca8c214b2d017531191070f990598de2fc6f3f993d91c0f08aa82697717f6b3b8732c9731866d233c9e
-  languageName: node
-  linkType: hard
-
 "bignumber.js@npm:^9.0.1":
   version: 9.0.1
   resolution: "bignumber.js@npm:9.0.1"
@@ -5467,13 +5460,6 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 8487182da74aabd810ac6d6f1994111dfc0e331b01271ae01ec1eb0ad7b5ecc2bbbbd2f053c05cb55a1ac30449527d819bbfbf0e3de1023db308cbcb47f86601
-  languageName: node
-  linkType: hard
-
-"emojis-list@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "emojis-list@npm:3.0.0"
-  checksum: ddaaa02542e1e9436c03970eeed445f4ed29a5337dfba0fe0c38dfdd2af5da2429c2a0821304e8a8d1cadf27fdd5b22ff793571fa803ae16852a6975c65e8e70
   languageName: node
   linkType: hard
 
@@ -7527,7 +7513,6 @@ __metadata:
     postcss-loader: ^7.2.4
     postcss-selector-parser: ^2.2.0
     prettier: ^2.8.7
-    raw-loader: ^4.0.2
     react: ^17.0.2
     react-dom: ^17.0.2
     react-draggable-list: ^4.0.2
@@ -8891,7 +8876,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.1.2, json5@npm:^2.2.2":
+"json5@npm:^2.2.2":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -9210,17 +9195,6 @@ __metadata:
   version: 4.3.0
   resolution: "loader-runner@npm:4.3.0"
   checksum: a90e00dee9a16be118ea43fec3192d0b491fe03a32ed48a4132eb61d498f5536a03a1315531c19d284392a8726a4ecad71d82044c28d7f22ef62e029bf761569
-  languageName: node
-  linkType: hard
-
-"loader-utils@npm:^2.0.0":
-  version: 2.0.4
-  resolution: "loader-utils@npm:2.0.4"
-  dependencies:
-    big.js: ^5.2.2
-    emojis-list: ^3.0.0
-    json5: ^2.1.2
-  checksum: a5281f5fff1eaa310ad5e1164095689443630f3411e927f95031ab4fb83b4a98f388185bb1fe949e8ab8d4247004336a625e9255c22122b815bb9a4c5d8fc3b7
   languageName: node
   linkType: hard
 
@@ -11243,18 +11217,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raw-loader@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "raw-loader@npm:4.0.2"
-  dependencies:
-    loader-utils: ^2.0.0
-    schema-utils: ^3.0.0
-  peerDependencies:
-    webpack: ^4.0.0 || ^5.0.0
-  checksum: 51cc1b0d0e8c37c4336b5318f3b2c9c51d6998ad6f56ea09612afcfefc9c1f596341309e934a744ae907177f28efc9f1654eacd62151e82853fcc6d37450e795
-  languageName: node
-  linkType: hard
-
 "react-dom@npm:^17.0.2":
   version: 17.0.2
   resolution: "react-dom@npm:17.0.2"
@@ -11896,7 +11858,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^3.0.0, schema-utils@npm:^3.1.0, schema-utils@npm:^3.1.1":
+"schema-utils@npm:^3.1.0, schema-utils@npm:^3.1.1":
   version: 3.1.1
   resolution: "schema-utils@npm:3.1.1"
   dependencies:


### PR DESCRIPTION
This change should only affect remote and `integratedPageWorld` builds--not npm package output.

We've been having issues where our many of our SDK source maps appear to be incorrectly mapped to `gmail-attachment-card`. This may be because our remote builds feature inlining of `pageWorld.js` into `platform-implementation`.

This PR changes remote build code in the following ways:

- inlining source maps for pageWorld
- minification is re-enabled for remote builds
- Only `inboxsdk.js` is bundled as UMD. `platform-implementation` is now the webpack default executable
- Remove deprecated `raw-loader` in favor of webpack's asset modules