### PR TITLE
fix: ComposeView.prototype.attachFiles in fullscreen mode

### DIFF
--- a/examples/compose-tooltip-button/content.js
+++ b/examples/compose-tooltip-button/content.js
@@ -18,6 +18,26 @@ InboxSDK.load(2, 'simple-example').then(function (inboxSDK) {
       section: 'TRAY_LEFT',
     });
 
+    composeView.setFullscreen(true);
+
+    // From https://stackoverflow.com/a/34670057/1924257
+    composeView.attachFiles([
+      new File(['teehee'], 'filename', { type: 'text/html' }),
+    ]);
+
+    var button = composeView.addButton({
+      title: 'Monkeys!',
+      iconUrl: chrome.runtime.getURL('monkey.png'),
+      hasDropdown: true,
+      onClick(event) {
+        event.dropdown.el.innerHTML =
+          'hello world! <br> <button type="button">Foo</button>';
+        event.dropdown.el.addEventListener('click', function () {
+          console.log('selection', composeView.getSelectedBodyText());
+        });
+      },
+      section: 'TRAY_LEFT',
+    });
     var button2 = composeView.addButton({
       title: 'Monkeys 2',
       iconUrl: chrome.runtime.getURL('monkey.png'),

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
@@ -1185,31 +1185,28 @@ class GmailComposeView implements ComposeViewDriver {
     const dropzoneSelector = inline
       ? 'body > .aC7:not(.aWP)'
       : 'body > .aC7.aWP';
-    const el: HTMLElement | null | undefined = t.toArray<
-      any,
-      HTMLElement | null | undefined
-    >(
-      Array.prototype.slice.call(
-        document.querySelectorAll<HTMLElement>(dropzoneSelector)
-      ),
-      t.compose(
-        t.filter(isElementVisible),
-        t.filter((dropzone: HTMLElement) => {
-          const top = parseInt(dropzone.style.top, 10);
-          const bottom = top + parseInt(dropzone.style.height, 10);
-          const left = parseInt(dropzone.style.left, 10);
-          const right = left + parseInt(dropzone.style.width, 10);
-          return (
-            top >= rect.top &&
-            left >= rect.left &&
-            right <= rect.right &&
-            bottom <= rect.bottom
-          );
-        }),
-        t.take(1)
-      )
-    )[0];
+    const el = [
+      ...document.querySelectorAll<HTMLElement>(dropzoneSelector),
+    ].find((dropzone) => {
+      if (!isElementVisible(dropzone)) {
+        return false;
+      }
 
+      const top = parseInt(dropzone.style.top, 10);
+      /**
+       * Fullscreen compose dropzones have no inline height style. `bottom` is NaN because of this.
+       */
+      const bottom = top + parseInt(dropzone.style.height, 10);
+      const left = parseInt(dropzone.style.left, 10);
+      const right = left + parseInt(dropzone.style.width, 10);
+
+      return (
+        top >= rect.top &&
+        left >= rect.left &&
+        right <= rect.right &&
+        (this.isFullscreen() || bottom <= rect.bottom)
+      );
+    });
     if (!el) {
       throw new Error('Failed to find dropzone');
     }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
@@ -1194,7 +1194,7 @@ class GmailComposeView implements ComposeViewDriver {
 
       const top = parseInt(dropzone.style.top, 10);
       /**
-       * Fullscreen compose dropzones have no inline height style. `bottom` is NaN because of this.
+       * Fullscreen compose dropzones have no explicit `Element.prototype.style.height`. `bottom` is NaN because of this.
        */
       const bottom = top + parseInt(dropzone.style.height, 10);
       const left = parseInt(dropzone.style.left, 10);


### PR DESCRIPTION
See https://github.com/InboxSDK/InboxSDK/issues/953#issuecomment-1660996299. It appears that fullscreen compose file attachment dropzones don't have a `style.height` set, and so our `bottom <= rect.bottom` check was failing.

Closes #953