### PR TITLE
fix: caching of remote loaded SDK source maps

### DIFF
--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -252,7 +252,9 @@ async function webpackTask({
         ? [
             new webpack.SourceMapDevToolPlugin({
               fileContext: '../',
-              filename: '[file].map',
+              // Adds hash to the end of the sourcemap URL so that
+              // remote code source maps are not cached erroneously by Sentry.
+              filename: '[file].map?hash=[contenthash]',
               publicPath: 'https://www.inboxsdk.com/build/',
             }),
           ]

--- a/src/common/load-script.ts
+++ b/src/common/load-script.ts
@@ -51,9 +51,11 @@ function addScriptToPage(url: string, cors: boolean): Promise<void> {
 }
 
 export interface LoadScriptOptions {
-  // By default, the script is executed within a function, so that top-level
-  // variables defined in it don't become global variables. Setting nowrap to
-  // true disables this behavior.
+  /**
+   * By default, the script is executed within a function, so that top-level
+   * variables defined in it don't become global variables. Setting nowrap to
+   * true disables this behavior.
+   */
   nowrap?: boolean;
   disableSourceMappingURL?: boolean;
   XMLHttpRequest?: typeof XMLHttpRequest;

--- a/src/inboxsdk-js/loading/platform-implementation-loader.ts
+++ b/src/inboxsdk-js/loading/platform-implementation-loader.ts
@@ -20,7 +20,11 @@ const PlatformImplementationLoader = {
 
   _loadScript: once(function () {
     return loadScript(process.env.IMPLEMENTATION_URL!, {
-      nowrap: true, // platform-implementation has no top-level vars so no need for function wrapping
+      // platform-implementation has no top-level vars so no need for function wrapping
+      nowrap: true,
+      // webpack adds a sourceMappingURL comment.
+      // This source mapping URL includes cache breaking for error reporting in remote builds.
+      disableSourceMappingURL: true,
     });
   }),
 

--- a/src/platform-implementation-js/lib/inject-script-EMBEDDED.ts
+++ b/src/platform-implementation-js/lib/inject-script-EMBEDDED.ts
@@ -1,18 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 export function injectScriptEmbedded() {
-  const url = 'https://www.inboxsdk.com/build/pageWorld.js';
-
   const script = document.createElement('script');
   script.type = 'text/javascript';
 
   const originalCode = require('../../../packages/core/pageWorld?raw');
 
-  const codeParts: string[] = [];
-  codeParts.push(originalCode);
-  codeParts.push('\n//# sourceURL=' + url + '\n');
-
-  const codeToRun = codeParts.join('');
-  script.text = codeToRun;
+  script.text = originalCode;
 
   document.head.appendChild(script).parentNode!.removeChild(script);
 }


### PR DESCRIPTION
At Streak, we use Sentry for error reporting. Our Sentry error reports have been reporting incorrect source map positions for a few months now, as detailed in #950.

Based on what we've heard from Sentry, it seems like sentry may just be holding onto sourceMaps indefinitely (even if source has changed) because our remote builds 'load' source maps for three files without content hashes:

- https://www.inboxsdk.com/build/pageWorld.js
- https://www.inboxsdk.com/build/platform-implementation.js
- https://www.inboxsdk.com/build/inboxsdk.js

This PR switches from using `sourceURL` to using `sourceMappingUrl` to add a query param hash. This hash should prevent Sentry from caching out of date source maps against newer source.

Closes #950 