### PR TITLE
fix: skip extraction of threadMetadata for Gmail Ads

### DIFF
--- a/__tests__/injected-thread-identifier.ts
+++ b/__tests__/injected-thread-identifier.ts
@@ -55,6 +55,13 @@ test('threadIdentifier works', () => {
     }, 0);
   });
   expect(pageCommunicator.getThreadIdForThreadRowByDatabase(amb)).toBe(null);
+  // With Node 18.16.0 and jest@29.6.5, not including the following lines causes src/injected-js/gmail/thread-identifier/click-and-get-popup-url to fail with
+  // TypeError: Cannot redefine property: onerror
+  const oldOnError = window.onerror;
+  Object.defineProperty(window, 'onerror', {
+    value: oldOnError,
+    writable: true,
+  });
   expect(pageCommunicator.getThreadIdForThreadRowByClick(amb)).toBe(
     '14a5f1c5ad340727'
   );

--- a/examples/thread-rows/content.js
+++ b/examples/thread-rows/content.js
@@ -1,3 +1,5 @@
+/// <reference path="../types.d.ts" />
+
 function log() {
   console.log.apply(
     console,

--- a/src/injected-js/gmail/thread-identifier/click-and-get-popup-url.ts
+++ b/src/injected-js/gmail/thread-identifier/click-and-get-popup-url.ts
@@ -27,11 +27,11 @@ export default function clickAndGetPopupUrl(
     shiftKey: false,
     metaKey: true,
   };
-  (event as any).initMouseEvent(
+  event.initMouseEvent(
     'click',
     options.bubbles,
     options.cancelable,
-    document.defaultView,
+    document.defaultView!,
     options.button,
     options.pointerX,
     options.pointerY,

--- a/src/injected-js/gmail/thread-identifier/index.ts
+++ b/src/injected-js/gmail/thread-identifier/index.ts
@@ -140,6 +140,12 @@ function getGmailThreadIdForThreadRowByDatabase(
 ): string | null | undefined {
   const domRowMetadata =
     threadRowParser.extractMetadataFromThreadRow(threadRow);
+
+  if (domRowMetadata === threadRowParser.ThreadRowAd) {
+    // TODO do we want to do anything here?
+    return;
+  }
+
   const key = threadMetadataKey(domRowMetadata);
   const value = threadIdsByKey.get(key);
 

--- a/src/injected-js/gmail/thread-identifier/index.ts
+++ b/src/injected-js/gmail/thread-identifier/index.ts
@@ -5,6 +5,8 @@ import * as logger from '../../injected-logger';
 import * as threadRowParser from './thread-row-parser';
 import clickAndGetPopupUrl from './click-and-get-popup-url';
 import findParent from '../../../common/find-parent';
+import { CustomDomEvent } from '../../../platform-implementation-js/lib/dom/custom-events';
+
 export function setup() {
   try {
     processPreloadedThreads();
@@ -13,9 +15,12 @@ export function setup() {
   }
 
   document.addEventListener(
-    'inboxSDKtellMeThisThreadIdByDatabase',
-    function (event: any) {
+    CustomDomEvent.tellMeThisThreadIdByDatabase,
+    function (event) {
       try {
+        if (!(event.target instanceof HTMLElement)) {
+          throw new Error('event.target is not an HTMLElement');
+        }
         const threadId = getGmailThreadIdForThreadRowByDatabase(event.target);
 
         if (threadId) {
@@ -27,9 +32,13 @@ export function setup() {
     }
   );
   document.addEventListener(
-    'inboxSDKtellMeThisThreadIdByClick',
-    function (event: any) {
+    CustomDomEvent.tellMeThisThreadIdByClick,
+    function (event) {
       try {
+        if (!(event.target instanceof HTMLElement)) {
+          throw new Error('event.target is not an HTMLElement');
+        }
+
         const threadId = getGmailThreadIdForThreadRowByClick(event.target);
 
         if (threadId) {

--- a/src/injected-js/gmail/thread-identifier/thread-row-parser.ts
+++ b/src/injected-js/gmail/thread-identifier/thread-row-parser.ts
@@ -20,9 +20,8 @@ export function extractMetadataFromThreadRow(
   var timeSpan, subjectSpan, peopleDiv;
   assert(threadRow.hasAttribute('id'), 'check element is main thread row');
   var errors = [];
-  const threadRowClasses = Array.from(threadRow.classList);
   var threadRowIsVertical =
-    intersection(threadRowClasses, ['zA', 'apv']).length === 2;
+    intersection(Array.from(threadRow.classList), ['zA', 'apv']).length === 2;
   const isThreadRowAd = threadRow.querySelector('.am0');
 
   if (isThreadRowAd) {

--- a/src/injected-js/gmail/thread-identifier/thread-row-parser.ts
+++ b/src/injected-js/gmail/thread-identifier/thread-row-parser.ts
@@ -23,8 +23,7 @@ export function extractMetadataFromThreadRow(
   const threadRowClasses = Array.from(threadRow.classList);
   var threadRowIsVertical =
     intersection(threadRowClasses, ['zA', 'apv']).length === 2;
-  const isThreadRowAd =
-    intersection(threadRowClasses, ['zA', 'zE']).length === 2;
+  const isThreadRowAd = threadRow.querySelector('.am0');
 
   if (isThreadRowAd) {
     return ThreadRowAd;

--- a/src/injected-js/gmail/thread-identifier/thread-row-parser.ts
+++ b/src/injected-js/gmail/thread-identifier/thread-row-parser.ts
@@ -2,21 +2,33 @@ import intersection from 'lodash/intersection';
 import assert from 'assert';
 import * as logger from '../../injected-logger';
 import { cleanupPeopleLine } from '../../../platform-implementation-js/dom-driver/gmail/gmail-response-processor';
+
 export type ThreadRowMetadata = {
   timeString: string;
   subject: string;
   peopleHtml: string;
 };
+
+/**
+ * Ads in the Promotions tab aren't included with other thread row data.
+ */
+export const ThreadRowAd = Symbol(`ThreadRowAd`);
+
 export function extractMetadataFromThreadRow(
   threadRow: HTMLElement
-): ThreadRowMetadata {
+): ThreadRowMetadata | typeof ThreadRowAd {
   var timeSpan, subjectSpan, peopleDiv;
   assert(threadRow.hasAttribute('id'), 'check element is main thread row');
   var errors = [];
+  const threadRowClasses = Array.from(threadRow.classList);
   var threadRowIsVertical =
-    intersection(Array.from(threadRow.classList), ['zA', 'apv']).length === 2;
+    intersection(threadRowClasses, ['zA', 'apv']).length === 2;
+  const isThreadRowAd =
+    intersection(threadRowClasses, ['zA', 'zE']).length === 2;
 
-  if (threadRowIsVertical) {
+  if (isThreadRowAd) {
+    return ThreadRowAd;
+  } else if (threadRowIsVertical) {
     var threadRow2 = threadRow.nextElementSibling;
 
     if (!threadRow2) {

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-page-communicator.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-page-communicator.ts
@@ -1,5 +1,6 @@
 import { AutocompleteSearchResultWithId } from '../../../injected-js/gmail/modify-suggestions';
 import CommonPageCommunicator from '../../lib/common-page-communicator';
+import { CustomDomEvent } from '../../lib/dom/custom-events';
 import makeMutationObserverChunkedStream from '../../lib/dom/make-mutation-observer-chunked-stream';
 
 import Kefir from 'kefir';
@@ -80,7 +81,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     let threadid = threadRow.getAttribute('data-inboxsdk-threadid');
     if (!threadid) {
       threadRow.dispatchEvent(
-        new CustomEvent('inboxSDKtellMeThisThreadIdByDatabase', {
+        new CustomEvent(CustomDomEvent.tellMeThisThreadIdByDatabase, {
           bubbles: true,
           cancelable: false,
           detail: null,
@@ -95,7 +96,7 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     let threadid = threadRow.getAttribute('data-inboxsdk-threadid');
     if (!threadid) {
       threadRow.dispatchEvent(
-        new CustomEvent('inboxSDKtellMeThisThreadIdByClick', {
+        new CustomEvent(CustomDomEvent.tellMeThisThreadIdByClick, {
           bubbles: true,
           cancelable: false,
           detail: null,

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
@@ -278,15 +278,18 @@ class GmailThreadRowView {
     return this._alreadyHadModifications;
   }
 
-  // Returns a Kefir stream that emits this object once this object is ready for the
-  // user. It should almost always synchronously ready immediately, but there's
-  // a few cases such as with multiple inbox or the drafts page that it needs a moment.
-  // make sure you take until by on the gmailThreadRowView.getStopper() because waitForReady
-  // must not be called after the gmailThreadRowView is destroyed
+  /**
+   * @returns a Kefir stream that emits this object once this object is ready for the user.
+   *
+   * It should almost always synchronously ready immediately, but there's
+   * a few cases such as with multiple inbox or the drafts page that it needs a moment.
+   * make sure you take until by on the @see GmailThreadRowView#getStopper because waitForReady
+   * must not be called after the GmailThreadRowView is destroyed
+   */
   waitForReady(): Kefir.Observable<GmailThreadRowView, unknown> {
     const time = [0, 10, 100, 1000, 15000];
 
-    const step: any = () => {
+    const step = (): Kefir.Observable<GmailThreadRowView | never, unknown> => {
       if (this._threadIdReady()) {
         asap(() => {
           if (this._elements.length) this._removeUnclaimedModifications();

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
@@ -289,7 +289,7 @@ class GmailThreadRowView {
   waitForReady(): Kefir.Observable<GmailThreadRowView, unknown> {
     const time = [0, 10, 100, 1000, 15000];
 
-    const step = (): Kefir.Observable<GmailThreadRowView | never, unknown> => {
+    const step = (): Kefir.Observable<GmailThreadRowView, unknown> => {
       if (this._threadIdReady()) {
         asap(() => {
           if (this._elements.length) this._removeUnclaimedModifications();

--- a/src/platform-implementation-js/lib/dom/custom-events.ts
+++ b/src/platform-implementation-js/lib/dom/custom-events.ts
@@ -1,0 +1,4 @@
+export const enum CustomDomEvent {
+  tellMeThisThreadIdByDatabase = 'inboxSDKtellMeThisThreadIdByDatabase',
+  tellMeThisThreadIdByClick = 'inboxSDKtellMeThisThreadIdByClick',
+}


### PR DESCRIPTION
Skip trying to extract metadata for ads in Gmail's Promotions tab.

<img width="1059" alt="Screenshot 2023-08-03 at 16 21 54" src="https://github.com/InboxSDK/InboxSDK/assets/5156873/eef5ca1b-15d5-42a5-b631-3ba54eee568c">

The way I've checked parsing after the change was with the sample extension found here: https://github.com/InboxSDK/InboxSDK/blob/833d6b8bcca9646c36b627f67e2f73958364e3f7/examples/thread-rows/content.js.

Closes #943