### PR TITLE
chore: more logging around #1072

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -23,6 +23,7 @@ import PageParserTree from 'page-parser-tree';
 import { makePageParser } from './page-parser';
 import toItemWithLifetimeStream from '../../../../lib/toItemWithLifetimeStream';
 import waitFor from '../../../../lib/wait-for';
+import { SelectorError } from '../../../../lib/dom/querySelectorOrFail';
 
 class GmailRouteView {
   _type: string;
@@ -376,25 +377,19 @@ class GmailRouteView {
   async _startMonitoringPreviewPaneForThread(
     previewPaneContainer: HTMLElement,
   ) {
-    const threadContainerElement = await waitFor(() => {
-      let threadContainerElement =
-        previewPaneContainer.querySelector<HTMLElement>('table.Bs > tr');
+    let threadContainerElement;
+    const selector_2023_11_16 = 'table.Bs > tr, .nH.g.id:has(.a98.iY)';
 
-      if (!threadContainerElement) {
-        threadContainerElement =
-          previewPaneContainer.querySelector<HTMLElement>(
-            '.nH.g.id:has(.a98.iY)',
-          );
-      }
-
-      return threadContainerElement;
-    });
-
-    if (!threadContainerElement) {
-      throw new Error(
-        `Failed to find element with selector: .nH.g.id:has(.a98.iY)`,
-        { cause: new Error("Thread container for preview pane wasn't found") },
-      );
+    try {
+      threadContainerElement = await waitFor(() => {
+        return previewPaneContainer.querySelector<HTMLElement>(
+          selector_2023_11_16,
+        );
+      }, 15_000);
+    } catch {
+      throw new SelectorError(selector_2023_11_16, {
+        cause: new Error("Thread container for preview pane wasn't found"),
+      });
     }
 
     const elementStream = makeElementChildStream(threadContainerElement).filter(

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
@@ -688,43 +688,40 @@ class GmailThreadView {
 
   _isToolbarContainerRelevant(toolbarContainerElement: HTMLElement): boolean {
     if (
-      (toolbarContainerElement as any).parentElement.parentElement ===
+      toolbarContainerElement.parentElement!.parentElement ===
       (this._element as any).parentElement.parentElement
     ) {
       return true;
     }
 
     if (
-      (toolbarContainerElement as any).parentElement.getAttribute('role') !==
-        'main' &&
-      (this._element as any).parentElement.getAttribute('role') !== 'main'
+      toolbarContainerElement.parentElement!.getAttribute('role') !== 'main' &&
+      this._element.parentElement!.getAttribute('role') !== 'main'
     ) {
       return true;
     }
 
     if (
-      (toolbarContainerElement as any).parentElement.getAttribute('role') ===
-        'main' &&
-      (toolbarContainerElement as any).parentElement.querySelector(
+      toolbarContainerElement.parentElement!.getAttribute('role') === 'main' &&
+      toolbarContainerElement.parentElement!.querySelector(
         '.if, .PeIF1d, .a98.iY',
       ) &&
-      ((toolbarContainerElement as any).parentElement.querySelector(
+      (toolbarContainerElement.parentElement!.querySelector(
         '.if, .PeIF1d, .a98.iY',
-      ).parentElement === this._element ||
-        (toolbarContainerElement as any).parentElement.querySelector(
-          '.a98.iY',
-        ) === this._element)
+      )!.parentElement === this._element ||
+        toolbarContainerElement.parentElement!.querySelector('.a98.iY') ===
+          this._element)
     ) {
       let version = '2018';
 
       if (this._element.matches('.a98.iY')) {
         version = '2023-11-16';
       } else if (
-        (toolbarContainerElement as any).parentElement.querySelector('.a98.iY')
+        toolbarContainerElement.parentElement!.querySelector('.a98.iY')
       ) {
         version = '2022-10-20';
       } else if (
-        (toolbarContainerElement as any).parentElement.querySelector('.PeIF1d')
+        toolbarContainerElement.parentElement!.querySelector('.PeIF1d')
       ) {
         version = '2022-10-12';
       }

--- a/src/platform-implementation-js/lib/dom/querySelectorOrFail.ts
+++ b/src/platform-implementation-js/lib/dom/querySelectorOrFail.ts
@@ -1,8 +1,16 @@
+export class SelectorError extends Error {
+  name = 'SelectorError';
+
+  constructor(selector: string, options?: { cause: unknown }) {
+    super(`Failed to find element with selector: ${selector}`, options);
+  }
+}
+
 export default function querySelector(
   el: Document | DocumentFragment | Element,
   selector: string,
 ): HTMLElement {
   const r = el.querySelector(selector);
-  if (!r) throw new Error(`Failed to find element with selector: ${selector}`);
+  if (!r) throw new SelectorError(selector);
   return r as HTMLElement;
 }


### PR DESCRIPTION
If the selectors neither `table.Bs > tr` or `.nH.g.id:has(.a98.iY)` are present, instead of logging a `WaitForError`, this PR alters logging to log a `SelectorError` instead. 

The latter SelectorError is easier to search for in our telemetry.