### PR TITLE
MV3ify mole-example

### DIFF
--- a/examples/mole-example/manifest.json
+++ b/examples/mole-example/manifest.json
@@ -11,13 +11,13 @@
   ],
   "permissions": ["https://mail.google.com/"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["inboxsdk.js.map", "pageWorld.js", "pageWorld.js.map"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3
 }


### PR DESCRIPTION
Cherry picked from #1008 to test #970's dropping of MV2 support from npm builds.