### PR TITLE
fix(#903): use higher dpi image for close button on retina screens

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -19,3 +19,6 @@ rules:
   selector-id-pattern: null
   shorthand-property-no-redundant-values: null
   value-keyword-case: null
+  media-feature-range-notation:
+    # Until Safari 16.3 and Chrome 103 are no longer supported (https://caniuse.com/css-media-range-syntax)
+    - 'prefix'

--- a/examples/modal-example/content.js
+++ b/examples/modal-example/content.js
@@ -1,3 +1,5 @@
+/// <reference path="../types.d.ts" />
+
 'use strict';
 
 var div = document.createElement('div');

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -42,6 +42,13 @@
   left: 0;
 }
 
+@media (min-resolution: 192dpi) {
+  .inboxsdk__close_button::after {
+    background: url(https://www.gstatic.com/images/icons/material/system/2x/close_black_24dp.png);
+    background-size: contain;
+  }
+}
+
 :local(.app_sidebar_waiting_platform) {
   display: none;
 }


### PR DESCRIPTION
[Using this example extension](https://github.com/InboxSDK/InboxSDK/blob/6dee33e3c9306ae00b3a959b4ea05d3a0ad474a7/examples/modal-example/content.js#L3)

# Lower than 192dpi

Note the _X_ in the top right of the modal on the right.

![Screenshot 2023-08-09 at 13 03 49](https://github.com/InboxSDK/InboxSDK/assets/5156873/33736bc9-44c1-4559-a978-c90197602d8c)

# >= 192dpi

<img width="1624" alt="Screenshot 2023-08-09 at 13 04 16" src="https://github.com/InboxSDK/InboxSDK/assets/5156873/503107be-c133-41c6-bf78-a1d27680d22e">

Closes #903