### PR TITLE
chore: move examples folder over to MV3 support

### DIFF
--- a/examples/add-route-view-sections/manifest.json
+++ b/examples/add-route-view-sections/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Collapsible Sections Inbox SDK example",
   "description": "Demonstrate adding collapsible sections list pages",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,20 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "monkey-face.jpg",
-    "lion.png",
-    "monkey.png"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "monkey-face.jpg", "lion.png", "monkey.png"]
+    }
   ],
-
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/app-menu/manifest.json
+++ b/examples/app-menu/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "AppMenu - Example Gmail Extension",
   "description": "Example extension testing NavMenu and NavItemView.",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,18 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "monkey-face.jpg",
-    "monkey.png",
-    "lion.png"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "monkey-face.jpg", "monkey.png", "lion.png"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/attachment-card/manifest.json
+++ b/examples/attachment-card/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Attachment Card Example Extension",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -15,22 +15,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": [
-    "https://mail.google.com/",
-    "https://mail-attachment.googleusercontent.com/"
-  ],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "partycat.jpg",
-    "zipicon.png"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "partycat.jpg", "zipicon.png"]
+    }
   ],
-
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/browser-test/manifest.json
+++ b/examples/browser-test/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "InboxSDK Test Extension",
   "description": "Used for automated tests",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,16 +9,16 @@
       "run_at": "document_start"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "monkey.png"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "monkey.png"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/compose-dropdown-button/manifest.json
+++ b/examples/compose-dropdown-button/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Compose Dropdown Example Extension",
   "description": "Compose dropdown button example!",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -10,17 +10,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "monkey.png"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "monkey.png"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/compose-stream/manifest.json
+++ b/examples/compose-stream/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Compose Button Stream Example Extension",
   "description": "Compose Button Stream example!",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -10,19 +10,16 @@
       "run_at": "document_start"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "monkey.png",
-    "monkey-face.jpg",
-    "lion.png"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "monkey.png", "monkey-face.jpg", "lion.png"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/compose-tooltip-button/manifest.json
+++ b/examples/compose-tooltip-button/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Compose Tooltip Example Extension",
   "description": "inboxsdk example",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -10,18 +10,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "monkey.png",
-    "partycat.jpg"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "monkey.png", "partycat.jpg"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/contact-hover-example/manifest.json
+++ b/examples/contact-hover-example/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Contact Hover - Example Gmail Extension",
   "description": "Example extension showing use of the Streak Gmail SDK",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,16 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "monkey-face.jpg",
-    "pageWorld.js",
-    "pageWorld.js.map"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["monkey-face.jpg", "pageWorld.js"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/custom-thread-list/manifest.json
+++ b/examples/custom-thread-list/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Custom Thread List - Example Gmail Extension",
   "description": "Example extension showing use of the Streak Gmail SDK",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,16 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "monkey-face.jpg",
-    "pageWorld.js",
-    "pageWorld.js.map"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["monkey-face.jpg", "pageWorld.js"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/custom-view/manifest.json
+++ b/examples/custom-view/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Custom View Inbox SDK example",
   "description": "Demonstrate registering a custom view",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,20 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "monkey-face.jpg",
-    "lion.png",
-    "monkey.png"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "monkey-face.jpg", "lion.png", "monkey.png"]
+    }
   ],
-
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/header-support/manifest.json
+++ b/examples/header-support/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Header Support",
   "description": "Header Support example!",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,11 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
-  "web_accessible_resources": ["pageWorld.js"],
+  "permissions": ["scripting"],
+  "web_accessible_resources": [
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js"]
+    }
+  ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/hello-world/manifest.json
+++ b/examples/hello-world/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Example Gmail Extension",
   "description": "Example extension showing use of the Streak Gmail SDK",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,11 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
-  "web_accessible_resources": ["pageWorld.js"],
+  "permissions": ["scripting"],
+  "web_accessible_resources": [
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js"]
+    }
+  ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/link-popovers/manifest.json
+++ b/examples/link-popovers/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Example SDK Custom Link Popovers Extension",
   "description": "Example extension showing use of the Streak Gmail SDK to create custom link popovers in the compose window",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,11 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
-  "web_accessible_resources": ["pageWorld.js"],
+  "permissions": ["scripting"],
+  "web_accessible_resources": [
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js"]
+    }
+  ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/modal-example/manifest.json
+++ b/examples/modal-example/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Example SDK Modal Extension",
   "description": "Example extension showing use of the Streak Inbox SDK making a modal",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,15 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/mole-example/manifest.json
+++ b/examples/mole-example/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Example SDK Mole View Extension",
   "description": "Example extension showing use of the Streak Inbox SDK making a mole view",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],

--- a/examples/nav-menu/manifest.json
+++ b/examples/nav-menu/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "NavMenu - Example Gmail Extension",
   "description": "Example extension testing NavMenu and NavItemView.",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,16 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "monkey-face.jpg"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "monkey-face.jpg"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/open-compose/manifest.json
+++ b/examples/open-compose/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Example Opening a new Compose Window",
   "description": "Example extension showing opening a new compose window",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,15 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/override-edit-subject/manifest.json
+++ b/examples/override-edit-subject/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Override Edit Subject Example Extension",
   "description": "inboxsdk example",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,18 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "monkey.png",
-    "partycat.jpg"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "monkey.png", "partycat.jpg"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/search-results/manifest.json
+++ b/examples/search-results/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Search Results Inbox SDK example",
   "description": "Demonstrate adding results to search results",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,19 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "monkey-face.jpg",
-    "lion.png",
-    "monkey.png"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "monkey-face.jpg", "lion.png", "monkey.png"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/search-suggestions/manifest.json
+++ b/examples/search-suggestions/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Search Suggestions - Example Gmail Extension",
   "description": "Example extension showing use of the Streak Gmail SDK",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,15 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/search-term/manifest.json
+++ b/examples/search-term/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Search Term - Example Gmail Extension",
   "description": "Example extension showing use of the Streak Gmail SDK",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,17 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js"]
+    }
   ],
-
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/sidebar-contact-example/manifest.json
+++ b/examples/sidebar-contact-example/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Sidebar Contact Hover Example Extension",
   "description": "Sidebar example!",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,13 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
-
-  "web_accessible_resources": ["pageWorld.js"],
+  "permissions": ["scripting"],
+  "web_accessible_resources": [
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js"]
+    }
+  ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/sidebar-example/manifest.json
+++ b/examples/sidebar-example/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Sidebar Example Extension",
   "description": "Sidebar example!",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -10,18 +10,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "monkey.png",
-    "monkey-face.jpg",
-    "lion.png"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "monkey.png", "monkey-face.jpg", "lion.png"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/thread-rows/manifest.json
+++ b/examples/thread-rows/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Thread Rows - Example Gmail Extension",
   "description": "Example extension showing use of the Streak Gmail SDK",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -10,15 +10,16 @@
       "run_at": "document_start"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/thread-test/manifest.json
+++ b/examples/thread-test/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Thread Example Extension",
   "description": "Test Thread and Message views",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -10,15 +10,16 @@
       "run_at": "document_start"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js"]
+    }
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }

--- a/examples/toolbar-button/manifest.json
+++ b/examples/toolbar-button/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Toolbar Button Inbox SDK example",
   "description": "Demonstrate registering a toolbar button",
-  "version": "0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
@@ -9,18 +9,16 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["https://mail.google.com/"],
+  "permissions": ["scripting"],
   "web_accessible_resources": [
-    "inboxsdk.js.map",
-    "pageWorld.js",
-    "pageWorld.js.map",
-    "monkey.png"
+    {
+      "matches": ["https://mail.google.com/*"],
+      "resources": ["pageWorld.js", "monkey.png"]
+    }
   ],
-
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-
-  "manifest_version": 2
+  "manifest_version": 3,
+  "host_permissions": ["https://mail.google.com/"]
 }


### PR DESCRIPTION
After #970, all but two our examples no longer work. To remedy that, this PR moves over the
existing MV2 configs to be the MV3 equivalent. Among other things, it:

- adds `"scripting"` as a permission along with `"host_permissions"`
- nests `"web_accessible_resources"`
- bumps example extension versions from {0.1 => 2.0}
- removes source map files that aren't accessible in MV3

It uses the following script to port MV2 manifests to MV3.

```js
import fs from 'node:fs';
import path from 'node:path';

for (const exampleFolder of fs.readdirSync('examples')) {
  const candidatePath = path.join('examples', exampleFolder, 'manifest.json');
  if (!fs.existsSync(candidatePath)) {
    continue;
  }

  let manifest = JSON.parse(
    fs.readFileSync(candidatePath, {
      encoding: 'utf-8',
    })
  );

  if (manifest.manifest_version !== 2) {
    continue;
  }

  const web_accessible_resources = [
    {
      matches: ['https://mail.google.com/*'],
      resources: manifest.web_accessible_resources.filter(
        (f) => !f.endsWith('.js.map')
      ),
    },
  ];

  manifest = {
    ...manifest,
    background: {
      service_worker: 'background.js',
    },
    host_permissions: ['https://mail.google.com/'],
    manifest_version: 3,
    permissions: ['scripting'],
    web_accessible_resources,
    version: '2.0',
  };

  fs.writeFileSync(candidatePath, JSON.stringify(manifest, null, 2));
}
```
