### PR TITLE
fix: rework ComposeView overflow menu handling

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -453,15 +453,6 @@ steps to repro:
   width: 376px !important;
 }
 
-/* fix native button wrapping */
-.inboxsdk__compose .a8X {
-  overflow: visible;
-}
-
-.inboxsdk__compose .a8X > .bAK {
-  flex-wrap: nowrap;
-}
-
 /* mimic button styling */
 .inboxsdk__composeButton,
 .inboxsdk__compose_sendButton {


### PR DESCRIPTION
- fix: remove overflow monkey patch
- tweak grouping of custom toolbar buttons to respond to native toolbar button overflow

The overflow: visible rule the SDK's styling adds seems to break Gmail's ComposeView toolbar menu overflow detection.

Closes #931