### PR TITLE
support gmail page loading state

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -311,11 +311,9 @@ class GmailRouteView {
       // role=main attribute is not set while page in a loading state
       await waitFor(() => document.querySelector('[role=main]'), 15_000);
     } catch {
-      this._driver
-        .getLogger()
-        .error(new Error('[role=main] element not found'), {
-          html: extractDocumentHtmlAndCss(),
-        });
+      this._driver.getLogger().error(new SelectorError('[role=main]'), {
+        html: extractDocumentHtmlAndCss(),
+      });
     }
   }
 


### PR DESCRIPTION
it appears that the Gmail search page now renders with a delay, first showing a loading spinner (and potentially more pages will be doing that soon). This broke the navigation handler that expects elements to be present instantly. Gmail adds `[role=main]` attribute once loading is finished.

![image](https://github.com/InboxSDK/InboxSDK/assets/1696091/fcbf856e-7854-47e7-9165-f7e851371ffa)

the issue was reproduced on the account provided by @Alex-Chopard and @RBische thank you!