### PR TITLE
chore: tie MessageView interface to MessageView and its driver

### DIFF
--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -13,6 +13,8 @@ import GmailDriver from './platform-implementation-js/dom-driver/gmail/gmail-dri
 import GmailRowListView from './platform-implementation-js/dom-driver/gmail/views/gmail-row-list-view';
 import type { AppLogger } from './platform-implementation-js/lib/logger';
 import type { IThreadRowView as ThreadRowView } from './platform-implementation-js/views/thread-row-view';
+import TypedEventEmitter from 'typed-emitter';
+import { MessageViewEvent } from './platform-implementation-js/views/conversations/message-view';
 export * from './platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view';
 
 export const LOADER_VERSION: string;
@@ -511,7 +513,7 @@ export interface MessageViewToolbarButtonDescriptor {
   orderHint?: number;
 }
 
-export interface MessageView extends EventEmitter {
+export interface MessageView extends TypedEventEmitter<MessageViewEvent> {
   addAttachmentIcon(
     opts:
       | MessageAttachmentIconDescriptor

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view/attachment-icon.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view/attachment-icon.ts
@@ -1,5 +1,6 @@
+import { AttachmentIcon as IAttachmentIcon } from '../../../../../inboxsdk';
 import SafeEventEmitter from '../../../../lib/safe-event-emitter';
 
-class AttachmentIcon extends SafeEventEmitter {}
+class AttachmentIcon extends (SafeEventEmitter as new () => IAttachmentIcon) {}
 
 export default AttachmentIcon;

--- a/src/platform-implementation-js/driver-interfaces/message-view-driver.ts
+++ b/src/platform-implementation-js/driver-interfaces/message-view-driver.ts
@@ -1,9 +1,12 @@
 import type * as Kefir from 'kefir';
 import type { AttachmentCardViewDriver } from './driver';
 import type {
-  MessageView,
+  AttachmentIcon,
+  Contact,
+  MessageAttachmentIconDescriptor,
   MessageViewToolbarButtonDescriptor,
 } from '../../inboxsdk';
+import { type MessageViewDriverEvents } from '../dom-driver/gmail/views/gmail-message-view';
 
 export type VIEW_STATE = 'HIDDEN' | 'COLLAPSED' | 'EXPANDED';
 export type MessageViewLinkDescriptor = {
@@ -13,18 +16,28 @@ export type MessageViewLinkDescriptor = {
   href: string;
   isInQuotedArea: boolean;
 };
-export type MessageViewDriver = MessageView & {
+export interface MessageViewDriver {
+  addAttachmentIcon(
+    opts:
+      | MessageAttachmentIconDescriptor
+      | Kefir.Stream<MessageAttachmentIconDescriptor, never>
+  ): AttachmentIcon;
+  isElementInQuotedArea(element: HTMLElement): boolean;
   getMessageID(): string;
   getContentsElement(): HTMLElement;
   addMoreMenuItem(options: MessageViewToolbarButtonDescriptor): void;
   getAttachmentCardViewDrivers(): Array<AttachmentCardViewDriver>;
   addAttachmentCard(options: Record<string, any>): AttachmentCardViewDriver;
   addButtonToDownloadAllArea(options: Record<string, any>): void;
-  getEventStream(): Kefir.Observable<Record<string, any>, unknown>;
+  getEventStream(): Kefir.Observable<MessageViewDriverEvents, unknown>;
+  getMessageIDAsync(): Promise<string>;
+  getRecipientsFull(): Promise<Array<Contact>>;
   getViewState(): VIEW_STATE;
   getDateString(): string;
   getReadyStream(): Kefir.Observable<any, unknown>;
   getRecipientEmailAddresses(): Array<string>;
+  getSender(): Contact;
   getThreadViewDriver(): Record<string, any>;
   hasOpenReply(): boolean;
-};
+  isLoaded(): boolean;
+}

--- a/src/platform-implementation-js/views/conversations/message-view.ts
+++ b/src/platform-implementation-js/views/conversations/message-view.ts
@@ -4,7 +4,9 @@ import EventEmitter from '../../lib/safe-event-emitter';
 import type Membrane from '../../lib/Membrane';
 import get from '../../../common/get-or-fail';
 import type AttachmentCardView from './attachment-card-view';
-import { MessageViewToolbarSectionNames } from '../../namespaces/conversations';
+import Conversations, {
+  MessageViewToolbarSectionNames,
+} from '../../namespaces/conversations';
 import type {
   MessageViewDriver,
   VIEW_STATE,
@@ -13,24 +15,46 @@ import type {
 import type { Driver } from '../../driver-interfaces/driver';
 import type { Contact, MessageView as IMessageView } from '../../../inboxsdk';
 import type { Observable } from 'kefir';
+import type {
+  MessageViewDriverEvents,
+  MessageViewDriverEventByName,
+} from '../../dom-driver/gmail/views/gmail-message-view';
+import type TypedEventEmitter from 'typed-emitter';
 
 interface Members {
-  Conversations: Record<string, any>;
+  Conversations: Conversations;
   driver: Driver;
   linksInBody: Array<MessageViewLinkDescriptor> | null | undefined;
   membrane: Membrane;
   messageViewImplementation: MessageViewDriver;
 }
-const memberMap = defonce(module, () => new WeakMap<MessageView, Members>()); // documented in src/docs/
 
-class MessageView extends EventEmitter implements IMessageView {
+export type MessageViewEvent = {
+  contactHover(
+    data: Omit<MessageViewDriverEventByName['contactHover'], 'eventName'>
+  ): void;
+  destroy(): void;
+  load(data: { messageView: MessageView }): void;
+  viewStateChange(data: {
+    oldViewState: VIEW_STATE;
+    newViewState: VIEW_STATE;
+    messageView: MessageView;
+  }): void;
+};
+
+const memberMap = defonce(module, () => new WeakMap<MessageView, Members>());
+
+class MessageView
+  extends (EventEmitter as new () => TypedEventEmitter<MessageViewEvent>)
+  implements IMessageView
+{
   destroyed: boolean = false;
 
   constructor(
     messageViewImplementation: MessageViewDriver,
     appId: string,
     membrane: Membrane,
-    Conversations: Record<string, any>,
+    Conversations: Conversations,
     driver: Driver
   ) {
     super();
@@ -253,7 +277,7 @@ class MessageView extends EventEmitter implements IMessageView {
 function _bindToEventStream(
   messageView: MessageView,
   members: Members,
-  stream: Observable<any, any>
+  stream: Observable<MessageViewDriverEvents, any>
 ) {
   stream.onEnd(function () {
     messageView.destroyed = true;
@@ -261,7 +285,9 @@ function _bindToEventStream(
     messageView.removeAllListeners();
   });
   stream
-    .filter(function (event) {
+    .filter(function (
+      event
+    ): event is MessageViewDriverEventByName['contactHover'] {
       return event.type !== 'internal' && event.eventName === 'contactHover';
     })
     .onValue(function (event) {
@@ -290,15 +316,17 @@ function _bindToEventStream(
   }
 
   stream
-    .filter(function (event) {
+    .filter(function (
+      event
+    ): event is MessageViewDriverEventByName['viewStateChange'] {
       return event.eventName === 'viewStateChange';
     })
     .onValue(function (event) {
       messageView.emit('viewStateChange', {
         oldViewState:
-          members.Conversations.MessageViewViewStates[event.oldValue],
+          members.Conversations.MessageViewViewStates[event.oldValue!],
         newViewState:
-          members.Conversations.MessageViewViewStates[event.newValue],
+          members.Conversations.MessageViewViewStates[event.newValue!],
         messageView: messageView,
       });
     });


### PR DESCRIPTION
This PR should be only TS type level changes. It also 

- adds narrower `getEventStream` typing for both the MessageView and its driver
- unlinks the Driver being an intersection type with the MessageView interface

Prelim for #939