### PR TITLE
chore: bump order-manager to remove old babel-runtime dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "matches-selector-ng": "^1.0.0",
     "mock-webstorage": "^1.0.3",
     "notp": "^2.0.3",
-    "order-manager": "^1.0.0",
+    "order-manager": "^1.0.3",
     "page-parser-tree": "^0.4.0",
     "pdelay": "^2.0.0",
     "postcss": "^8.4.21",

--- a/src/common/rate-limit-queuer.test.ts
+++ b/src/common/rate-limit-queuer.test.ts
@@ -4,11 +4,6 @@ import rateLimitQueuer from './rate-limit-queuer';
 
 jest.useFakeTimers();
 
-// Babel replaces calls to Date.now which makes mocking it awkward, so undo that.
-jest.mock('core-js/library/fn/date/now', () => {
-  return () => global.Date.now();
-});
-
 const _originalDateNow = global.Date.now;
 
 beforeEach(() => {

--- a/src/common/rate-limit.test.ts
+++ b/src/common/rate-limit.test.ts
@@ -1,10 +1,5 @@
 import rateLimit from './rate-limit';
 
-// Babel replaces calls to Date.now which makes mocking it awkward, so undo that.
-jest.mock('core-js/library/fn/date/now', () => {
-  return () => global.Date.now();
-});
-
 const _originalDateNow = global.Date.now;
 beforeEach(() => {
   const start = _originalDateNow.call(Date);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,7 +1497,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.23.1, @babel/runtime@npm:^7.4.5, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.23.1, @babel/runtime@npm:^7.4.5, @babel/runtime@npm:^7.8.4":
   version: 7.23.1
   resolution: "@babel/runtime@npm:7.23.1"
   dependencies:
@@ -3566,16 +3566,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-runtime@npm:^6.18.0":
-  version: 6.26.0
-  resolution: "babel-runtime@npm:6.26.0"
-  dependencies:
-    core-js: ^2.4.0
-    regenerator-runtime: ^0.11.0
-  checksum: 8aeade94665e67a73c1ccc10f6fd42ba0c689b980032b70929de7a6d9a12eb87ef51902733f8fefede35afea7a5c3ef7e916a64d503446c1eedc9e3284bd3d50
-  languageName: node
-  linkType: hard
-
 "bach@npm:^1.0.0":
   version: 1.2.0
   resolution: "bach@npm:1.2.0"
@@ -4373,13 +4363,6 @@ __metadata:
   dependencies:
     browserslist: ^4.22.1
   checksum: 83ae54008c09b8e0ae3c59457039866c342c7e28b0d30eebb638a5b51c01432e63fe97695c90645cbc6a8b073a4f9a8b0e75f0818bbf8b4b054e01f4c17d3181
-  languageName: node
-  linkType: hard
-
-"core-js@npm:^2.4.0":
-  version: 2.6.12
-  resolution: "core-js@npm:2.6.12"
-  checksum: 44fa9934a85f8c78d61e0c8b7b22436330471ffe59ec5076fe7f324d6e8cf7f824b14b1c81ca73608b13bdb0fef035bd820989bf059767ad6fa13123bb8bd016
   languageName: node
   linkType: hard
 
@@ -6674,16 +6657,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutability-helper@npm:^2.0.0":
-  version: 2.9.1
-  resolution: "immutability-helper@npm:2.9.1"
-  dependencies:
-    invariant: ^2.2.0
-  checksum: 8b66d20c22d517d4bff861616adec67294f1cf40bc1aedf68a5ebd5ae42c56593dc6c9bfb507f18705048bdecec03ef01f2b7817d6864fd7b06cbcc5e1f3f855
-  languageName: node
-  linkType: hard
-
-"immutability-helper@npm:^3.0.0":
+"immutability-helper@npm:^3.0.0, immutability-helper@npm:^3.1.1":
   version: 3.1.1
   resolution: "immutability-helper@npm:3.1.1"
   checksum: 6fdbf6d2123efa567263e904bbaff07aca0e24560d270d34967b03aab8ec20bd3e4057f394d59e50eb6c4718c9415591a6281692bb0aafd522ad72cf4887133f
@@ -6797,7 +6771,7 @@ __metadata:
     matches-selector-ng: ^1.0.0
     mock-webstorage: ^1.0.3
     notp: ^2.0.3
-    order-manager: ^1.0.0
+    order-manager: ^1.0.3
     page-parser-tree: ^0.4.0
     pdelay: ^2.0.0
     postcss: ^8.4.21
@@ -6904,15 +6878,6 @@ __metadata:
   version: 1.4.0
   resolution: "interpret@npm:1.4.0"
   checksum: 2e5f51268b5941e4a17e4ef0575bc91ed0ab5f8515e3cf77486f7c14d13f3010df9c0959f37063dcc96e78d12dc6b0bb1b9e111cdfe69771f4656d2993d36155
-  languageName: node
-  linkType: hard
-
-"invariant@npm:^2.2.0":
-  version: 2.2.4
-  resolution: "invariant@npm:2.2.4"
-  dependencies:
-    loose-envify: ^1.0.0
-  checksum: cc3182d793aad82a8d1f0af697b462939cb46066ec48bbf1707c150ad5fad6406137e91a262022c269702e01621f35ef60269f6c0d7fd178487959809acdfb14
   languageName: node
   linkType: hard
 
@@ -8483,7 +8448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -9451,14 +9416,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"order-manager@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "order-manager@npm:1.0.2"
+"order-manager@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "order-manager@npm:1.0.3"
   dependencies:
-    babel-runtime: ^6.18.0
-    immutability-helper: ^2.0.0
+    "@babel/runtime": ^7.20.13
+    immutability-helper: ^3.1.1
     lodash: ^4.16.6
-  checksum: 6638fafd351508650e4f13016245b70c7da8f3904a8a7813372227d2fafdac03a5efc5a4403e7776af99ed0b6846c94c83b9a29ce9ec0275dbdc9e47aed45437
+  checksum: 352d67703204708ae1e8d5263ce98cbfe3ecec8cc074702bda2b63ce00beeeca5506995ecafe2158b68ce61adc033053cebb107729266d16355d19eda44c02e6
   languageName: node
   linkType: hard
 
@@ -10420,13 +10385,6 @@ __metadata:
   version: 1.4.2
   resolution: "regenerate@npm:1.4.2"
   checksum: 3317a09b2f802da8db09aa276e469b57a6c0dd818347e05b8862959c6193408242f150db5de83c12c3fa99091ad95fb42a6db2c3329bfaa12a0ea4cbbeb30cb0
-  languageName: node
-  linkType: hard
-
-"regenerator-runtime@npm:^0.11.0":
-  version: 0.11.1
-  resolution: "regenerator-runtime@npm:0.11.1"
-  checksum: 3c97bd2c7b2b3247e6f8e2147a002eb78c995323732dad5dc70fac8d8d0b758d0295e7015b90d3d444446ae77cbd24b9f9123ec3a77018e81d8999818301b4f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumping to `order-manager@1.0.3` drops our last usage of `babel-runtime`.