### PR TITLE
fix: stop compose from flashing in if SDK mole's moleParent doesn't exist yet

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -149,10 +149,6 @@ const GmailElementGetter = {
     return getMainContentElementChangedStream(this);
   }),
 
-  getMoleParent(): HTMLElement | null {
-    return document.body.querySelector('.dw .nH > .nH > .no');
-  },
-
   /**
    * This method checks whether we should use the old InboxSDK style of adding nav items
    * inline among Gmail's nav items (as opposed to the newer style where we put our nav items

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -298,7 +298,7 @@ class GmailMoleViewDriver {
           document.body.classList.add(styles.hideComposes);
           const gmailComposeView =
             await this.#driver.openNewComposeViewDriver();
-          gmailComposeView.close();
+          gmailComposeView.discard();
         } finally {
           document.body.classList.remove(styles.hideComposes);
         }

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -1,7 +1,6 @@
 import * as Kefir from 'kefir';
 import kefirBus from 'kefir-bus';
 import kefirStopper from 'kefir-stopper';
-import streamWaitFor from '../../../lib/stream-wait-for';
 import querySelector from '../../../lib/dom/querySelectorOrFail';
 import GmailElementGetter from '../gmail-element-getter';
 import type GmailDriver from '../gmail-driver';
@@ -56,6 +55,7 @@ const enum Tag {
 
 class GmailMoleViewDriver {
   static #page: PageParserTree;
+  static #moleParentReadyEvent = kefirBus<HTMLElement, unknown>();
 
   static {
     this.#page = new PageParserTree(document, {
@@ -97,7 +97,7 @@ class GmailMoleViewDriver {
               isNotNil,
             ),
           interval(elementCount, timeRunning) {
-            return timeRunning <= 5_000 && elementCount === 0 ? 100 : 5_000;
+            return timeRunning <= 15_000 && elementCount === 0 ? 100 : 5_000;
           },
         },
         [Tag.Mole]: {
@@ -112,6 +112,22 @@ class GmailMoleViewDriver {
           },
         },
       },
+    });
+
+    const moleParent = this.#page.tree.getAllByTag(Tag.MoleParent);
+
+    const moleParentLiveSet = moleParent.subscribe((changes) => {
+      for (const change of changes) {
+        switch (change.type) {
+          case 'add': {
+            const el = change.value.getValue();
+
+            this.#moleParentReadyEvent.emit(el);
+
+            moleParentLiveSet.unsubscribe();
+          }
+        }
+      }
     });
 
     const moles = this.#page.tree.getAllByTag(Tag.Mole);
@@ -237,58 +253,56 @@ class GmailMoleViewDriver {
     );
   }
 
-  show() {
-    const doShow = (moleParent: HTMLElement) => {
-      const insertBefore = moleParent.lastElementChild;
+  #doShow = (moleParent: HTMLElement) => {
+    const insertBefore = moleParent.lastElementChild;
 
-      if (insertBefore instanceof HTMLElement) {
-        moleParent.insertBefore(this.#element, insertBefore);
-      } else {
-        this.#driver.logger.error(
-          new Error(
-            'Mole show invariant violated. `lastMole` is not an HTMLElement',
-          ),
-        );
-        return;
-      }
-
-      const dw = moleParent.closest('div.dw');
-
-      if (dw) {
-        dw.classList.add('inboxsdk__moles_in_use', styles.inboxsdkMolesInUse);
-      }
-    };
-
-    const moleParent = GmailElementGetter.getMoleParent();
-
-    if (moleParent) {
-      doShow(moleParent);
+    if (insertBefore instanceof HTMLElement) {
+      moleParent.insertBefore(this.#element, insertBefore);
     } else {
-      const moleParentReadyEvent = streamWaitFor(() =>
-        GmailElementGetter.getMoleParent(),
-      )
-        .takeUntilBy(this.#stopper)
-        .onValue(doShow);
-      // For some users, the mole parent element seems to be lazily loaded by
-      // Gmail only once the user has used a compose view or a thread view.
-      // If the gmail mode has settled, we've been loaded for 10 seconds, and
-      // we don't have the mole parent yet, then force the mole parent to load
-      // by opening a compose view and then closing it.
-      Kefir.fromPromise(GmailElementGetter.waitForGmailModeToSettle())
-        .flatMap(() => {
-          // delay until we've passed TimestampOnReady + 10 seconds
-          return this.#driver.delayToTimeAfterReady(10 * 1000);
-        })
-        .takeUntilBy(moleParentReadyEvent)
-        .takeUntilBy(this.#stopper)
-        .onValue(() => {
-          this.#driver.getLogger().eventSdkActive('mole parent force load');
-
-          this.#driver.openNewComposeViewDriver().then((gmailComposeView) => {
-            gmailComposeView.close();
-          });
-        });
+      this.#driver.logger.error(
+        new Error(
+          'Mole show invariant violated. `lastMole` is not an HTMLElement',
+        ),
+      );
+      return;
     }
+
+    const dw = moleParent.closest('div.dw');
+
+    if (dw) {
+      dw.classList.add('inboxsdk__moles_in_use', styles.inboxsdkMolesInUse);
+    }
+  };
+
+  show() {
+    const moleParentReadyEvent = GmailMoleViewDriver.#moleParentReadyEvent
+      .takeUntilBy(this.#stopper)
+      .onValue(this.#doShow);
+
+    // For some users, the mole parent element seems to be lazily loaded by
+    // Gmail only once the user has used a compose view or a thread view.
+    // If the gmail mode has settled, we've been loaded for 10 seconds, and
+    // we don't have the mole parent yet, then force the mole parent to load
+    // by opening a compose view and then closing it.
+    Kefir.fromPromise(GmailElementGetter.waitForGmailModeToSettle())
+      .flatMap(() => {
+        // delay until we've passed TimestampOnReady + 10 seconds
+        return this.#driver.delayToTimeAfterReady(10 * 1000);
+      })
+      .takeUntilBy(moleParentReadyEvent)
+      .takeUntilBy(this.#stopper)
+      .onValue(async () => {
+        this.#driver.getLogger().eventSdkActive('mole parent force load');
+
+        try {
+          document.body.classList.add(styles.hideComposes);
+          const gmailComposeView =
+            await this.#driver.openNewComposeViewDriver();
+          gmailComposeView.close();
+        } finally {
+          document.body.classList.remove(styles.hideComposes);
+        }
+      });
   }
 
   /**

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/mole-view.module.css
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/mole-view.module.css
@@ -8,3 +8,14 @@
 .inboxsdkMolesInUse :global(.aDj.ahe) {
   position: static !important;
 }
+
+.hideComposes
+  :global(
+    .dw
+      .nH
+      > .nH
+      > .no
+      > *:not([style*='order: 0;'], [style*='order: 2147483647;'], .aJl).nn.nH
+  ) {
+  display: none !important;
+}


### PR DESCRIPTION
When we add SDK moles to Gmail, we add them in the same element that Gmail adds ComposeViews (and if Chat is enabled, Chat moles)--the moleParent. The moleParent doesn't seem to exist by default when Gmail starts up unless:

- there's a ComposeView lingering from a previous Gmail load
- The user is on a route like MessageView where there are inline ComposeViews

The way we ensure the moleParent is present (only an issue once per page load) is by quickly opening a ComposeView and then closing it. This can be slow enough that there is a FOUC around the ComposeView showing up alongside an SDK mole.

This PR adds a class to `document.body` while we're forcing moleParent into existence to hide the FOUC. It also discards instead of just closing the temporary compose draft to handle the edge case for _users with email signatures where flashing in a compose inadvertently saves a draft_.