### PR TITLE
update selector for preview pane thread container

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -392,12 +392,9 @@ class GmailRouteView {
       if (isStreakAppId(this._driver.getAppId())) {
         this._driver
           .getLogger()
-          .errorSite(
-            new Error("Thread container for preview pane wasn't found"),
-            {
-              html: censorHTMLstring(previewPaneContainer.innerHTML),
-            },
-          );
+          .error(new Error("Thread container for preview pane wasn't found"), {
+            html: censorHTMLstring(previewPaneContainer.innerHTML),
+          });
       }
 
       throw new SelectorError(selector_2023_11_16, {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -24,6 +24,7 @@ import { makePageParser } from './page-parser';
 import toItemWithLifetimeStream from '../../../../lib/toItemWithLifetimeStream';
 import waitFor from '../../../../lib/wait-for';
 import { SelectorError } from '../../../../lib/dom/querySelectorOrFail';
+import censorHTMLstring from '../../../../../common/censorHTMLstring';
 
 class GmailRouteView {
   _type: string;
@@ -378,7 +379,7 @@ class GmailRouteView {
     previewPaneContainer: HTMLElement,
   ) {
     let threadContainerElement;
-    const selector_2023_11_16 = 'table.Bs > tr, .nH.g.id:has(.a98.iY)';
+    const selector_2023_11_16 = 'table.Bs > tr, .ao8:has(.a98.iY)';
 
     try {
       threadContainerElement = await waitFor(() => {
@@ -387,6 +388,15 @@ class GmailRouteView {
         );
       }, 15_000);
     } catch {
+      this._driver
+        .getLogger()
+        .errorSite(
+          new Error("Thread container for preview pane wasn't found"),
+          {
+            html: censorHTMLstring(previewPaneContainer.innerHTML),
+          },
+        );
+
       throw new SelectorError(selector_2023_11_16, {
         cause: new Error("Thread container for preview pane wasn't found"),
       });

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -25,6 +25,7 @@ import toItemWithLifetimeStream from '../../../../lib/toItemWithLifetimeStream';
 import waitFor from '../../../../lib/wait-for';
 import { SelectorError } from '../../../../lib/dom/querySelectorOrFail';
 import censorHTMLstring from '../../../../../common/censorHTMLstring';
+import isStreakAppId from '../../../../lib/isStreakAppId';
 
 class GmailRouteView {
   _type: string;
@@ -388,14 +389,16 @@ class GmailRouteView {
         );
       }, 15_000);
     } catch {
-      this._driver
-        .getLogger()
-        .errorSite(
-          new Error("Thread container for preview pane wasn't found"),
-          {
-            html: censorHTMLstring(previewPaneContainer.innerHTML),
-          },
-        );
+      if (isStreakAppId(this._driver.getAppId())) {
+        this._driver
+          .getLogger()
+          .errorSite(
+            new Error("Thread container for preview pane wasn't found"),
+            {
+              html: censorHTMLstring(previewPaneContainer.innerHTML),
+            },
+          );
+      }
 
       throw new SelectorError(selector_2023_11_16, {
         cause: new Error("Thread container for preview pane wasn't found"),

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -389,17 +389,18 @@ class GmailRouteView {
         );
       }, 15_000);
     } catch {
+      const selectorError = new SelectorError(selector_2023_11_16, {
+        cause: new Error("Thread container for preview pane wasn't found"),
+      });
       if (isStreakAppId(this._driver.getAppId())) {
         this._driver
           .getLogger()
-          .error(new Error("Thread container for preview pane wasn't found"), {
+          .error(selectorError, {
             html: censorHTMLstring(previewPaneContainer.innerHTML),
           });
       }
 
-      throw new SelectorError(selector_2023_11_16, {
-        cause: new Error("Thread container for preview pane wasn't found"),
-      });
+      throw selectorError;
     }
 
     const elementStream = makeElementChildStream(threadContainerElement).filter(

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -393,11 +393,9 @@ class GmailRouteView {
         cause: new Error("Thread container for preview pane wasn't found"),
       });
       if (isStreakAppId(this._driver.getAppId())) {
-        this._driver
-          .getLogger()
-          .error(selectorError, {
-            html: censorHTMLstring(previewPaneContainer.innerHTML),
-          });
+        this._driver.getLogger().error(selectorError, {
+          html: censorHTMLstring(previewPaneContainer.innerHTML),
+        });
       }
 
       throw selectorError;


### PR DESCRIPTION
looks like new gmail thread container markup is not being parsed properly in split mode. Update to potential new selector, and log censored html of the preview if still cannot be found