### PR TITLE
Revert "fix: caching of remote loaded SDK source maps"

### DIFF
--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -252,9 +252,7 @@ async function webpackTask({
         ? [
             new webpack.SourceMapDevToolPlugin({
               fileContext: '../',
-              // Adds hash to the end of the sourcemap URL so that
-              // remote code source maps are not cached erroneously by Sentry.
-              filename: '[file].map?hash=[contenthash]',
+              filename: '[file].map',
               publicPath: 'https://www.inboxsdk.com/build/',
             }),
           ]

--- a/src/common/load-script.ts
+++ b/src/common/load-script.ts
@@ -56,7 +56,6 @@ export interface LoadScriptOptions {
   // true disables this behavior.
   nowrap?: boolean;
   disableSourceMappingURL?: boolean;
-  disableSourceURL?: boolean;
   XMLHttpRequest?: typeof XMLHttpRequest;
 }
 
@@ -114,9 +113,7 @@ export default function loadScript(
           codeParts.push('\n});');
         }
 
-        if (opts?.disableSourceURL !== true) {
-          codeParts.push('\n//# sourceURL=' + url + '\n');
-        }
+        codeParts.push('\n//# sourceURL=' + url + '\n');
 
         const codeToRun = codeParts.join('');
         let program;

--- a/src/common/load-script.ts
+++ b/src/common/load-script.ts
@@ -51,11 +51,9 @@ function addScriptToPage(url: string, cors: boolean): Promise<void> {
 }
 
 export interface LoadScriptOptions {
-  /**
-   * By default, the script is executed within a function, so that top-level
-   * variables defined in it don't become global variables. Setting nowrap to
-   * true disables this behavior.
-   */
+  // By default, the script is executed within a function, so that top-level
+  // variables defined in it don't become global variables. Setting nowrap to
+  // true disables this behavior.
   nowrap?: boolean;
   disableSourceMappingURL?: boolean;
   disableSourceURL?: boolean;

--- a/src/inboxsdk-js/loading/platform-implementation-loader.ts
+++ b/src/inboxsdk-js/loading/platform-implementation-loader.ts
@@ -22,9 +22,6 @@ const PlatformImplementationLoader = {
     return loadScript(process.env.IMPLEMENTATION_URL!, {
       // platform-implementation has no top-level vars so no need for function wrapping
       nowrap: true,
-      // webpack adds a sourceMappingURL comment.
-      // This source mapping URL includes cache breaking for error reporting in remote builds.
-      disableSourceURL: true,
     });
   }),
 

--- a/src/platform-implementation-js/lib/inject-script-EMBEDDED.ts
+++ b/src/platform-implementation-js/lib/inject-script-EMBEDDED.ts
@@ -1,11 +1,18 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 export function injectScriptEmbedded() {
+  const url = 'https://www.inboxsdk.com/build/pageWorld.js';
+
   const script = document.createElement('script');
   script.type = 'text/javascript';
 
   const originalCode = require('../../../packages/core/pageWorld?raw');
 
-  script.text = originalCode;
+  const codeParts: string[] = [];
+  codeParts.push(originalCode);
+  codeParts.push('\n//# sourceURL=' + url + '\n');
+
+  const codeToRun = codeParts.join('');
+  script.text = codeToRun;
 
   document.head.appendChild(script).parentNode!.removeChild(script);
 }


### PR DESCRIPTION
This reverts commit 78440a9bd48064e4f9d164d0a535ef7599cef5ea and e9debbf29798ef0b589affe3e780deaaa43085d1.

958d1cd (#960) was reverted in #974.