### PR TITLE
Fix errors in console

### DIFF
--- a/src/injected-js/gmail/setup-gmail-interceptor.ts
+++ b/src/injected-js/gmail/setup-gmail-interceptor.ts
@@ -1166,8 +1166,12 @@ export function setupGmailInterceptorOnFrames(
 
     main_wrappers.push({
       isRelevantTo(connection) {
-        const url = new URL(connection.url);
-        return url.hostname.endsWith('.google.com');
+        // check for absolute URLs going to a google domain
+        if (connection.url.startsWith('https://')) {
+          const url = new URL(connection.url);
+          return url.hostname.endsWith('.google.com');
+        }
+        return false;
       },
 
       originalSendBodyLogger(connection) {


### PR DESCRIPTION
Fixes "TypeError: Failed to construct 'URL': Invalid URL" errors showing up in console occasionally. These errors were not breaking any functionality; they were just caught and noisily logged.

The error was caused because I forgot that `connection.url` could be a relative URL.