### PR TITLE
chore: tighten mole view driver up

### DIFF
--- a/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.ts
+++ b/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.ts
@@ -9,7 +9,7 @@ export interface ContentPanelDescriptor {
   appIconUrl?: string;
   appName?: string;
   el: HTMLElement;
-  id: string;
+  id?: string;
   hideTitleBar?: boolean;
   iconClass?: string;
   iconUrl?: string;


### PR DESCRIPTION
Scavenges work around #1036 

- relax type def around ContentPanelDescriptor
- enforce private on ViewDriver fields/methods
