### PR TITLE
fix order of thread view parsing in split mode

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -281,10 +281,17 @@ const GmailElementGetter = {
   },
 
   getThreadContainerElement(): HTMLElement | null {
-    // [role=main] .g.id .a98.iY is the new selector after Nov 16, 2023 gmail change
-    return document.querySelector(
-      '[role=main] .g.id table.Bs > tr, [role=main] .g.id .a98.iY',
-    );
+    const selector = '[role=main] .g.id table.Bs > tr';
+    const selector_2023_11_16 = '[role=main] .g.id .a98.iY';
+
+    const threadContainerElement =
+      document.querySelector<HTMLElement>(selector);
+
+    if (threadContainerElement) {
+      return threadContainerElement;
+    }
+
+    return document.querySelector(selector_2023_11_16);
   },
 
   getToolbarElement(): HTMLElement {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -380,10 +380,19 @@ class GmailRouteView {
     previewPaneContainer: HTMLElement,
   ) {
     let threadContainerElement;
-    const selector_2023_11_16 = 'table.Bs > tr, .ao8:has(.a98.iY)';
+
+    const selector = 'table.Bs > tr';
+    const selector_2023_11_16 = '.ao8:has(.a98.iY)';
 
     try {
       threadContainerElement = await waitFor(() => {
+        const threadContainerElement =
+          previewPaneContainer.querySelector<HTMLElement>(selector);
+
+        if (threadContainerElement) {
+          return threadContainerElement;
+        }
+
         return previewPaneContainer.querySelector<HTMLElement>(
           selector_2023_11_16,
         );

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -398,9 +398,12 @@ class GmailRouteView {
         );
       }, 15_000);
     } catch {
-      const selectorError = new SelectorError(selector_2023_11_16, {
-        cause: new Error("Thread container for preview pane wasn't found"),
-      });
+      const selectorError = new SelectorError(
+        `${selector}, ${selector_2023_11_16}`,
+        {
+          cause: new Error("Thread container for preview pane wasn't found"),
+        },
+      );
       if (isStreakAppId(this._driver.getAppId())) {
         this._driver.getLogger().error(selectorError, {
           html: extractDocumentHtmlAndCss(),


### PR DESCRIPTION
`.querySelector` will return the second match if it is within children of the first match, so in order to keep inboxsdk expected container, the selectors should be split