### PR TITLE
fix(#950): add content hash to sourceMappingURL file name itself

### DIFF
--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -252,7 +252,7 @@ async function webpackTask({
         ? [
             new webpack.SourceMapDevToolPlugin({
               fileContext: '../',
-              filename: '[file].map',
+              filename: '[file].[contenthash].map',
               publicPath: 'https://www.inboxsdk.com/build/',
             }),
           ]


### PR DESCRIPTION
May allow cache breaking on the sentry side to get source maps to work correctly.
