### PR TITLE
fix: expand isThreadRowAd selector to include a different ad format

### DIFF
--- a/src/injected-js/gmail/thread-identifier/thread-row-parser.ts
+++ b/src/injected-js/gmail/thread-identifier/thread-row-parser.ts
@@ -22,7 +22,7 @@ export function extractMetadataFromThreadRow(
   var errors = [];
   var threadRowIsVertical =
     intersection(Array.from(threadRow.classList), ['zA', 'apv']).length === 2;
-  const isThreadRowAd = threadRow.querySelector('.am0');
+  const isThreadRowAd = threadRow.querySelector('.am0,.bvA');
 
   if (isThreadRowAd) {
     return ThreadRowAd;


### PR DESCRIPTION
Supports an additional ad format when identifying ads in Gmail's Promotions and Social tabs.

![a-screenshot](https://github.com/InboxSDK/InboxSDK/assets/1148312/a204282b-2c61-4a1b-bf9a-8c0346de473b)

Tested with sample extension: https://github.com/InboxSDK/InboxSDK/tree/main/examples/thread-rows

Closes https://github.com/InboxSDK/InboxSDK/issues/1000