### PR TITLE
fix: stale style monkey patch in ComposeView

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/manage-button-grouping.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/manage-button-grouping.ts
@@ -121,8 +121,6 @@ function _groupButtonsIfNeeded(gmailComposeView: GmailComposeView) {
     groupButtonsIfNeededMap.delete(gmailComposeView);
     if (gmailComposeView.isDestroyed()) return;
 
-    _narrowButtonsIfNeeded(gmailComposeView);
-
     if (_doButtonsNeedToGroup(gmailComposeView)) {
       var groupedActionToolbarContainer =
         _createGroupedActionToolbarContainer(gmailComposeView);
@@ -142,38 +140,12 @@ function _groupButtonsIfNeeded(gmailComposeView: GmailComposeView) {
         groupToggleButtonViewController
       );
 
-      // remove narrow buttons class
-      gmailComposeView
-        .getElement()
-        .classList.remove('inboxsdk__compose_narrow_buttons');
-
-      // see if we should narrow buttons again
-      _narrowButtonsIfNeeded(gmailComposeView);
-
       gmailComposeView.getStopper().onValue(function () {
         groupedActionToolbarContainer.remove();
         groupToggleButtonViewController.destroy();
       });
     }
   });
-}
-
-function _narrowButtonsIfNeeded(gmailComposeView: GmailComposeView) {
-  if (
-    gmailComposeView.getElement().clientWidth >
-      _getBottomBarTableWidth(gmailComposeView) ||
-    gmailComposeView.getElement().querySelectorAll('.inboxsdk__composeButton')
-      .length === 0 ||
-    gmailComposeView
-      .getElement()
-      .classList.contains('inboxsdk__compose_narrow_buttons')
-  )
-    return;
-  gmailComposeView
-    .getElement()
-    .classList.add('inboxsdk__compose_narrow_buttons');
-  //force reflow
-  gmailComposeView.getElement().offsetTop;
 }
 
 function _doButtonsNeedToGroup(gmailComposeView: GmailComposeView): boolean {

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -453,15 +453,6 @@ steps to repro:
   width: 376px !important;
 }
 
-/* fix native button wrapping */
-.inboxsdk__compose .a8X {
-  overflow: visible;
-}
-
-.inboxsdk__compose .a8X > .bAK {
-  flex-wrap: nowrap;
-}
-
 /* mimic button styling */
 .inboxsdk__composeButton,
 .inboxsdk__compose_sendButton {

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -462,34 +462,6 @@ steps to repro:
   flex-wrap: nowrap;
 }
 
-/* in material Gmail reduce padding between buttons  */
-.inboxsdk__compose_narrow_buttons .gU:not(:first-child) {
-  padding-left: 5px;
-}
-
-.inboxsdk__compose_narrow_buttons .inboxsdk__compose_actionToolbar {
-  padding-left: 10px;
-}
-
-.inboxsdk__compose_narrow_buttons .wG:not(:first-child) {
-  margin-left: 15px;
-}
-
-.inboxsdk__compose_narrow_buttons
-  .inboxsdk__compose_actionToolbar
-  div.inboxsdk__composeButton:last-child {
-  margin-right: 0px;
-}
-
-.inboxsdk__compose_narrow_buttons
-  .inboxsdk__compose_actionToolbar
-  div.inboxsdk__composeButton
-  + div.inboxsdk__composeButton {
-  margin-left: 3px;
-}
-
-/* end narrow */
-
 /* mimic button styling */
 .inboxsdk__composeButton,
 .inboxsdk__compose_sendButton {


### PR DESCRIPTION
Removes additional button padding and margin around the ComposeView toolbar. @hwfwalton pointed out these styles were added a number of major Gmail changes ago.

The `.inboxsdk__compose_narrow_buttons` class made compose toolbar buttons wider. This was happening irrespective of how wide the compose view was when it was created.

There is still the bug around composes and button overflow when the client is <= 1000px wide. I believe that should be fixed with Gmail handles narrower than 1000px screens with ComposeView. For clients wider than 1000px, this patch should allow native button styles through.

# Screenshots

At roughly 1000px wide with the [example extension found here.](https://github.com/InboxSDK/InboxSDK/blob/e957bfff657e0f7fe2fd3a2b9764738a6e1fd5cd/examples/compose-tooltip-button/content.js#L1)

## Before

Note the additional 15px of spacing between ComposeView toolbar buttons

<img width="1216" alt="Screenshot 2023-07-25 at 13 47 35" src="https://github.com/InboxSDK/InboxSDK/assets/5156873/6932fe0e-ab5e-4e69-af8d-0f8fff4c7207">

## After

Note that the _Delete_ draft button is overflowing the compose window here.

<img width="1216" alt="Screenshot 2023-07-25 at 13 42 00" src="https://github.com/InboxSDK/InboxSDK/assets/5156873/30ee90a5-a4f1-48ce-89ba-4a6067424724">

Resolves #835, resolves #931