### PR TITLE
add example for compose bodyChanged

### DIFF
--- a/examples/compose-stream/content.js
+++ b/examples/compose-stream/content.js
@@ -217,6 +217,9 @@ InboxSDK.load(2, 'compose-stream-example').then((inboxSDK) => {
     composeView.on('subjectChanged', () => {
       console.log('subject changed', composeView.getSubject());
     });
+    composeView.on('bodyChanged', () => {
+      console.log('body changed', composeView.getTextContent());
+    });
     composeView.on(
       'toContactAdded',
       console.log.bind(console, 'toContactAdded'),


### PR DESCRIPTION
adding an example for compose view `bodyChanged` event. this helps testing if our `bodyChanged` event is emitted correctly when gmail user inserts a template. 

- turn on `Template` from gmail advanced setttings
<img width="1022" alt="image" src="https://github.com/InboxSDK/InboxSDK/assets/7209644/4a6fa001-6ef9-43ba-8d73-096906c3260e">

- load example: Compose Button Stream
- open dev console
- open compose view
- insert a template
<img width="730" alt="image" src="https://github.com/InboxSDK/InboxSDK/assets/7209644/64f82e01-0620-40a4-b43a-5f9030e1e722">

- check that dev console log `bodyChanged` event