### PR TITLE
fix: relax recipientsElement selector from error to warning

### DIFF
--- a/src/platform-implementation-js/lib/dom/querySelectorOrWarn.test.ts
+++ b/src/platform-implementation-js/lib/dom/querySelectorOrWarn.test.ts
@@ -1,0 +1,18 @@
+import { querySelectorOrWarn } from './querySelectorOrWarn';
+
+const p = document.createElement('p');
+document.body.appendChild(p);
+
+test('works', () => {
+  expect(querySelectorOrWarn(document, 'p')).toBe(p);
+  expect(querySelectorOrWarn(document.body, 'p')).toBe(p);
+});
+
+test('fails', () => {
+  // https://stackoverflow.com/a/56677834/1924257
+  const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
+
+  expect(querySelectorOrWarn(document, 'p.foo')).toBeNull();
+  expect(consoleWarnMock).toHaveBeenCalledTimes(1);
+  consoleWarnMock.mockRestore();
+});

--- a/src/platform-implementation-js/lib/dom/querySelectorOrWarn.ts
+++ b/src/platform-implementation-js/lib/dom/querySelectorOrWarn.ts
@@ -1,0 +1,14 @@
+export function querySelectorOrWarn<T extends Element>(
+  el: Document | DocumentFragment | Element,
+  selector: string
+): T | null {
+  const result = el.querySelector<T>(selector);
+
+  if (result) {
+    return result;
+  }
+
+  console.warn('element with selector not found:', selector);
+
+  return null;
+}

--- a/src/platform-implementation-js/views/thread-row-view.ts
+++ b/src/platform-implementation-js/views/thread-row-view.ts
@@ -35,6 +35,9 @@ export type IThreadRowView = EmitterType & {
     imageDescriptor: ImageDescriptor | Observable<ImageDescriptor | null, any>
   ): void;
   getElement(): HTMLElement;
+  /**
+   * @returns the {number} of visible draft messages in the row. This is purely an estimate based on what is visible in the row.
+   */
   getVisibleDraftCount(): number;
   /** @deprecated */
   getThreadIDIfStable(): string | null | undefined;
@@ -62,6 +65,9 @@ export type IThreadRowView = EmitterType & {
       | null
       | Observable<ThreadDateDescriptor | null, any>
   ): void;
+  /**
+   * @returns the {number} of visible messages in the thread based on the visible numeric marker.
+   */
   getVisibleMessageCount(): number;
   getSubject(): string;
   replaceSubject(newSubjectStr: string): void;


### PR DESCRIPTION
In some cases, recipientsEmail is null. It may be from the SDK being run alongside the popular 'Email Tracker for Gmail, Mail Merge-Mailtrack' extension. This PR changes gmail-thread-row-view's selector to not throw when recipientsElement isn't present. Instead, 0 counts are returned for both getVisibleMessageCount and getVisibleDraftCount.

Our docs around ThreadRowView's getVisibleDraftCount method already suggest the resulting number is 'purely an estimate'. getVisibleMessageCount is more confident. Neither mentions throwing.
