### PR TITLE
fix isListRoute for searching result page route detection

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -413,6 +413,8 @@ class GmailRouteView {
       .take(1)
       .map(({ el }) => {
         const main = el.getValue();
+        console.log('==== main', main);
+
         let sectionsContainer = main.querySelector<HTMLElement>(
           '.inboxsdk__custom_sections',
         );
@@ -534,14 +536,11 @@ class GmailRouteView {
   }
 
   _isListRoute(): boolean {
-    const rowListElements = GmailElementGetter.getRowListElements();
-
     return (
       (this._type === 'CUSTOM_LIST' ||
         this._gmailRouteProcessor.isListRouteName(this._name)) &&
       // this case is for when you're on a THREAD route, but the thread renders a list like our thread breaker does
-      rowListElements != null &&
-      rowListElements.length > 0
+      !this._isThreadRoute()
     );
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -413,8 +413,6 @@ class GmailRouteView {
       .take(1)
       .map(({ el }) => {
         const main = el.getValue();
-        console.log('==== main', main);
-
         let sectionsContainer = main.querySelector<HTMLElement>(
           '.inboxsdk__custom_sections',
         );


### PR DESCRIPTION
check is not thread instead of finding the row list elements which could be async loaded -> tested search results example working fine