### PR TITLE
Fix isListRoute check

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -539,6 +539,7 @@ class GmailRouteView {
     return (
       (this._type === 'CUSTOM_LIST' ||
         this._gmailRouteProcessor.isListRouteName(this._name)) &&
+      // this case is for when you're on a THREAD route, but the thread renders a list like our thread breaker does
       rowListElements != null &&
       rowListElements.length > 0
     );

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -534,9 +534,13 @@ class GmailRouteView {
   }
 
   _isListRoute(): boolean {
+    const rowListElements = GmailElementGetter.getRowListElements();
+
     return (
-      this._type === 'CUSTOM_LIST' ||
-      this._gmailRouteProcessor.isListRouteName(this._name)
+      (this._type === 'CUSTOM_LIST' ||
+        this._gmailRouteProcessor.isListRouteName(this._name)) &&
+      rowListElements != null &&
+      rowListElements.length > 0
     );
   }
 


### PR DESCRIPTION
follow up on https://github.com/InboxSDK/InboxSDK/pull/1045, we changed how we were checking isListRoute, it turns out we had the use case we indeed are on a thread view but we render a list of the messages on the thread view, we'd still need the isListRoute to be false in this case, so adding it back and a comment for it. 