### PR TITLE
chore: append sourceURL in lieu of sourceMappingURL

### DIFF
--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -255,6 +255,7 @@ async function webpackTask({
               // Adds hash to the end of the sourcemap URL so that
               // remote code source maps are not cached erroneously by Sentry.
               filename: '[file].map?hash=[contenthash]',
+              append: `\n//# sourceURL=https://www.inboxsdk.com/build/[file]?hash=[contenthash]`,
               publicPath: 'https://www.inboxsdk.com/build/',
             }),
           ]

--- a/src/inboxsdk-js/loading/platform-implementation-loader.ts
+++ b/src/inboxsdk-js/loading/platform-implementation-loader.ts
@@ -22,8 +22,8 @@ const PlatformImplementationLoader = {
     return loadScript(process.env.IMPLEMENTATION_URL!, {
       // platform-implementation has no top-level vars so no need for function wrapping
       nowrap: true,
-      // webpack adds a sourceMappingURL comment.
-      // This source mapping URL includes cache breaking for error reporting in remote builds.
+      // webpack adds a sourceURL comment.
+      // This sourceURL includes cache breaking for error reporting in remote builds.
       disableSourceMappingURL: true,
     });
   }),


### PR DESCRIPTION
Related to #950. Sentry still seems to be caching source map paths regardless of `sourceMappingURL` being set. `sourceMappingURL` being set doesn't seem to work eval. This PR swaps back to using `sourceURL` but appended by webpack on each build target.