### PR TITLE
chore: check places isUsingSyncAPI variants are used

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
@@ -73,7 +73,7 @@ import type Logger from '../../lib/logger';
 import type PageCommunicator from './gmail-page-communicator';
 import type { RouteParams } from '../../namespaces/router';
 import type ButterBar from '../../namespaces/butter-bar';
-import type { Driver, DrawerViewOptions } from '../../driver-interfaces/driver';
+import type { DrawerViewOptions } from '../../driver-interfaces/driver';
 import type GmailComposeView from './views/gmail-compose-view';
 import type GmailMessageView from './views/gmail-message-view';
 import type GmailThreadView from './views/gmail-thread-view';
@@ -92,7 +92,7 @@ import { MoleOptions } from '../../driver-interfaces/mole-view-driver';
 import { Contact } from '../../../inboxsdk';
 import GmailAttachmentCardView from './views/gmail-attachment-card-view';
 
-class GmailDriver implements Driver {
+class GmailDriver {
   _appId: string;
   _logger: Logger;
   _opts: PiOpts;
@@ -909,6 +909,9 @@ class GmailDriver implements Driver {
     return !!((global as any).GLOBALS && (global as any)._GM_main);
   }
 
+  /**
+   * @see PageCommunicator#isUsingSyncAPI
+   */
   isUsingSyncAPI(): boolean {
     return this._pageCommunicator.isUsingSyncAPI();
   }

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-page-communicator.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-page-communicator.ts
@@ -136,6 +136,13 @@ export default class GmailPageCommunicator extends CommonPageCommunicator {
     return s;
   }
 
+  /**
+   * This method seems to have existed to distinguish between Inbox and Gmail. Since Inbox support was dropped in '19, it exists only as a vestige.
+   *
+   * TODO: Remove this method and its machinery.
+   *
+   * @returns effectively only {true} or, very rarely, {null} or {false}.
+   */
   isUsingSyncAPI(): boolean {
     const s = document.head.getAttribute('data-inboxsdk-using-sync-api');
     if (s == null) throw new Error('Failed to read value');

--- a/src/platform-implementation-js/driver-common/getGmailThreadIdForRfcMessageId.ts
+++ b/src/platform-implementation-js/driver-common/getGmailThreadIdForRfcMessageId.ts
@@ -9,7 +9,7 @@ async function getGmailThreadIdForRfcMessageId(
   driver: Driver,
   rfcMessageId: string
 ): Promise<string> {
-  if ((driver as any).isUsingSyncAPI && (driver as any).isUsingSyncAPI()) {
+  if (driver.isUsingSyncAPI()) {
     const { threads: threadDescriptors } = await getSyncThreadsForSearch(
       driver,
       'rfc822msgid:' + rfcMessageId

--- a/src/platform-implementation-js/lib/common-page-communicator.ts
+++ b/src/platform-implementation-js/lib/common-page-communicator.ts
@@ -45,10 +45,6 @@ export default class CommonPageCommunicator {
     throw new Error("Failed to look up 'ik' value");
   }
 
-  isUsingSyncAPI(): boolean {
-    return false;
-  }
-
   async getXsrfToken(): Promise<string> {
     const existingHeader = document.head.getAttribute(
       'data-inboxsdk-xsrf-token'


### PR DESCRIPTION
Digging into [isUsingSyncAPI](https://github.com/InboxSDK/InboxSDK/blob/c8b9f02934d8cd87121bb121277bed046365144a/src/platform-implementation-js/dom-driver/gmail/gmail-page-communicator.ts#L146) for #942, it appears that isUsingSyncAPI=true is a million times more frequently logged than false in the last week up until 2023-08-15. Ignoring (or removing) isUsingSyncAPI=false seems like it might be a viable path forward
