### PR TITLE
fix: mole header icons

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -14,7 +14,7 @@ import isNotNil from '../../../lib/isNotNil';
 
 export type MoleButtonDescriptor = {
   title: string;
-  iconUrl: string;
+  iconUrl?: string;
   iconClass?: string;
   onClick: (...args: Array<any>) => any;
 };
@@ -226,7 +226,9 @@ class GmailMoleViewDriver {
             event.stopPropagation();
             titleButton.onClick.call(null);
           });
-          img.src = titleButton.iconUrl;
+          if (titleButton.iconUrl) {
+            img.src = titleButton.iconUrl;
+          }
           titleButtonContainer.insertBefore(img, lastChild);
         });
       }

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1466,7 +1466,6 @@ isn't visible behind it. */
   width: 24px;
   position: relative;
   top: 2px;
-  opacity: 0.6;
 }
 
 .inboxsdk__mole_title_buttons:not(.inboxsdk__original_view) > img {


### PR DESCRIPTION
# Use gmail's fully opaque style for SDK mole header icons

The SDK has used reduced opacity for SDK mole title icons. This PR removes the lowered opacity in favor of Gmail's full opacity usage.

## Current

<img width="1120" alt="Screenshot 2023-10-31 at 08 27 19" src="https://github.com/InboxSDK/InboxSDK/assets/5156873/a754a743-5dad-42b7-8c62-75f1135d66c9">
Note the slight difference in icon colors between the left (native) and right (SDK) mole.

# Make `iconUrl` optional

At Streak, we use mole titleButtons in this way already downstream.