### PR TITLE
chore: disable double sourceURL

### DIFF
--- a/src/common/load-script.ts
+++ b/src/common/load-script.ts
@@ -58,6 +58,7 @@ export interface LoadScriptOptions {
    */
   nowrap?: boolean;
   disableSourceMappingURL?: boolean;
+  disableSourceURL?: boolean;
   XMLHttpRequest?: typeof XMLHttpRequest;
 }
 
@@ -115,7 +116,9 @@ export default function loadScript(
           codeParts.push('\n});');
         }
 
-        codeParts.push('\n//# sourceURL=' + url + '\n');
+        if (opts?.disableSourceURL !== true) {
+          codeParts.push('\n//# sourceURL=' + url + '\n');
+        }
 
         const codeToRun = codeParts.join('');
         let program;

--- a/src/inboxsdk-js/loading/platform-implementation-loader.ts
+++ b/src/inboxsdk-js/loading/platform-implementation-loader.ts
@@ -24,7 +24,7 @@ const PlatformImplementationLoader = {
       nowrap: true,
       // webpack adds a sourceURL comment.
       // This sourceURL includes cache breaking for error reporting in remote builds.
-      disableSourceMappingURL: true,
+      disableSourceURL: true,
     });
   }),
 


### PR DESCRIPTION
#959 successfully appended `sourceURL` but had an additional sourceURL comment added after resulting in a remotely loaded platform-implementation.js that ended with the following:

```
//# sourceURL=https://www.inboxsdk.com/build/platform-implementation.js?hash=4cefb05b726253ed68d15ba8d34e03b8
//# sourceURL=https://www.inboxsdk.com/build/platform-implementation.js
```

This change should only include the former sourceURL and not the latter.

Related to #950 