### PR TITLE
selectors update for gmail thread view container changes

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -281,7 +281,10 @@ const GmailElementGetter = {
   },
 
   getThreadContainerElement(): HTMLElement | null {
-    return document.querySelector('[role=main] .g.id table.Bs > tr');
+    // [role=main] .g.id .a98.iY is the new selector after Nov 16, 2023 gmail change
+    return document.querySelector(
+      '[role=main] .g.id table.Bs > tr, [role=main] .g.id .a98.iY',
+    );
   },
 
   getToolbarElement(): HTMLElement {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -367,7 +367,11 @@ class GmailMessageView {
   #getOpenMoreMenu(): HTMLElement | null | undefined {
     const selector_2022_11_23 =
       'td > div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]';
+    const selector_2023_11_16 =
+      'div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]';
+
     const maybeMoreMenu =
+      document.body.querySelector<HTMLElement>(selector_2023_11_16) ||
       document.body.querySelector<HTMLElement>(selector_2022_11_23);
     // This will find any message's open more menu! The caller needs to make
     // sure it belongs to this message!

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -17,12 +17,12 @@ import GmailThreadView from '../gmail-thread-view';
 import GmailCollapsibleSectionView from '../gmail-collapsible-section-view';
 import GmailElementGetter from '../../gmail-element-getter';
 import { simulateClick } from '../../../../lib/dom/simulate-mouse-event';
-import querySelector from '../../../../lib/dom/querySelectorOrFail';
 import type GmailDriver from '../../gmail-driver';
 import type GmailRouteProcessor from '../gmail-route-view/gmail-route-processor';
 import PageParserTree from 'page-parser-tree';
 import { makePageParser } from './page-parser';
 import toItemWithLifetimeStream from '../../../../lib/toItemWithLifetimeStream';
+import waitFor from '../../../../lib/wait-for';
 
 class GmailRouteView {
   _type: string;
@@ -373,14 +373,27 @@ class GmailRouteView {
     }
   }
 
-  _startMonitoringPreviewPaneForThread(previewPaneContainer: HTMLElement) {
-    let threadContainerElement =
-      previewPaneContainer.querySelector<HTMLElement>('table.Bs > tr');
+  async _startMonitoringPreviewPaneForThread(
+    previewPaneContainer: HTMLElement,
+  ) {
+    const threadContainerElement = await waitFor(() => {
+      let threadContainerElement =
+        previewPaneContainer.querySelector<HTMLElement>('table.Bs > tr');
+
+      if (!threadContainerElement) {
+        threadContainerElement =
+          previewPaneContainer.querySelector<HTMLElement>(
+            '.nH.g.id:has(.a98.iY)',
+          );
+      }
+
+      return threadContainerElement;
+    });
 
     if (!threadContainerElement) {
-      threadContainerElement = querySelector(
-        previewPaneContainer,
-        '.nH.g.id:has(.a98.iY)',
+      throw new Error(
+        `Failed to find element with selector: .nH.g.id:has(.a98.iY)`,
+        { cause: new Error("Thread container for preview pane wasn't found") },
       );
     }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -374,13 +374,17 @@ class GmailRouteView {
   }
 
   _startMonitoringPreviewPaneForThread(previewPaneContainer: HTMLElement) {
-    const threadContainerTableElement = querySelector(
-      previewPaneContainer,
-      'table.Bs > tr',
-    );
-    const elementStream = makeElementChildStream(
-      threadContainerTableElement,
-    ).filter(
+    let threadContainerElement =
+      previewPaneContainer.querySelector<HTMLElement>('table.Bs > tr');
+
+    if (!threadContainerElement) {
+      threadContainerElement = querySelector(
+        previewPaneContainer,
+        '.nH.g.id:has(.a98.iY)',
+      );
+    }
+
+    const elementStream = makeElementChildStream(threadContainerElement).filter(
       (event) =>
         !!event.el.querySelector('.if') ||
         !!event.el.querySelector('.PeIF1d') ||

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
@@ -198,18 +198,26 @@ class GmailThreadView {
     [2018]: '.if > .nH',
   };
 
+  _subjectContainerSelectorsAfterNov162023 = {
+    '2023_11_16': '> .nH',
+  };
+
   addNoticeBar(): SimpleElementView {
     const el = document.createElement('div');
     el.className = idMap('thread_noticeBar');
     let version;
     let subjectContainer;
 
-    for (const [currentVersion, selector] of Object.entries(
-      this._subjectContainerSelectors,
-    )) {
-      // Flow should be able to infer selector to be a string,
-      // Typescript can. Remove this when ported.
-      const el = this._element.querySelector(selector as any);
+    let selectorsToTry: Record<string, string> =
+      this._subjectContainerSelectors;
+
+    if (this._element.matches('.a98.iY')) {
+      // thread view gmail update Nov 16, 2023
+      selectorsToTry = this._subjectContainerSelectorsAfterNov162023;
+    }
+
+    for (const [currentVersion, selector] of Object.entries(selectorsToTry)) {
+      const el = this._element.querySelector(selector);
 
       if (!el) {
         continue;
@@ -700,13 +708,18 @@ class GmailThreadView {
       (toolbarContainerElement as any).parentElement.querySelector(
         '.if, .PeIF1d, .a98.iY',
       ) &&
-      (toolbarContainerElement as any).parentElement.querySelector(
+      ((toolbarContainerElement as any).parentElement.querySelector(
         '.if, .PeIF1d, .a98.iY',
-      ).parentElement === this._element
+      ).parentElement === this._element ||
+        (toolbarContainerElement as any).parentElement.querySelector(
+          '.a98.iY',
+        ) === this._element)
     ) {
       let version = '2018';
 
-      if (
+      if (this._element.matches('.a98.iY')) {
+        version = '2023-11-16';
+      } else if (
         (toolbarContainerElement as any).parentElement.querySelector('.a98.iY')
       ) {
         version = '2022-10-20';


### PR DESCRIPTION
gmail started rolling out update to its thread view markup, new markup no longer contains `table.Bs` selector, PR switched to use `.a98.iY` selector (because it is present in old and new markup, it required extra condition changes etc)

![image](https://github.com/InboxSDK/InboxSDK/assets/1696091/5319a2ce-a07a-4222-a090-10cbe0b7017a)

the fix is tentative and may need to be tweaked further.
