### PR TITLE
Added data-tooltip to Toolbar Button

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
@@ -593,6 +593,7 @@ class GmailThreadRowView {
 
             if (buttonDescriptor.title) {
               buttonSpan.setAttribute('title', buttonDescriptor.title);
+              buttonSpan.setAttribute('data-tooltip', buttonDescriptor.title);
             } else {
               buttonSpan.removeAttribute('title');
             }


### PR DESCRIPTION
The tooltip was not displaying when hovering the thread row view button. Upon inspecting the Gmail DOM, it was observed that other native Gmail buttons utilize the data-tooltip attribute for tooltip text.