### PR TITLE
chore: stricter sidebar interface

### DIFF
--- a/__tests__/inboxsdk-gmail.ts
+++ b/__tests__/inboxsdk-gmail.ts
@@ -45,8 +45,8 @@ test('loads in gmail mock', () => {
       ).map((x) => `window.${x}`);
       expect(newGlobals).toEqual([]);
 
-      expect((inboxsdk as any).LOADER_VERSION).toBe('beep');
-      expect((inboxsdk as any).IMPL_VERSION).toBe('beep');
+      expect(inboxsdk.LOADER_VERSION).toBe('beep');
+      expect(inboxsdk.IMPL_VERSION).toBe('beep');
       expect(inboxsdk.User.getAccountSwitcherContactList()).toEqual([
         { name: 'Chris Cowan', emailAddress: 'cowan@streak.com' },
         { name: 'Jonny Ive', emailAddress: 'streak.web.test.1@gmail.com' },

--- a/src/common/ajax.ts
+++ b/src/common/ajax.ts
@@ -85,7 +85,7 @@ export default function ajax(opts: AjaxOpts): Promise<AjaxResponse> {
         }
       }
 
-      const err = Object.assign(new Error(`Failed to load ${url}`) as any, {
+      const err = Object.assign(new Error(`Failed to load ${url}`), {
         event,
         xhr,
         status: xhr.status,

--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -24,6 +24,7 @@ import type { IMoleView as MoleView } from './platform-implementation-js/widgets
 export * from './platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view';
 import type User from './platform-implementation-js/namespaces/user';
 import { ContentPanelDescriptor } from './platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver';
+import type ContentPanelView from './platform-implementation-js/views/content-panel-view';
 
 export type { User };
 
@@ -460,12 +461,7 @@ export interface CustomMessageView extends EventEmitter {
   getSortDate(): Date | null;
 }
 
-export interface ContentPanelView extends EventEmitter {
-  close(): void;
-  isActive(): boolean;
-  open(): void;
-  remove(): void;
-}
+export { ContentPanelView };
 
 export interface MessageAttachmentIconDescriptor {
   iconUrl?: string;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/index.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/index.ts
@@ -9,35 +9,40 @@ import type GmailDriver from '../../gmail-driver';
 import type GmailThreadView from '../gmail-thread-view';
 const updates = udKefir(module, null);
 
+/**
+ * @internal
+ */
 class GmailAppSidebarView {
-  _stopper = kefirStopper();
-  _driver: GmailDriver;
-  _instanceId: string;
+  #stopper = kefirStopper();
+  #driver: GmailDriver;
+  #instanceId: string;
 
   constructor(
     driver: GmailDriver,
     companionSidebarContentContainerElement: HTMLElement,
   ) {
-    this._driver = driver;
-    // We need to be able to cooperate with other apps/extensions that are
-    // sharing the app sidebar. We store some properties as attributes in the
-    // shared DOM instead of as class properties; class properties are mostly
-    // restricted to being used for references to DOM nodes. When
-    // GmailAppSidebarView is instantiated, we check the element for an
-    // attribute to see whether a previous extension's GmailAppSidebarView has
-    // already set up the sidebar or not.
+    this.#driver = driver;
+    /**
+     * We need to be able to cooperate with other apps/extensions that are
+     * sharing the app sidebar. We store some properties as attributes in the
+     * shared DOM instead of as class properties; class properties are mostly
+     * restricted to being used for references to DOM nodes. When
+     * GmailAppSidebarView is instantiated, we check the element for an
+     * attribute to see whether a previous extension's GmailAppSidebarView has
+     * already set up the sidebar or not.
+     */
     const instanceId = companionSidebarContentContainerElement.getAttribute(
       'data-sdk-sidebar-instance-id',
     );
 
     if (instanceId != null) {
-      this._instanceId = instanceId;
+      this.#instanceId = instanceId;
     } else {
       let primary = new GmailAppSidebarPrimary(
         driver,
         companionSidebarContentContainerElement,
       );
-      this._instanceId = primary.getInstanceId();
+      this.#instanceId = primary.getInstanceId();
       // hot reloading support. Not perfect; this will break any existing panels.
       updates.changes().onValue(() => {
         primary.destroy();
@@ -45,58 +50,17 @@ class GmailAppSidebarView {
           driver,
           companionSidebarContentContainerElement,
         );
-        this._instanceId = primary.getInstanceId();
+        this.#instanceId = primary.getInstanceId();
       });
     }
   }
 
   destroy() {
-    this._stopper.destroy();
+    this.#stopper.destroy();
   }
 
   getStopper() {
-    return this._stopper;
-  }
-
-  _getShouldThreadAppSidebarOpen(): boolean {
-    return (
-      global.localStorage.getItem(
-        'inboxsdk__thread_app_sidebar_should_open',
-      ) !== 'false'
-    );
-  }
-
-  _setShouldThreadAppSidebarOpen(open: boolean) {
-    try {
-      global.localStorage.setItem(
-        'inboxsdk__thread_app_sidebar_should_open',
-        String(open),
-      );
-    } catch (err) {
-      console.error('error saving', err);
-    }
-  }
-
-  // This value controls whether the app sidebar should automatically open
-  // itself when available when the chat sidebar isn't present. It's only set
-  // if the user interacts with the app sidebar button.
-  _getShouldGlobalAppSidebarOpen(): boolean {
-    return (
-      global.localStorage.getItem(
-        'inboxsdk__global_app_sidebar_should_open',
-      ) === 'true'
-    );
-  }
-
-  _setShouldGlobalAppSidebarOpen(open: boolean) {
-    try {
-      global.localStorage.setItem(
-        'inboxsdk__global_app_sidebar_should_open',
-        String(open),
-      );
-    } catch (err) {
-      console.error('error saving', err);
-    }
+    return this.#stopper;
   }
 
   addThreadSidebarContentPanel(
@@ -104,11 +68,11 @@ class GmailAppSidebarView {
     threadView: GmailThreadView,
   ) {
     const panel = new ContentPanelViewDriver(
-      this._driver,
+      this.#driver,
       descriptor,
-      this._instanceId,
+      this.#instanceId,
     );
-    Kefir.merge([threadView.getStopper(), this._stopper])
+    Kefir.merge([threadView.getStopper(), this.#stopper])
       .take(1)
       .takeUntilBy(panel.getStopper())
       .onValue(() => panel.remove());
@@ -119,13 +83,13 @@ class GmailAppSidebarView {
     descriptor: Kefir.Observable<ContentPanelDescriptor, unknown>,
   ) {
     const panel = new ContentPanelViewDriver(
-      this._driver,
+      this.#driver,
       descriptor,
-      this._instanceId,
+      this.#instanceId,
       true,
     );
 
-    this._stopper.takeUntilBy(panel.getStopper()).onValue(() => panel.remove());
+    this.#stopper.takeUntilBy(panel.getStopper()).onValue(() => panel.remove());
 
     return panel;
   }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.tsx
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.tsx
@@ -27,37 +27,42 @@ import {
   sidebarWaitingPlatformSelector,
 } from '../../../../../driver-common/sidebar/constants';
 const ACTIVE_ADD_ON_ICON_SELECTOR = '.aT5-aOt-I-KO';
-const COMPANION_SIDEBAR_CONTENT_CLOSED_SHADOW_CLASS = 'brC-brG-btc'; // Only one instance of this Primary is ever created within a page, even if
-// there are multiple InboxSDK instances and/or extensions. All other InboxSDK
-// instances (including from other extensions) communicate with this Primary
-// through DOM events.
+const COMPANION_SIDEBAR_CONTENT_CLOSED_SHADOW_CLASS = 'brC-brG-btc';
 
+/** Only one instance of this Primary is ever created within a page, even if
+ * there are multiple InboxSDK instances and/or extensions. All other InboxSDK
+ * instances (including from other extensions) communicate with this Primary
+ * through DOM events. */
 class GmailAppSidebarPrimary {
-  _stopper = kefirStopper();
-  // There could be multiple InboxSDK instances (and therefore GmailDrivers)
-  // talking to this Primary, so we shouldn't privilege the specific GmailDriver
-  // that happened to create the Primary. Only use this GmailDriver for
-  // logging-related functionality!
-  _driver: GmailDriver;
-  // This Primary has an identifier used by the DOM events to specify they're
-  // talking to this Primary. This leaves us some room for having multiple
-  // Primary instances (representing different visual locations in Gmail) or
-  // multiple classes that make use of the same DOM events, but we don't make
-  // use of that now. Mainly I didn't want to risk baking in the singleton
-  // nature too deeply; that always seems to bite me.
-  _instanceId: string = `${Date.now()}-${Math.random()}`;
-  _companionSidebarContentContainerEl: HTMLElement;
-  _instanceIdsToDescriptors: Map<string, Record<string, any>> = new Map();
-  _threadSidebarComponent: AppSidebar | null | undefined = null;
-  _threadIconArea: HTMLElement | null | undefined = null;
-  _globalIconArea: HTMLElement | null | undefined = null;
-  _globalButtonContainers: Map<string, HTMLElement> = new Map();
-  _threadButtonContainers: Map<string, HTMLElement> = new Map();
-  _contentContainers: Map<string, HTMLElement> = new Map();
-  _threadSidebarContainerEl: HTMLElement | null | undefined = null;
-  _companionSidebarOuterWrapper!: HTMLElement;
-  _currentIds: Set<string> = new Set();
-  _orderManager = new OrderManager<PanelDescriptor>({
+  #stopper = kefirStopper();
+  /**
+   * There could be multiple InboxSDK instances (and therefore GmailDrivers)
+   * talking to this Primary, so we shouldn't privilege the specific GmailDriver
+   * that happened to create the Primary. Only use this GmailDriver for
+   * logging-related functionality!
+   */
+  #driver: { getLogger: GmailDriver['getLogger'] };
+  /**
+   * This Primary has an identifier used by the DOM events to specify they're
+   * talking to this Primary. This leaves us some room for having multiple
+   * Primary instances (representing different visual locations in Gmail) or
+   * multiple classes that make use of the same DOM events, but we don't make
+   * use of that now. Mainly I didn't want to risk baking in the singleton
+   * nature too deeply; that always seems to bite me.
+   */
+  #instanceId: string = `${Date.now()}-${Math.random()}`;
+  #companionSidebarContentContainerEl: HTMLElement;
+  #instanceIdsToDescriptors: Map<string, Record<string, any>> = new Map();
+  #threadSidebarComponent: AppSidebar | null | undefined = null;
+  #threadIconArea: HTMLElement | null | undefined = null;
+  #globalIconArea: HTMLElement | null | undefined = null;
+  #globalButtonContainers: Map<string, HTMLElement> = new Map();
+  #threadButtonContainers: Map<string, HTMLElement> = new Map();
+  #contentContainers: Map<string, HTMLElement> = new Map();
+  #threadSidebarContainerEl: HTMLElement | null | undefined = null;
+  #companionSidebarOuterWrapper!: HTMLElement;
+  #currentIds: Set<string> = new Set();
+  #orderManager = new OrderManager<PanelDescriptor>({
     get() {
       try {
         return JSON.parse(
@@ -79,35 +84,39 @@ class GmailAppSidebarPrimary {
       }
     },
   });
-  _containerProp!: () => HTMLElement;
-  _updateHighlightedAppThreadIconBus: Bus<null, unknown> = kefirBus();
+  #containerProp!: () => HTMLElement;
+  #updateHighlightedAppThreadIconBus: Bus<null, unknown> = kefirBus();
 
   constructor(
     driver: GmailDriver,
     companionSidebarContentContainerElement: HTMLElement,
   ) {
-    this._driver = driver;
-    this._companionSidebarContentContainerEl =
+    this.#driver = driver;
+    this.#companionSidebarContentContainerEl =
       companionSidebarContentContainerElement;
 
-    this._setupElement();
+    this.#setupElement();
   }
 
   getInstanceId(): string {
-    return this._instanceId;
+    return this.#instanceId;
   }
 
-  // Only use this if a different Primary needs to take over this one's elements.
-  // Currently this is only done when hot-reloading in dev. Don't use this when
-  // a threadview exits, the sdk.destroy() is called, etc.
+  /**
+   * Only use this if a different Primary needs to take over this one's elements.
+   * Currently this is only done when hot-reloading in dev. Don't use this when
+   * a threadview exits, the sdk.destroy() is called, etc.
+   */
   destroy() {
-    this._stopper.destroy();
+    this.#stopper.destroy();
   }
 
-  // This value controls whether the app sidebar should automatically open
-  // itself when available when the chat sidebar isn't present. It's only set
-  // if the user interacts with the app sidebar button.
-  _getShouldGlobalAppSidebarOpen(): boolean {
+  /**
+   * This value controls whether the app sidebar should automatically open
+   * itself when available when the chat sidebar isn't present. It's only set
+   * if the user interacts with the app sidebar button.
+   */
+  #getShouldGlobalAppSidebarOpen(): boolean {
     return (
       global.localStorage.getItem(
         'inboxsdk__global_app_sidebar_should_open',
@@ -115,7 +124,7 @@ class GmailAppSidebarPrimary {
     );
   }
 
-  _setShouldGlobalAppSidebarOpen(open: boolean) {
+  #setShouldGlobalAppSidebarOpen(open: boolean) {
     try {
       global.localStorage.setItem(
         'inboxsdk__global_app_sidebar_should_open',
@@ -126,7 +135,7 @@ class GmailAppSidebarPrimary {
     }
   }
 
-  _getShouldThreadAppSidebarOpen(): boolean {
+  #getShouldThreadAppSidebarOpen(): boolean {
     return (
       global.localStorage.getItem(
         'inboxsdk__thread_app_sidebar_should_open',
@@ -134,7 +143,7 @@ class GmailAppSidebarPrimary {
     );
   }
 
-  _setShouldThreadAppSidebarOpen(open: boolean) {
+  #setShouldThreadAppSidebarOpen(open: boolean) {
     try {
       global.localStorage.setItem(
         'inboxsdk__thread_app_sidebar_should_open',
@@ -145,9 +154,9 @@ class GmailAppSidebarPrimary {
     }
   }
 
-  _createThreadSidebarIfNeeded(): HTMLElement {
-    if (this._threadSidebarContainerEl) return this._threadSidebarContainerEl;
-    const threadSidebarContainerEl = (this._threadSidebarContainerEl =
+  #createThreadSidebarIfNeeded(): HTMLElement {
+    if (this.#threadSidebarContainerEl) return this.#threadSidebarContainerEl;
+    const threadSidebarContainerEl = (this.#threadSidebarContainerEl =
       document.createElement('div'));
     threadSidebarContainerEl.classList.add(
       'thread_app_sidebar',
@@ -155,17 +164,17 @@ class GmailAppSidebarPrimary {
       'addon_sidebar',
     );
 
-    this._companionSidebarContentContainerEl.insertBefore(
+    this.#companionSidebarContentContainerEl.insertBefore(
       threadSidebarContainerEl,
-      this._companionSidebarContentContainerEl.firstElementChild,
+      this.#companionSidebarContentContainerEl.firstElementChild,
     );
 
-    this._containerProp = () => threadSidebarContainerEl;
+    this.#containerProp = () => threadSidebarContainerEl;
 
-    this._updateHighlightedAppThreadIconBus
+    this.#updateHighlightedAppThreadIconBus
       .bufferWithTimeOrCount(150, 100)
       .filter((events: any[]) => events.length > 0)
-      .takeUntilBy(this._stopper)
+      .takeUntilBy(this.#stopper)
       .onValue(() => {
         // Before touching this code, make sure you understand the meaning of the clientRect
         // values and of scrollTop. In particular, make sure you understand the distinction of
@@ -225,11 +234,11 @@ class GmailAppSidebarPrimary {
           const appName = titleBar.getAttribute('data-app-name');
           if (!appName) return;
 
-          const appButton = this._threadButtonContainers.get(appName);
+          const appButton = this.#threadButtonContainers.get(appName);
 
-          if (!appButton || !this._threadIconArea) return;
+          if (!appButton || !this.#threadIconArea) return;
 
-          const activeButtonContainer = this._threadIconArea.querySelector(
+          const activeButtonContainer = this.#threadIconArea.querySelector(
             '.sidebar_button_container_active',
           );
 
@@ -244,34 +253,34 @@ class GmailAppSidebarPrimary {
       });
 
     //listen for scroll and update active icon if needed
-    this._updateHighlightedAppThreadIconBus.plug(
+    this.#updateHighlightedAppThreadIconBus.plug(
       Kefir.fromEvents(threadSidebarContainerEl, 'scroll').map(() => null),
     );
 
     // handle rendering thread sidebar contents
-    this._renderThreadSidebar();
+    this.#renderThreadSidebar();
 
     return threadSidebarContainerEl;
   }
 
-  _renderThreadSidebarIfPresent() {
-    if (!this._threadSidebarContainerEl) {
+  #renderThreadSidebarIfPresent() {
+    if (!this.#threadSidebarContainerEl) {
       return;
     }
 
-    this._renderThreadSidebar();
+    this.#renderThreadSidebar();
   }
 
-  _appSidebarRefSetter: (el: AppSidebar | null | undefined) => void = (
+  #appSidebarRefSetter: (el: AppSidebar | null | undefined) => void = (
     threadSidebarComponent,
   ) => {
     if (threadSidebarComponent) {
-      this._threadSidebarComponent = threadSidebarComponent;
+      this.#threadSidebarComponent = threadSidebarComponent;
     }
   };
 
-  _renderThreadSidebar(): Promise<AppSidebar> {
-    const threadSidebarContainerEl = this._threadSidebarContainerEl;
+  #renderThreadSidebar(): Promise<AppSidebar> {
+    const threadSidebarContainerEl = this.#threadSidebarContainerEl;
 
     if (!threadSidebarContainerEl) {
       throw new Error(
@@ -282,43 +291,43 @@ class GmailAppSidebarPrimary {
     return new Promise((resolve) => {
       ReactDOM.render(
         <AppSidebar
-          ref={this._appSidebarRefSetter}
-          panels={this._orderManager.getOrderedItems().map((x) => x.value)}
+          ref={this.#appSidebarRefSetter}
+          panels={this.#orderManager.getOrderedItems().map((x) => x.value)}
           onMoveEnd={(newList, movedItem, oldIndex, newIndex) => {
-            this._orderManager.moveItem(oldIndex, newIndex);
+            this.#orderManager.moveItem(oldIndex, newIndex);
 
-            this._renderThreadSidebar();
+            this.#renderThreadSidebar();
           }}
           onExpandedToggle={() => {
-            this._updateHighlightedAppThreadIconBus.emit(null);
+            this.#updateHighlightedAppThreadIconBus.emit(null);
           }}
-          container={this._containerProp}
+          container={this.#containerProp}
         />,
         threadSidebarContainerEl,
         () => {
-          if (!this._threadSidebarComponent) {
+          if (!this.#threadSidebarComponent) {
             throw new Error('Should not happen');
           }
 
-          resolve(this._threadSidebarComponent);
+          resolve(this.#threadSidebarComponent);
 
-          this._updateHighlightedAppThreadIconBus.emit(null);
+          this.#updateHighlightedAppThreadIconBus.emit(null);
         },
       );
     });
   }
 
-  _getActiveButtonContainer(): HTMLElement | null | undefined {
+  #getActiveButtonContainer(): HTMLElement | null | undefined {
     let activeButtonContainer;
 
-    if (this._globalIconArea) {
-      activeButtonContainer = this._globalIconArea.querySelector<HTMLElement>(
+    if (this.#globalIconArea) {
+      activeButtonContainer = this.#globalIconArea.querySelector<HTMLElement>(
         '.sidebar_button_container_active',
       );
     }
 
-    if (!activeButtonContainer && this._threadIconArea) {
-      activeButtonContainer = this._threadIconArea.querySelector<HTMLElement>(
+    if (!activeButtonContainer && this.#threadIconArea) {
+      activeButtonContainer = this.#threadIconArea.querySelector<HTMLElement>(
         '.sidebar_button_container_active',
       );
     }
@@ -326,9 +335,9 @@ class GmailAppSidebarPrimary {
     return activeButtonContainer;
   }
 
-  _closeButton: ((userClick: boolean) => void) | null | undefined = null;
+  #closeButton: ((userClick: boolean) => void) | null | undefined = null;
 
-  _addButton(
+  #addButton(
     iconArea: HTMLElement,
     event: Record<string, any>,
     isGlobal: boolean,
@@ -349,8 +358,8 @@ class GmailAppSidebarPrimary {
       // If there's an existing button for the app, then just increment its
       // data-count attribute instead of adding a new button.
       const existingButtonContainer = isGlobal
-        ? this._globalButtonContainers.get(appName)
-        : this._threadButtonContainers.get(appName);
+        ? this.#globalButtonContainers.get(appName)
+        : this.#threadButtonContainers.get(appName);
       let buttonContainer: HTMLElement;
 
       if (existingButtonContainer) {
@@ -380,36 +389,36 @@ class GmailAppSidebarPrimary {
         }
 
         if (isGlobal) {
-          this._globalButtonContainers.set(appName, buttonContainer);
+          this.#globalButtonContainers.set(appName, buttonContainer);
         } else {
-          this._threadButtonContainers.set(appName, buttonContainer);
+          this.#threadButtonContainers.set(appName, buttonContainer);
         }
 
         const activate = (dontScrollIntoView = false) => {
-          const activeButtonContainer = this._getActiveButtonContainer();
+          const activeButtonContainer = this.#getActiveButtonContainer();
 
           if (activeButtonContainer === buttonContainer) {
             // button was clicked while its panel was open, so close it.
-            if (!this._closeButton) throw new Error();
+            if (!this.#closeButton) throw new Error();
 
-            this._closeButton(true);
+            this.#closeButton(true);
           } else {
             // button was clicked while its own panel wasn't open, so open it.
-            if (this._closeButton) {
-              this._closeButton(true);
+            if (this.#closeButton) {
+              this.#closeButton(true);
             }
 
-            if (isGlobal) this._setShouldGlobalAppSidebarOpen(true);
-            else this._setShouldThreadAppSidebarOpen(true);
+            if (isGlobal) this.#setShouldGlobalAppSidebarOpen(true);
+            else this.#setShouldThreadAppSidebarOpen(true);
 
-            this._openSidebarAndActivateButton(buttonContainer, isGlobal);
+            this.#openSidebarAndActivateButton(buttonContainer, isGlobal);
 
             if (isGlobal) {
-              const contentEl = this._contentContainers.get(appName);
+              const contentEl = this.#contentContainers.get(appName);
 
               if (contentEl) contentEl.style.display = '';
 
-              this._companionSidebarContentContainerEl.classList.add(
+              this.#companionSidebarContentContainerEl.classList.add(
                 'companion_global_app_sidebar_visible',
               );
 
@@ -424,7 +433,7 @@ class GmailAppSidebarPrimary {
                 }),
               );
             } else {
-              const threadSidebarComponent = this._threadSidebarComponent;
+              const threadSidebarComponent = this.#threadSidebarComponent;
 
               if (!threadSidebarComponent) {
                 throw new Error('sidebar not mounted');
@@ -436,26 +445,26 @@ class GmailAppSidebarPrimary {
               }
             }
 
-            this._closeButton = (userClick: boolean) => {
-              this._closeButton = null;
+            this.#closeButton = (userClick: boolean) => {
+              this.#closeButton = null;
 
-              const activeButtonContainer = this._getActiveButtonContainer();
+              const activeButtonContainer = this.#getActiveButtonContainer();
 
               if (!activeButtonContainer) {
                 throw new Error('Expected activeButtonContainer');
               }
 
-              this._closeSidebarAndDeactivateButton(activeButtonContainer);
+              this.#closeSidebarAndDeactivateButton(activeButtonContainer);
 
               if (isGlobal) {
-                if (userClick) this._setShouldGlobalAppSidebarOpen(false);
+                if (userClick) this.#setShouldGlobalAppSidebarOpen(false);
 
-                const contentEl = this._contentContainers.get(appName);
+                const contentEl = this.#contentContainers.get(appName);
 
                 if (contentEl) {
                   contentEl.style.display = 'none';
                 } else {
-                  this._driver
+                  this.#driver
                     .getLogger()
                     .error(new Error('Unexpected: contentEl not set'));
                 }
@@ -470,7 +479,7 @@ class GmailAppSidebarPrimary {
                   }),
                 );
               } else {
-                if (userClick) this._setShouldThreadAppSidebarOpen(false);
+                if (userClick) this.#setShouldThreadAppSidebarOpen(false);
               }
 
               //fake a window resize after closing so gmail fixes any heights that are messed up
@@ -492,31 +501,31 @@ class GmailAppSidebarPrimary {
         );
 
         if (iconArea) {
-          addToIconArea(this._orderManager, appName, buttonContainer, iconArea);
+          addToIconArea(this.#orderManager, appName, buttonContainer, iconArea);
         }
 
         // if we last had an SDK sidebar open then bring up the SDK sidebar when the first
         // panel gets added
         {
-          const activeButtonContainer = this._getActiveButtonContainer();
+          const activeButtonContainer = this.#getActiveButtonContainer();
 
           if (isGlobal) {
-            if (this._getShouldGlobalAppSidebarOpen()) {
+            if (this.#getShouldGlobalAppSidebarOpen()) {
               const activeButtonContainerPresentAndIsForGlobal =
-                this._globalIconArea &&
+                this.#globalIconArea &&
                 activeButtonContainer &&
-                this._globalIconArea.contains(activeButtonContainer);
+                this.#globalIconArea.contains(activeButtonContainer);
 
               if (!activeButtonContainerPresentAndIsForGlobal) {
                 activate(true);
               }
             }
           } else {
-            if (this._getShouldThreadAppSidebarOpen()) {
+            if (this.#getShouldThreadAppSidebarOpen()) {
               const activeButtonContainerPresentAndIsForThread =
-                this._threadIconArea &&
+                this.#threadIconArea &&
                 activeButtonContainer &&
-                this._threadIconArea.contains(activeButtonContainer);
+                this.#threadIconArea.contains(activeButtonContainer);
 
               if (!activeButtonContainerPresentAndIsForThread) {
                 activate(true);
@@ -528,7 +537,7 @@ class GmailAppSidebarPrimary {
     });
   }
 
-  _removeButton(
+  #removeButton(
     event: Record<string, any>,
     buttonContainers: Map<string, HTMLElement>,
     iconArea: HTMLElement | null | undefined,
@@ -550,20 +559,20 @@ class GmailAppSidebarPrimary {
       );
 
       if (container === activeButtonContainer) {
-        if (!this._closeButton) throw new Error();
+        if (!this.#closeButton) throw new Error();
 
-        this._closeButton(false);
+        this.#closeButton(false);
 
-        this._companionSidebarOuterWrapper.classList.remove(
+        this.#companionSidebarOuterWrapper.classList.remove(
           'companion_app_sidebar_wrapper_visible',
         );
 
-        this._companionSidebarContentContainerEl.classList.remove(
+        this.#companionSidebarContentContainerEl.classList.remove(
           'companion_app_sidebar_visible',
         );
 
         const contentContainer =
-          this._companionSidebarOuterWrapper.previousElementSibling;
+          this.#companionSidebarOuterWrapper.previousElementSibling;
         if (contentContainer)
           contentContainer.classList.remove(
             'companion_container_app_sidebar_visible',
@@ -579,31 +588,31 @@ class GmailAppSidebarPrimary {
     }
   }
 
-  _closeSidebarAndDeactivateButton(activeButtonContainer: HTMLElement) {
+  #closeSidebarAndDeactivateButton(activeButtonContainer: HTMLElement) {
     activeButtonContainer.classList.remove('sidebar_button_container_active');
 
-    this._companionSidebarOuterWrapper.classList.remove(
+    this.#companionSidebarOuterWrapper.classList.remove(
       'companion_app_sidebar_wrapper_visible',
     );
 
-    this._companionSidebarContentContainerEl.classList.add(
+    this.#companionSidebarContentContainerEl.classList.add(
       COMPANION_SIDEBAR_CONTENT_CLOSED_SHADOW_CLASS,
     );
 
-    this._companionSidebarContentContainerEl.classList.remove(
+    this.#companionSidebarContentContainerEl.classList.remove(
       'companion_app_sidebar_visible',
       'companion_global_app_sidebar_visible',
     );
 
     const contentContainer =
-      this._companionSidebarOuterWrapper.previousElementSibling;
+      this.#companionSidebarOuterWrapper.previousElementSibling;
     if (contentContainer)
       contentContainer.classList.remove(
         'companion_container_app_sidebar_visible',
       );
   }
 
-  _openSidebarAndActivateButton(
+  #openSidebarAndActivateButton(
     buttonContainer: HTMLElement,
     isGlobal: boolean,
   ) {
@@ -614,7 +623,7 @@ class GmailAppSidebarPrimary {
         'Could not find companion sidebar icon container element',
       );
 
-    const activeButtonContainer = this._getActiveButtonContainer();
+    const activeButtonContainer = this.#getActiveButtonContainer();
 
     if (activeButtonContainer) {
       throw new Error('activeButtonContainer should not be true'); // this._closeSidebarAndDeactivateButton(activeButtonContainer);
@@ -633,29 +642,29 @@ class GmailAppSidebarPrimary {
     }
     buttonContainer.classList.add('sidebar_button_container_active');
 
-    this._companionSidebarOuterWrapper.classList.add(
+    this.#companionSidebarOuterWrapper.classList.add(
       'companion_app_sidebar_wrapper_visible',
     );
 
-    this._companionSidebarContentContainerEl.classList.add(
+    this.#companionSidebarContentContainerEl.classList.add(
       'companion_app_sidebar_visible',
     );
 
-    this._companionSidebarContentContainerEl.classList.remove(
+    this.#companionSidebarContentContainerEl.classList.remove(
       COMPANION_SIDEBAR_CONTENT_CLOSED_SHADOW_CLASS,
     );
 
     const contentContainer =
-      this._companionSidebarOuterWrapper.previousElementSibling;
+      this.#companionSidebarOuterWrapper.previousElementSibling;
     if (contentContainer)
       contentContainer.classList.add('companion_container_app_sidebar_visible');
     if (isGlobal)
-      this._companionSidebarContentContainerEl.classList.add(
+      this.#companionSidebarContentContainerEl.classList.add(
         'companion_global_app_sidebar_visible',
       );
   }
 
-  _setupElement() {
+  #setupElement() {
     const companionSidebarIconContainerEl =
       GmailElementGetter.getCompanionSidebarIconContainerElement();
     if (!companionSidebarIconContainerEl)
@@ -663,26 +672,26 @@ class GmailAppSidebarPrimary {
         'Could not find companion sidebar icon container element',
       );
 
-    this._companionSidebarContentContainerEl.setAttribute(
+    this.#companionSidebarContentContainerEl.setAttribute(
       'data-sdk-sidebar-instance-id',
-      this._instanceId,
+      this.#instanceId,
     );
 
     // TODO: Once the changes to the GMail DOM have been entirely ramped, drop the ternary here and
     // always get the parentElement. (Jun 20, 2018)
-    this._companionSidebarOuterWrapper =
-      this._companionSidebarContentContainerEl.classList.contains('bq9')
-        ? this._companionSidebarContentContainerEl
-        : (this._companionSidebarContentContainerEl.parentElement as any);
+    this.#companionSidebarOuterWrapper =
+      this.#companionSidebarContentContainerEl.classList.contains('bq9')
+        ? this.#companionSidebarContentContainerEl
+        : (this.#companionSidebarContentContainerEl.parentElement as any);
 
-    if (!this._companionSidebarOuterWrapper) {
+    if (!this.#companionSidebarOuterWrapper) {
       throw new Error(
         'should not happen: failed to find companionSidebarOuterWrapper',
       );
     }
 
     const contentContainer =
-      this._companionSidebarOuterWrapper.previousElementSibling;
+      this.#companionSidebarOuterWrapper.previousElementSibling;
 
     if (contentContainer) {
       contentContainer.classList.add(
@@ -690,7 +699,7 @@ class GmailAppSidebarPrimary {
       );
     }
 
-    this._companionSidebarContentContainerEl.classList.add(
+    this.#companionSidebarContentContainerEl.classList.add(
       idMap('app_sidebar_in_use'),
     );
 
@@ -707,31 +716,31 @@ class GmailAppSidebarPrimary {
     {
       Kefir.fromEvents<StorageEvent, unknown>(window, 'storage')
         .filter((e) => e.key === 'inboxsdk__sidebar_ordering')
-        .takeUntilBy(this._stopper)
+        .takeUntilBy(this.#stopper)
         .onValue(() => {
-          this._orderManager.reload();
+          this.#orderManager.reload();
 
-          this._renderThreadSidebarIfPresent();
+          this.#renderThreadSidebarIfPresent();
         });
       Kefir.fromEvents<any, unknown>(document.body, 'inboxsdkNewSidebarPanel')
         .filter(
-          (e) => e.detail.sidebarId === this._instanceId && !e.detail.isGlobal,
+          (e) => e.detail.sidebarId === this.#instanceId && !e.detail.isGlobal,
         )
-        .takeUntilBy(this._stopper)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
-          this._createThreadSidebarIfNeeded();
+          this.#createThreadSidebarIfNeeded();
 
           let id = event.detail.id;
 
-          while (this._currentIds.has(id)) {
+          while (this.#currentIds.has(id)) {
             id = incrementName(id);
           }
 
-          this._currentIds.add(id);
+          this.#currentIds.add(id);
 
           const appName = event.detail.appName;
 
-          this._orderManager.addItem({
+          this.#orderManager.addItem({
             groupId: event.detail.appId,
             id,
             orderHint: event.detail.orderHint,
@@ -748,37 +757,37 @@ class GmailAppSidebarPrimary {
             },
           });
 
-          this._renderThreadSidebar();
+          this.#renderThreadSidebar();
 
-          let threadIconArea = (this._threadIconArea =
+          let threadIconArea = (this.#threadIconArea =
             companionSidebarIconContainerEl.querySelector<HTMLElement>(
               '.sidebar_thread_iconArea',
             ));
 
           if (!threadIconArea) {
-            threadIconArea = this._threadIconArea =
+            threadIconArea = this.#threadIconArea =
               document.createElement('div');
             threadIconArea.className = idMap('sidebar_iconArea');
             threadIconArea.classList.add('sidebar_thread_iconArea');
             addCompanionThreadIconArea(
-              this._driver.getLogger(),
+              this.#driver.getLogger(),
               threadIconArea,
               companionSidebarIconContainerEl,
             );
           }
 
-          this._addButton(threadIconArea, event, false);
+          this.#addButton(threadIconArea, event, false);
         });
       Kefir.fromEvents<any, unknown>(
         document.body,
         'inboxsdkUpdateSidebarPanel',
       )
         .filter(
-          (e) => e.detail.sidebarId === this._instanceId && !e.detail.isGlobal,
+          (e) => e.detail.sidebarId === this.#instanceId && !e.detail.isGlobal,
         )
-        .takeUntilBy(this._stopper)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
-          const orderedItems = this._orderManager.getOrderedItems();
+          const orderedItems = this.#orderManager.getOrderedItems();
 
           const index = findIndex(
             orderedItems,
@@ -787,7 +796,7 @@ class GmailAppSidebarPrimary {
           if (index === -1)
             throw new Error('should not happen: failed to find orderItem');
 
-          this._orderManager.updateItemValueByIndex(index, {
+          this.#orderManager.updateItemValueByIndex(index, {
             id: orderedItems[index].value.id,
             appId: event.detail.appId,
             appName: event.detail.appName || event.detail.title,
@@ -799,18 +808,18 @@ class GmailAppSidebarPrimary {
             el: event.target,
           });
 
-          this._renderThreadSidebar();
+          this.#renderThreadSidebar();
         });
       Kefir.fromEvents<any, unknown>(
         document.body,
         'inboxsdkRemoveSidebarPanel',
       )
         .filter(
-          (e) => e.detail.sidebarId === this._instanceId && !e.detail.isGlobal,
+          (e) => e.detail.sidebarId === this.#instanceId && !e.detail.isGlobal,
         )
-        .takeUntilBy(this._stopper)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
-          const orderedItems = this._orderManager.getOrderedItems();
+          const orderedItems = this.#orderManager.getOrderedItems();
 
           const index = findIndex(
             orderedItems,
@@ -819,16 +828,16 @@ class GmailAppSidebarPrimary {
           if (index === -1)
             throw new Error('should not happen: failed to find orderItem');
 
-          this._currentIds.delete(orderedItems[index].id);
+          this.#currentIds.delete(orderedItems[index].id);
 
-          this._orderManager.removeItemByIndex(index);
+          this.#orderManager.removeItemByIndex(index);
 
-          this._renderThreadSidebar();
+          this.#renderThreadSidebar();
 
-          this._removeButton(
+          this.#removeButton(
             event,
-            this._threadButtonContainers,
-            this._threadIconArea,
+            this.#threadButtonContainers,
+            this.#threadIconArea,
           );
         });
       Kefir.fromEvents<any, unknown>(
@@ -836,39 +845,39 @@ class GmailAppSidebarPrimary {
         'inboxsdkSidebarPanelScrollIntoView',
       )
         .filter(
-          (e) => e.detail.sidebarId === this._instanceId && !e.detail.isGlobal,
+          (e) => e.detail.sidebarId === this.#instanceId && !e.detail.isGlobal,
         )
-        .takeUntilBy(this._stopper)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
-          if (this._threadSidebarComponent)
-            this._threadSidebarComponent.scrollPanelIntoView(
+          if (this.#threadSidebarComponent)
+            this.#threadSidebarComponent.scrollPanelIntoView(
               event.detail.instanceId,
             );
         });
       Kefir.fromEvents<any, unknown>(document.body, 'inboxsdkSidebarPanelClose')
         .filter(
-          (e) => e.detail.sidebarId === this._instanceId && !e.detail.isGlobal,
+          (e) => e.detail.sidebarId === this.#instanceId && !e.detail.isGlobal,
         )
-        .takeUntilBy(this._stopper)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
-          if (this._threadSidebarComponent)
-            this._threadSidebarComponent.closePanel(event.detail.instanceId);
+          if (this.#threadSidebarComponent)
+            this.#threadSidebarComponent.closePanel(event.detail.instanceId);
         });
       Kefir.fromEvents<any, unknown>(document.body, 'inboxsdkSidebarPanelOpen')
         .filter(
-          (e) => e.detail.sidebarId === this._instanceId && !e.detail.isGlobal,
+          (e) => e.detail.sidebarId === this.#instanceId && !e.detail.isGlobal,
         )
-        .takeUntilBy(this._stopper)
+        .takeUntilBy(this.#stopper)
         .onValue((e) => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          this._renderThreadSidebar().then((threadSidebarComponent) => {
-            const descriptor = this._instanceIdsToDescriptors.get(
+          this.#renderThreadSidebar().then((threadSidebarComponent) => {
+            const descriptor = this.#instanceIdsToDescriptors.get(
               e.detail.instanceId,
             );
 
             if (!descriptor) return;
 
-            const buttonContainer = this._threadButtonContainers.get(
+            const buttonContainer = this.#threadButtonContainers.get(
               descriptor.appName,
             );
 
@@ -876,7 +885,7 @@ class GmailAppSidebarPrimary {
               throw new Error('missing button container');
             }
 
-            const activeButtonContainer = this._getActiveButtonContainer();
+            const activeButtonContainer = this.#getActiveButtonContainer();
 
             if (activeButtonContainer !== buttonContainer) {
               querySelector(buttonContainer, 'button').click();
@@ -888,31 +897,31 @@ class GmailAppSidebarPrimary {
     {
       Kefir.fromEvents<any, unknown>(document.body, 'inboxsdkNewSidebarPanel')
         .filter(
-          (e) => e.detail.sidebarId === this._instanceId && e.detail.isGlobal,
+          (e) => e.detail.sidebarId === this.#instanceId && e.detail.isGlobal,
         )
-        .takeUntilBy(this._stopper)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
           let id = event.detail.id;
 
-          while (this._currentIds.has(id)) {
+          while (this.#currentIds.has(id)) {
             id = incrementName(id);
           }
 
-          this._currentIds.add(id);
+          this.#currentIds.add(id);
 
           const appName = event.detail.appName;
-          let globalIconArea = (this._globalIconArea =
+          let globalIconArea = (this.#globalIconArea =
             companionSidebarIconContainerEl.querySelector<HTMLElement>(
               '.sidebar_global_iconArea',
             ));
 
           if (!globalIconArea) {
-            globalIconArea = this._globalIconArea =
+            globalIconArea = this.#globalIconArea =
               document.createElement('div');
             globalIconArea.className = idMap('sidebar_iconArea');
             globalIconArea.classList.add('sidebar_global_iconArea');
             addCompanionGlobalIconArea(
-              this._driver.getLogger(),
+              this.#driver.getLogger(),
               globalIconArea,
               companionSidebarIconContainerEl,
             );
@@ -925,28 +934,28 @@ class GmailAppSidebarPrimary {
             'global_app_sidebar',
           );
 
-          this._companionSidebarContentContainerEl.insertAdjacentElement(
+          this.#companionSidebarContentContainerEl.insertAdjacentElement(
             'afterbegin',
             sdkContentContainerEl,
           );
 
-          this._contentContainers.set(appName, sdkContentContainerEl);
+          this.#contentContainers.set(appName, sdkContentContainerEl);
 
           sdkContentContainerEl.appendChild(event.target);
           sdkContentContainerEl.style.display = 'none';
 
-          this._addButton(globalIconArea, event, true);
+          this.#addButton(globalIconArea, event, true);
         });
       Kefir.fromEvents<any, unknown>(
         document.body,
         'inboxsdkUpdateSidebarPanel',
       )
         .filter(
-          (e) => e.detail.sidebarId === this._instanceId && e.detail.isGlobal,
+          (e) => e.detail.sidebarId === this.#instanceId && e.detail.isGlobal,
         )
-        .takeUntilBy(this._stopper)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
-          const buttonContainer = this._globalButtonContainers.get(
+          const buttonContainer = this.#globalButtonContainers.get(
             event.detail.appName,
           );
 
@@ -963,65 +972,65 @@ class GmailAppSidebarPrimary {
         'inboxsdkRemoveSidebarPanel',
       )
         .filter(
-          (e) => e.detail.sidebarId === this._instanceId && e.detail.isGlobal,
+          (e) => e.detail.sidebarId === this.#instanceId && e.detail.isGlobal,
         )
-        .takeUntilBy(this._stopper)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
-          this._currentIds.delete(event.detail.id);
+          this.#currentIds.delete(event.detail.id);
 
-          this._removeButton(
+          this.#removeButton(
             event,
-            this._globalButtonContainers,
-            this._globalIconArea,
+            this.#globalButtonContainers,
+            this.#globalIconArea,
           );
         });
       Kefir.fromEvents<any, unknown>(document.body, 'inboxsdkSidebarPanelClose')
         .filter(
-          (e) => e.detail.sidebarId === this._instanceId && e.detail.isGlobal,
+          (e) => e.detail.sidebarId === this.#instanceId && e.detail.isGlobal,
         )
-        .takeUntilBy(this._stopper)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
-          const descriptor = this._instanceIdsToDescriptors.get(
+          const descriptor = this.#instanceIdsToDescriptors.get(
             event.detail.instanceId,
           );
 
           if (!descriptor) return;
 
-          const buttonContainer = this._globalButtonContainers.get(
+          const buttonContainer = this.#globalButtonContainers.get(
             descriptor.appName,
           );
 
           if (!buttonContainer) return;
 
-          const activeButtonContainer = this._getActiveButtonContainer();
+          const activeButtonContainer = this.#getActiveButtonContainer();
 
           if (activeButtonContainer === buttonContainer) {
-            if (!this._closeButton) {
+            if (!this.#closeButton) {
               throw new Error('Expected this._closeButton');
             }
 
-            this._closeButton(true);
+            this.#closeButton(true);
           }
         });
       Kefir.fromEvents<any, unknown>(document.body, 'inboxsdkSidebarPanelOpen')
         .filter(
-          (e) => e.detail.sidebarId === this._instanceId && e.detail.isGlobal,
+          (e) => e.detail.sidebarId === this.#instanceId && e.detail.isGlobal,
         )
-        .takeUntilBy(this._stopper)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
-          const descriptor = this._instanceIdsToDescriptors.get(
+          const descriptor = this.#instanceIdsToDescriptors.get(
             event.detail.instanceId,
           );
 
           if (!descriptor) return;
 
-          const buttonContainer = this._globalButtonContainers.get(
+          const buttonContainer = this.#globalButtonContainers.get(
             descriptor.appName,
           );
 
           if (!buttonContainer) return;
 
-          const activeButtonContainer = this._getActiveButtonContainer();
+          const activeButtonContainer = this.#getActiveButtonContainer();
 
           if (activeButtonContainer !== buttonContainer) {
             querySelector(buttonContainer, 'button').click();
@@ -1031,10 +1040,10 @@ class GmailAppSidebarPrimary {
     // instance id to descriptor management
     {
       Kefir.fromEvents<any, unknown>(document.body, 'inboxsdkNewSidebarPanel')
-        .filter((e) => e.detail.sidebarId === this._instanceId)
-        .takeUntilBy(this._stopper)
+        .filter((e) => e.detail.sidebarId === this.#instanceId)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
-          this._instanceIdsToDescriptors.set(
+          this.#instanceIdsToDescriptors.set(
             event.detail.instanceId,
             event.detail,
           );
@@ -1043,19 +1052,19 @@ class GmailAppSidebarPrimary {
         document.body,
         'inboxsdkRemoveSidebarPanel',
       )
-        .filter((e) => e.detail.sidebarId === this._instanceId)
-        .takeUntilBy(this._stopper)
+        .filter((e) => e.detail.sidebarId === this.#instanceId)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
-          this._instanceIdsToDescriptors.delete(event.detail.instanceId);
+          this.#instanceIdsToDescriptors.delete(event.detail.instanceId);
         });
       Kefir.fromEvents<any, unknown>(
         document.body,
         'inboxsdkUpdateSidebarPanel',
       )
-        .filter((e) => e.detail.sidebarId === this._instanceId)
-        .takeUntilBy(this._stopper)
+        .filter((e) => e.detail.sidebarId === this.#instanceId)
+        .takeUntilBy(this.#stopper)
         .onValue((event) => {
-          this._instanceIdsToDescriptors.set(
+          this.#instanceIdsToDescriptors.set(
             event.detail.instanceId,
             event.detail,
           );
@@ -1069,9 +1078,9 @@ class GmailAppSidebarPrimary {
     // or the thread add-on content element are visible
     // if they are both display: '' or display: none then the native sidebar
     // contents are not visible
-    const globalAddOnContentContainer = this._companionSidebarContentContainerEl
+    const globalAddOnContentContainer = this.#companionSidebarContentContainerEl
       .children[0] as HTMLElement;
-    const threadAddOnContentContainer = this._companionSidebarContentContainerEl
+    const threadAddOnContentContainer = this.#companionSidebarContentContainerEl
       .children[1] as HTMLElement;
     Kefir.merge(
       [globalAddOnContentContainer, threadAddOnContentContainer].map(
@@ -1087,11 +1096,11 @@ class GmailAppSidebarPrimary {
           globalAddOnContentContainer.style.display !==
           threadAddOnContentContainer.style.display,
       )
-      .takeUntilBy(this._stopper)
+      .takeUntilBy(this.#stopper)
       .onValue(() => {
         // TODO What is this block for? It closes the current section whenever
         // one of the Gmail addons bar elements changes?
-        const activeButtonContainer = this._getActiveButtonContainer();
+        const activeButtonContainer = this.#getActiveButtonContainer();
 
         if (activeButtonContainer) {
           querySelector(activeButtonContainer, 'button').click();

--- a/src/platform-implementation-js/driver-common/getGmailThreadIdForRfcMessageId.ts
+++ b/src/platform-implementation-js/driver-common/getGmailThreadIdForRfcMessageId.ts
@@ -9,7 +9,7 @@ async function getGmailThreadIdForRfcMessageId(
   driver: Driver,
   rfcMessageId: string,
 ): Promise<string> {
-  if ((driver as any).isUsingSyncAPI && (driver as any).isUsingSyncAPI()) {
+  if (driver.isUsingSyncAPI && driver.isUsingSyncAPI()) {
     const { threads: threadDescriptors } = await getSyncThreadsForSearch(
       driver,
       'rfc822msgid:' + rfcMessageId,

--- a/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.ts
+++ b/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.ts
@@ -16,7 +16,7 @@ export interface ContentPanelDescriptor {
   orderHint?: number;
   primaryColor?: string;
   secondaryColor?: string;
-  title: string;
+  title?: string;
 }
 
 class ContentPanelViewDriver {

--- a/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.ts
+++ b/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.ts
@@ -45,7 +45,6 @@ class ContentPanelViewDriver {
       .ignoreValues()
       .beforeEnd(() => null)
       .toProperty();
-    const document = global.document; //fix for unit test
 
     this.#eventStream.plug(
       Kefir.fromEvents(document.body, 'inboxsdkSidebarPanelActivated')

--- a/src/platform-implementation-js/views/content-panel-view.ts
+++ b/src/platform-implementation-js/views/content-panel-view.ts
@@ -1,12 +1,18 @@
 import EventEmitter from '../lib/safe-event-emitter';
 import get from '../../common/get-or-fail';
 import type ContentPanelViewDriver from '../driver-common/sidebar/ContentPanelViewDriver';
+import type TypedEventEmitter from 'typed-emitter';
+
 interface Members {
   contentPanelViewImplementation: ContentPanelViewDriver;
 }
-const membersMap = new WeakMap<ContentPanelView, Members>(); // documented in src/docs/
+const membersMap = new WeakMap<ContentPanelView, Members>();
 
-export default class ContentPanelView extends EventEmitter {
+export default class ContentPanelView extends (EventEmitter as new () => TypedEventEmitter<{
+  activate(): void;
+  deactivate(): void;
+  destroy(): void;
+}>) {
   destroyed: boolean = false;
 
   constructor(contentPanelViewImplementation: ContentPanelViewDriver) {
@@ -16,7 +22,7 @@ export default class ContentPanelView extends EventEmitter {
     };
     membersMap.set(this, members);
 
-    this._bindToStreamEvents();
+    this.#bindToStreamEvents();
   }
 
   remove() {
@@ -35,7 +41,7 @@ export default class ContentPanelView extends EventEmitter {
     return get(membersMap, this).contentPanelViewImplementation.isActive();
   }
 
-  _bindToStreamEvents() {
+  #bindToStreamEvents() {
     const stream = get(
       membersMap,
       this,


### PR DESCRIPTION
As part of prep work for reworking mole & sidebar interactions, go through the existing sidebar interface and look for non-public usages that could be private.

- chore: true private in several @internal classes
- remove several `any`s
