### PR TITLE
added missing title property

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
@@ -449,6 +449,7 @@ class GmailDriver implements Driver {
             hasDropdown: options.hasDropdown,
             iconClass: options.iconClass,
             iconUrl: options.iconUrl,
+            title: options.title,
             orderHint: options.orderHint,
             onClick: (event: any) => {
               if (!options.onClick) return;


### PR DESCRIPTION
`title`  property was missing when passing Button descriptor to  `gmailThreadRow.addButton()`