### PR TITLE
Fixed - Bug: messageView.addToolbarButton does not create a button #1056

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -366,7 +366,7 @@ class GmailMessageView {
 
   #getOpenMoreMenu(): HTMLElement | null | undefined {
     const selector_2022_11_23 =
-      'td > div.nH.a98.iY > div.nH.aHU .b7.J-M[aria-haspopup=true]';
+      'td > div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]';
     const maybeMoreMenu =
       document.body.querySelector<HTMLElement>(selector_2022_11_23);
     // This will find any message's open more menu! The caller needs to make


### PR DESCRIPTION
Hi **@wegry**,

I had updated the code by adding space in HTML DOM selector in the method #getOpenMoreMenu() as below 
(Tested & it is working).
I kindly request you to merge the PR ASAP as broken is feature in our extension, please let me know if you have any concerns for the same.

td > div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]
		
**@adm-bome:** Thanks for the solution.

Thanks,
Shashikiran