### PR TITLE
chore: drop node polyfill 'assert'

### DIFF
--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -271,8 +271,6 @@ async function webpackTask({
     resolve: {
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
       fallback: {
-        // 'assert' used in the SDK directly
-        assert: require.resolve('assert/'),
         // 'querystring' used in the SDK directly
         querystring: require.resolve('querystring-es3/'),
       },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
     "asap": "^2.0.3",
-    "assert": "^2.0.0",
     "auto-html": "^1.0.4",
     "babel-jest": "^29",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",

--- a/src/common/assert.test.ts
+++ b/src/common/assert.test.ts
@@ -1,0 +1,21 @@
+import { AssertionError, assert } from './assert';
+
+describe(assert.name, () => {
+  it('should throw an error if the condition is false', () => {
+    expect(() => assert(false, 'test')).toThrow(AssertionError);
+  });
+
+  it('should not throw an error if the condition is true', () => {
+    expect(() => assert(true, 'test')).not.toThrow(AssertionError);
+  });
+
+  it('should throw an error with the correct message', () => {
+    try {
+      assert(false, 'test');
+    } catch (e) {
+      if (e instanceof Error) {
+        expect(e.message).toEqual('test');
+      }
+    }
+  });
+});

--- a/src/common/assert.ts
+++ b/src/common/assert.ts
@@ -1,0 +1,15 @@
+export class AssertionError extends Error {
+  name = 'AssertionError';
+  constructor(message?: string) {
+    super(message ?? 'assertion failed');
+  }
+}
+
+export function assert(condition: unknown, message?: string) {
+  // eslint-disable-next-line no-extra-boolean-cast -- this is to mimic Node's assert behavior
+  if (!!condition) {
+    // ok
+  } else {
+    throw new AssertionError(message);
+  }
+}

--- a/src/injected-js/gmail/thread-identifier/thread-row-parser.ts
+++ b/src/injected-js/gmail/thread-identifier/thread-row-parser.ts
@@ -1,7 +1,7 @@
 import intersection from 'lodash/intersection';
-import assert from 'assert';
 import * as logger from '../../injected-logger';
 import { cleanupPeopleLine } from '../../../platform-implementation-js/dom-driver/gmail/gmail-response-processor';
+import { assert } from '../../../common/assert';
 
 export type ThreadRowMetadata = {
   timeString: string;

--- a/src/injected-js/xhr-proxy-factory.test.ts
+++ b/src/injected-js/xhr-proxy-factory.test.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import assert from 'node:assert';
 import _ from 'lodash';
 import noop from 'lodash/noop';
 import sinon from 'sinon';

--- a/src/injected-js/xhr-proxy-factory.ts
+++ b/src/injected-js/xhr-proxy-factory.ts
@@ -5,7 +5,7 @@ import each from 'lodash/each';
 import filter from 'lodash/filter';
 import includes from 'lodash/includes';
 import once from 'lodash/once';
-import assert from 'assert';
+import { assert } from '../common/assert';
 import EventEmitter from 'events';
 import { parse as deparam } from 'querystring';
 export type Opts = {

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-response-processor.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-response-processor.ts
@@ -2,8 +2,8 @@ import flatten from 'lodash/flatten';
 import last from 'lodash/last';
 import t from 'transducers.js';
 import mapIndexed from 'map-indexed-xf';
-import assert from 'assert';
 import htmlToText from '../../../common/html-to-text';
+import { assert } from '../../../common/assert';
 
 export function interpretSentEmailResponse(responseString: string): {
   threadID: string;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-row-list-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-row-list-view.ts
@@ -1,6 +1,5 @@
 import find from 'lodash/find';
 import zip from 'lodash/zip';
-import assert from 'assert';
 import * as Kefir from 'kefir';
 import kefirBus from 'kefir-bus';
 import type { Bus } from 'kefir-bus';
@@ -11,6 +10,7 @@ import GmailThreadRowView from './gmail-thread-row-view';
 import makeElementChildStream from '../../../lib/dom/make-element-child-stream';
 import type GmailDriver from '../gmail-driver';
 import type GmailRouteView from './gmail-route-view/gmail-route-view';
+import { assert } from '../../../../common/assert';
 const THREAD_ROW_SELECTED_CLASSNAME = 'x7';
 const THREAD_ROW_SELECTED_CLASSNAME_REGEX = /\bx7\b/;
 
@@ -184,7 +184,7 @@ class GmailRowListView {
       const newCols = newTableParent.querySelectorAll<HTMLElement>(
         'table.cf > colgroup > col'
       );
-      assert.strictEqual(firstCols.length, newCols.length);
+      assert(Object.is(firstCols.length, newCols.length));
       zip(firstCols, newCols).forEach(([firstCol, newCol]) => {
         newCol!.style.width = firstCol!.style.width;
       });

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
@@ -5,7 +5,6 @@ import intersection from 'lodash/intersection';
 import uniqBy from 'lodash/uniqBy';
 import flatMap from 'lodash/flatMap';
 import { defonce } from 'ud';
-import assert from 'assert';
 import * as Kefir from 'kefir';
 import asap from 'asap';
 import querySelector from '../../../lib/dom/querySelectorOrFail';
@@ -27,6 +26,7 @@ import type {
   LabelDescriptor,
   ThreadDateDescriptor,
 } from '../../../../inboxsdk';
+import { assert } from '../../../../common/assert';
 
 type LabelMod = {
   gmailLabelView: Record<string, any>;

--- a/test/lib/mock-element-parent.ts
+++ b/test/lib/mock-element-parent.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import assert from 'node:assert';
 import EventEmitter from 'events';
 
 // Mock element suitable for use with MockMutationObserver

--- a/yarn.lock
+++ b/yarn.lock
@@ -3942,9 +3942,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001400, caniuse-lite@npm:^1.0.30001449":
-  version: 1.0.30001470
-  resolution: "caniuse-lite@npm:1.0.30001470"
-  checksum: 14ce3cf17c90960309b82256b991c546a53aa321efae973578954faf5256a88dec1eaebe6bea516cfca04ea146787a89664a09b254df72da5c3ec4a95b5f319f
+  version: 1.0.30001532
+  resolution: "caniuse-lite@npm:1.0.30001532"
+  checksum: 613abeb15e03dde307d543195a7860f7ba7450c9c9262d45642b2c8fbe097914fa060d68c8647f9d443947b1f62b09d891858bde7d2cac94fae8133a0b518b28
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,18 +3417,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"assert@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "assert@npm:2.0.0"
-  dependencies:
-    es6-object-assign: ^1.1.0
-    is-nan: ^1.2.1
-    object-is: ^1.0.1
-    util: ^0.12.0
-  checksum: bb91f181a86d10588ee16c5e09c280f9811373974c29974cbe401987ea34e966699d7989a812b0e19377b511ea0bc627f5905647ce569311824848ede382cae8
-  languageName: node
-  linkType: hard
-
 "assign-symbols@npm:^1.0.0":
   version: 1.0.0
   resolution: "assign-symbols@npm:1.0.0"
@@ -5174,13 +5162,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es6-object-assign@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "es6-object-assign@npm:1.1.0"
-  checksum: 8d4fdf63484d78b5c64cacc2c2e1165bc7b6a64b739d2a9db6a4dc8641d99cc9efb433cdd4dc3d3d6b00bfa6ce959694e4665e3255190339945c5f33b692b5d8
-  languageName: node
-  linkType: hard
-
 "es6-symbol@npm:^3.1.1, es6-symbol@npm:~3.1.3":
   version: 3.1.3
   resolution: "es6-symbol@npm:3.1.3"
@@ -6836,7 +6817,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.59.8
     "@typescript-eslint/parser": ^5.59.8
     asap: ^2.0.3
-    assert: ^2.0.0
     auto-html: ^1.0.4
     babel-jest: ^29
     babel-loader: ^9.1.2
@@ -7034,16 +7014,6 @@ __metadata:
   dependencies:
     kind-of: ^6.0.0
   checksum: 8e475968e9b22f9849343c25854fa24492dbe8ba0dea1a818978f9f1b887339190b022c9300d08c47fe36f1b913d70ce8cbaca00369c55a56705fdb7caed37fe
-  languageName: node
-  linkType: hard
-
-"is-arguments@npm:^1.0.4":
-  version: 1.1.1
-  resolution: "is-arguments@npm:1.1.1"
-  dependencies:
-    call-bind: ^1.0.2
-    has-tostringtag: ^1.0.0
-  checksum: 7f02700ec2171b691ef3e4d0e3e6c0ba408e8434368504bb593d0d7c891c0dbfda6d19d30808b904a6cb1929bca648c061ba438c39f296c2a8ca083229c49f27
   languageName: node
   linkType: hard
 
@@ -7247,15 +7217,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-generator-function@npm:^1.0.7":
-  version: 1.0.10
-  resolution: "is-generator-function@npm:1.0.10"
-  dependencies:
-    has-tostringtag: ^1.0.0
-  checksum: d54644e7dbaccef15ceb1e5d91d680eb5068c9ee9f9eb0a9e04173eb5542c9b51b5ab52c5537f5703e48d5fddfd376817c1ca07a84a407b7115b769d4bdde72b
-  languageName: node
-  linkType: hard
-
 "is-glob@npm:^3.1.0":
   version: 3.1.0
   resolution: "is-glob@npm:3.1.0"
@@ -7287,16 +7248,6 @@ __metadata:
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
   checksum: 93a32f01940220532e5948538699ad610d5924ac86093fcee83022252b363eb0cc99ba53ab084a04e4fb62bf7b5731f55496257a4c38adf87af9c4d352c71c35
-  languageName: node
-  linkType: hard
-
-"is-nan@npm:^1.2.1":
-  version: 1.3.2
-  resolution: "is-nan@npm:1.3.2"
-  dependencies:
-    call-bind: ^1.0.0
-    define-properties: ^1.1.3
-  checksum: 5dfadcef6ad12d3029d43643d9800adbba21cf3ce2ec849f734b0e14ee8da4070d82b15fdb35138716d02587c6578225b9a22779cab34888a139cc43e4e3610a
   languageName: node
   linkType: hard
 
@@ -7475,15 +7426,6 @@ __metadata:
     gopd: ^1.0.1
     has-tostringtag: ^1.0.0
   checksum: aac6ecb59d4c56a1cdeb69b1f129154ef462bbffe434cb8a8235ca89b42f258b7ae94073c41b3cb7bce37f6a1733ad4499f07882d5d5093a7ba84dfc4ebb8017
-  languageName: node
-  linkType: hard
-
-"is-typed-array@npm:^1.1.3":
-  version: 1.1.12
-  resolution: "is-typed-array@npm:1.1.12"
-  dependencies:
-    which-typed-array: ^1.1.11
-  checksum: 4c89c4a3be07186caddadf92197b17fda663a9d259ea0d44a85f171558270d36059d1c386d34a12cba22dfade5aba497ce22778e866adc9406098c8fc4771796
   languageName: node
   linkType: hard
 
@@ -9365,16 +9307,6 @@ __metadata:
   version: 1.12.3
   resolution: "object-inspect@npm:1.12.3"
   checksum: dabfd824d97a5f407e6d5d24810d888859f6be394d8b733a77442b277e0808860555176719c5905e765e3743a7cada6b8b0a3b85e5331c530fd418cc8ae991db
-  languageName: node
-  linkType: hard
-
-"object-is@npm:^1.0.1":
-  version: 1.1.5
-  resolution: "object-is@npm:1.1.5"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-  checksum: 989b18c4cba258a6b74dc1d74a41805c1a1425bce29f6cabb50dcb1a6a651ea9104a1b07046739a49a5bb1bc49727bcb00efd5c55f932f6ea04ec8927a7901fe
   languageName: node
   linkType: hard
 
@@ -12587,19 +12519,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util@npm:^0.12.0":
-  version: 0.12.5
-  resolution: "util@npm:0.12.5"
-  dependencies:
-    inherits: ^2.0.3
-    is-arguments: ^1.0.4
-    is-generator-function: ^1.0.7
-    is-typed-array: ^1.1.3
-    which-typed-array: ^1.1.2
-  checksum: 705e51f0de5b446f4edec10739752ac25856541e0254ea1e7e45e5b9f9b0cb105bc4bd415736a6210edc68245a7f903bf085ffb08dd7deb8a0e847f60538a38a
-  languageName: node
-  linkType: hard
-
 "v8-compile-cache@npm:^2.3.0":
   version: 2.3.0
   resolution: "v8-compile-cache@npm:2.3.0"
@@ -12820,19 +12739,6 @@ __metadata:
   version: 1.0.0
   resolution: "which-module@npm:1.0.0"
   checksum: 98434f7deb36350cb543c1f15612188541737e1f12d39b23b1c371dff5cf4aa4746210f2bdec202d5fe9da8682adaf8e3f7c44c520687d30948cfc59d5534edb
-  languageName: node
-  linkType: hard
-
-"which-typed-array@npm:^1.1.11, which-typed-array@npm:^1.1.2":
-  version: 1.1.11
-  resolution: "which-typed-array@npm:1.1.11"
-  dependencies:
-    available-typed-arrays: ^1.0.5
-    call-bind: ^1.0.2
-    for-each: ^0.3.3
-    gopd: ^1.0.1
-    has-tostringtag: ^1.0.0
-  checksum: 711ffc8ef891ca6597b19539075ec3e08bb9b4c2ca1f78887e3c07a977ab91ac1421940505a197758fb5939aa9524976d0a5bbcac34d07ed6faa75cedbb17206
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removes node polyfill `assert` in favor of a single function. In tests, `node:assert` is used. Where `assert.strictEqual` was used previously in browser code, `assert(Object.isEqual(...))` is now used.

Note: there are at node polyfills present within the SDK for:

- `buffer`
- `querystring-es3`
- `process`