### PR TITLE
support extracting whole document html and css

### DIFF
--- a/src/common/censorHTMLstring.test.ts
+++ b/src/common/censorHTMLstring.test.ts
@@ -9,3 +9,13 @@ it('works', () => {
     '...<b href="..." bar src="..." a="..." class="whitelisted">...</b><i src="..."></i>...',
   );
 });
+
+it('can handle attributes with special symbol', () => {
+  expect(
+    censorHTMLstring(
+      `<div class="ar as" data-tooltip="Name <email@example.com>"><div class="at"><div class="au"><div class="av">Name</div></div></div></div>`,
+    ),
+  ).toBe(
+    `<div class="ar as" data-tooltip="..."><div class="at"><div class="au"><div class="av">...</div></div></div></div>`,
+  );
+});

--- a/src/common/censorHTMLstring.ts
+++ b/src/common/censorHTMLstring.ts
@@ -33,12 +33,12 @@ export const ATTRIBUTE_WHITELIST: Set<string> = new Set([
 // then log the censored HTML so we know we aren't logging user data.
 export default function censorHTMLstring(html: string): string {
   return html
+    .replace(/\s([^\s=]+)\s*=\s*"[^"]+"/g, (match: string, attr: string) =>
+      ATTRIBUTE_WHITELIST.has(attr) ? match : ` ${attr}="..."`,
+    )
     .replace(
       /(^|>)([^<]+)/g,
       (match: string, start: string, text: string) =>
         start + (text.trim().length ? '...' : ''),
-    )
-    .replace(/\s([^\s=]+)\s*=\s*"[^"]+"/g, (match: string, attr: string) =>
-      ATTRIBUTE_WHITELIST.has(attr) ? match : ` ${attr}="..."`,
     );
 }

--- a/src/common/extractDocumentHtmlAndCss.ts
+++ b/src/common/extractDocumentHtmlAndCss.ts
@@ -1,0 +1,56 @@
+import censorHTMLstring from './censorHTMLstring';
+
+export function extractDocumentHtmlAndCss(
+  options: { censor: boolean } = { censor: true },
+) {
+  try {
+    const css = Array.from(document.styleSheets)
+      .flatMap((sheet) => {
+        try {
+          const name = `\n/* Stylesheet : ${
+            sheet.href || '[inline styles]'
+          } */`;
+          const rules = Array.from(sheet.cssRules).map(
+            (cssRule) => cssRule.cssText,
+          );
+          rules.splice(0, 0, name);
+          return rules;
+        } catch (e) {
+          return [];
+        }
+      })
+      .join('\n')
+      .replaceAll(`url("//`, `url("https://`);
+
+    const links = Array.from(document.querySelectorAll('link'))
+      .filter((link) => link.href?.includes('fonts') || link.as === 'image')
+      .map((link) => link.outerHTML)
+      .join('\n');
+
+    let body = document.body.innerHTML;
+    body = body.replace(
+      /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+      '',
+    );
+    if (options.censor) {
+      body = censorHTMLstring(body);
+    }
+
+    return `
+      <!DOCTYPE html>
+      <html>
+          <head>
+            ${links}
+            <style>
+              ${css}
+            </style>
+          </head>
+          <body>
+            ${body}
+          </body>
+      </html>
+      `;
+  } catch (err) {
+    return `couldn't extract document html and css: ${err}`;
+  }
+}

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -24,8 +24,8 @@ import { makePageParser } from './page-parser';
 import toItemWithLifetimeStream from '../../../../lib/toItemWithLifetimeStream';
 import waitFor from '../../../../lib/wait-for';
 import { SelectorError } from '../../../../lib/dom/querySelectorOrFail';
-import censorHTMLstring from '../../../../../common/censorHTMLstring';
 import isStreakAppId from '../../../../lib/isStreakAppId';
+import { extractDocumentHtmlAndCss } from '../../../../../common/extractDocumentHtmlAndCss';
 
 class GmailRouteView {
   _type: string;
@@ -394,7 +394,7 @@ class GmailRouteView {
       });
       if (isStreakAppId(this._driver.getAppId())) {
         this._driver.getLogger().error(selectorError, {
-          html: censorHTMLstring(previewPaneContainer.innerHTML),
+          html: extractDocumentHtmlAndCss(),
         });
       }
 


### PR DESCRIPTION
because of gmail gradual updates there is a need in logging full document html with css so then it is possible to inspect the DOM tree and identify changes.

`extractDocumentHtmlAndCss` will output obfuscated document.body content and all css that is used on the page

example of the output
![image](https://github.com/InboxSDK/InboxSDK/assets/1696091/fd4e6e3b-1d06-42b4-b5c1-b354c9c0f8be)
