### PR TITLE
fix: order SDK moles as Gmail does Composes

### DIFF
--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -385,6 +385,7 @@ if (args.remote) {
 } else {
   // standard npm non-remote bundle
   config = {
+    devtool: args.production ? false : 'inline-source-map',
     entry: {
       ...pageWorld,
       [sdkFilename]: {

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/isIntegratedViewGmail.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/isIntegratedViewGmail.ts
@@ -16,9 +16,6 @@ export function isCollapsiblePanelHidden(): boolean | null {
   return document.querySelector('div[role=navigation].aBA') != null;
 }
 
-/**
- * @note only able to @return true when @see {isIntegratedViewGmail} returns true
- */
 export function isGoogleChatEnabled() {
   return document.querySelector('div[role=navigation] > .ao4') != null;
 }

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -109,6 +109,16 @@ class GmailMoleViewDriver {
       for (const change of changes) {
         switch (change.type) {
           case 'add': {
+            /**
+             * @todo this approach doesn't seem to work in the edge case when
+             *
+             * - chat enabled
+             * - open a gmail compose
+             * - reload the page
+             * - open an SDK mole before the previous compose loads in
+             *
+             * We end up with a the SDK mole starting on the left, but then it is very noticably moved to the right of the Gmail compose.
+             */
             const el = change.value.getValue();
 
             if (el.matches(Selector.ComposeMole)) {
@@ -122,6 +132,11 @@ class GmailMoleViewDriver {
     });
   }
 
+  /**
+   * This method, among other things, DOES NOT
+   * - preseve initial load order with moles.
+   * - preserve mole order after a mole has been maximized.
+   */
   static #maybeMoveMole(mole: HTMLElement) {
     const rightSpacer = mole.parentElement?.lastElementChild;
 

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -135,24 +135,17 @@ class GmailMoleViewDriver {
   }
 
   static #reorderMoles() {
-    let insertionPoint: Element | null | undefined;
-    const chatEnabled = isGoogleChatEnabled();
+    if (this.#moleInsertOrder.size <= 1) {
+      return;
+    }
 
-    const reinsert = (mole: HTMLElement) => {
-      const moleParent = mole.parentElement;
-      if (chatEnabled) {
-        insertionPoint ??= moleParent?.lastElementChild;
-        insertionPoint?.insertAdjacentElement('beforebegin', mole);
-      } else {
-        insertionPoint ??= moleParent?.querySelector(
-          Selector.ChatMolePlaceholder,
-        );
-        insertionPoint?.insertAdjacentElement('afterend', mole);
-      }
-    };
+    let moleParent;
+    let insertionPoint: Element | null | undefined;
 
     for (const mole of this.#moleInsertOrder) {
-      reinsert(mole);
+      moleParent ??= mole.parentElement;
+      insertionPoint ??= moleParent?.lastElementChild;
+      insertionPoint?.insertAdjacentElement('beforebegin', mole);
     }
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -64,6 +64,13 @@ class GmailMoleViewDriver {
           el,
           html: el ? censorHTMLtree(el) : null,
         };
+        // ignore 'errors' that seem to be warnings instead...
+        if (
+          err.message.includes('found element missed by watcher') ||
+          err.message.includes('watcher found element already found by finder')
+        ) {
+          return;
+        }
         console.log(err, details);
       },
       tags: {

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -196,10 +196,9 @@ class GmailMoleViewDriver {
           this.#element,
           '.inboxsdk__mole_title_buttons',
         );
-        const lastChild: HTMLElement =
-          titleButtonContainer.lastElementChild as any;
+        const lastChild = titleButtonContainer.lastElementChild;
         titleButtons.forEach((titleButton) => {
-          const img: HTMLImageElement = document.createElement('img') as any;
+          const img = document.createElement('img');
 
           if (titleButton.iconClass) {
             img.className = titleButton.iconClass;

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -96,9 +96,20 @@ class GmailMoleViewDriver {
             [root.querySelector<HTMLElement>(Selector.MoleParent)].filter(
               isNotNil,
             ),
+          interval(elementCount, timeRunning) {
+            return timeRunning <= 5_000 ? 100 : 5000;
+          },
         },
         [Tag.Mole]: {
           fn: (root) => root.querySelectorAll(Selector.Mole),
+          interval(elementCount, timeRunning) {
+            // For initial Gmail load, we want to prevent an issue where compose moles are reordered to the left SDK moles after 5 seconds when
+            //
+            // - Google Chat is enabled
+            // - a compose mole is open from a previous Gmail load
+            // - a SDK mole is added immediately after page load.
+            return timeRunning <= 5_000 ? 100 : 5000;
+          },
         },
       },
     });
@@ -109,16 +120,6 @@ class GmailMoleViewDriver {
       for (const change of changes) {
         switch (change.type) {
           case 'add': {
-            /**
-             * @todo this approach doesn't seem to work in the edge case when
-             *
-             * - chat enabled
-             * - open a gmail compose
-             * - reload the page
-             * - open an SDK mole before the previous compose loads in
-             *
-             * We end up with a the SDK mole starting on the left, but then it is very noticably moved to the right of the Gmail compose.
-             */
             const el = change.value.getValue();
 
             if (el.matches(Selector.ComposeMole)) {

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -97,7 +97,7 @@ class GmailMoleViewDriver {
               isNotNil,
             ),
           interval(elementCount, timeRunning) {
-            return timeRunning <= 5_000 ? 100 : 5000;
+            return timeRunning <= 5_000 && elementCount === 0 ? 100 : 5_000;
           },
         },
         [Tag.Mole]: {
@@ -108,7 +108,7 @@ class GmailMoleViewDriver {
             // - Google Chat is enabled
             // - a compose mole is open from a previous Gmail load
             // - a SDK mole is added immediately after page load.
-            return timeRunning <= 5_000 ? 100 : 5000;
+            return timeRunning <= 5_000 && elementCount === 0 ? 100 : 5_000;
           },
         },
       },

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/mole-view.module.css
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/mole-view.module.css
@@ -1,3 +1,7 @@
+.main {
+  order: 1;
+}
+
 /* .aDj.ahe are the `position: fixed` are elements that contain ComposeView toolbars when the ComposeView body isn't focused.
  * This selector may have been the equivalent of `.aDj.aDi` before 2023-08-30.
  */


### PR DESCRIPTION
# When Google Chat is enabled

1. Open Gmail Compose mole
2. Open SDK mole
3. Open Gmail Compose mole
4. Open SDK mole

Results in the following mole order, from left to right:

```
[4] [3] [2] [1]
```

# When Google Chat is disabled

1. Open Gmail Compose mole
2. Open SDK mole
3. Open Gmail Compose mole
4. Open SDK mole

Results in the following mole order, from left to right:

```
[1] [2] [3] [4]
```
