### PR TITLE
fix: re-enable attachment card button onClick handler

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-attachment-card-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-attachment-card-view.ts
@@ -106,6 +106,16 @@ class GmailAttachmentCardView {
       iconUrl: options.iconUrl,
       tooltip: options.tooltip,
     });
+    new BasicButtonViewController({
+      activateFunction: () => {
+        if (options.onClick) {
+          options.onClick({
+            getDownloadURL: () => this.getDownloadURL(),
+          });
+        }
+      },
+      buttonView: buttonView,
+    });
 
     this._addButton(buttonView);
   }


### PR DESCRIPTION
Before commit a57d655e a new BasicButtonViewController was instantiated and assigned to a variable which was never used.
I assume this was catched by ESLint and the variable assignment was removed.
Unfortunately the BasicButtonViewController was needed to make the button work.