### PR TITLE
handle async thread container element

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -294,6 +294,31 @@ const GmailElementGetter = {
     return document.querySelector(selector_2023_11_16);
   },
 
+  getPreviewPaneThreadContainerElement(): HTMLElement | null | undefined {
+    // This element is always present in thread lists, but it only has contents
+    // when in preview pane mode. We want to monitor it in either case
+    // because the user could switch into preview pane mode.
+    const previewPaneContainer = document.querySelector<HTMLElement>(
+      'div[role=main] .aia',
+    );
+
+    if (!previewPaneContainer) {
+      return null;
+    }
+
+    const selector = 'table.Bs > tr';
+    const selector_2023_11_16 = '.ao8:has(.a98.iY)';
+
+    const threadContainerElement =
+      previewPaneContainer.querySelector<HTMLElement>(selector);
+
+    if (threadContainerElement) {
+      return threadContainerElement;
+    }
+
+    return previewPaneContainer.querySelector<HTMLElement>(selector_2023_11_16);
+  },
+
   getToolbarElement(): HTMLElement {
     return querySelector(document, '[gh=tm]');
   },

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -294,7 +294,7 @@ const GmailElementGetter = {
     return document.querySelector(selector_2023_11_16);
   },
 
-  getPreviewPaneThreadContainerElement(): HTMLElement | null | undefined {
+  getPreviewPaneThreadContainerElement(): HTMLElement | null {
     // This element is always present in thread lists, but it only has contents
     // when in preview pane mode. We want to monitor it in either case
     // because the user could switch into preview pane mode.

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -406,11 +406,15 @@ class GmailRouteView {
     }
 
     if (parseResult === null) {
+      // check if the page contains list of thread rows
+      const viewWithRows =
+        this.#page.tree.getAllByTag('rowListElement').values().size > 0;
+
       const readingPaneDisabled = !document.querySelector(
         '.bGI[role=main] .Nu.S3.aZ6',
       );
 
-      if (readingPaneDisabled) {
+      if (viewWithRows && readingPaneDisabled) {
         // (.aia) element is not present when reading pane is disabled in Gmail settings
         // avoid logging not found error in this case
       } else {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -304,7 +304,7 @@ class GmailRouteView {
       await this.#waitForMainElementSafe();
 
       this.#monitorRowListElements();
-      this._setupContentAndSidebarView();
+      this.#setupContentAndSidebarView();
       this._setupScrollStream();
     });
   }
@@ -345,7 +345,7 @@ class GmailRouteView {
     });
   }
 
-  async _setupContentAndSidebarView() {
+  async #setupContentAndSidebarView() {
     let container:
       | {
           threadContainerElement?: HTMLElement;
@@ -415,7 +415,7 @@ class GmailRouteView {
         view: gmailThreadView,
       });
     } else if (container?.previewPaneContainerElement) {
-      this._startMonitoringPreviewPaneForThread(
+      this.#startMonitoringPreviewPaneForThread(
         container.previewPaneContainerElement,
       );
     } else {
@@ -443,13 +443,13 @@ class GmailRouteView {
     }
   }
 
-  async _startMonitoringPreviewPaneForThread(
+  async #startMonitoringPreviewPaneForThread(
     previewPaneContainer: HTMLElement,
   ) {
     let threadContainerElement;
 
     const selector = 'table.Bs > tr';
-    const selector_2023_11_16 = '.ao8:has(.a98.iY)';
+    const selector_2023_11_16 = '.ao8:has(.a98.iY), .ao9:has(.apa)';
 
     try {
       threadContainerElement = await waitFor(() => {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -453,13 +453,17 @@ class GmailRouteView {
   async #startMonitoringPreviewPaneForThread(
     previewPaneContainer: HTMLElement,
   ) {
-    let threadContainerElement;
+    let threadContainerElement: HTMLElement | 'destroyed';
 
     const selector = 'table.Bs > tr';
     const selector_2023_11_16 = '.ao8:has(.a98.iY), .ao9:has(.apa)';
 
     try {
       threadContainerElement = await waitFor(() => {
+        if (this.#destroyed) {
+          return 'destroyed';
+        }
+
         const threadContainerElement =
           previewPaneContainer.querySelector<HTMLElement>(selector);
 
@@ -485,6 +489,10 @@ class GmailRouteView {
       }
 
       throw selectorError;
+    }
+
+    if (threadContainerElement === 'destroyed') {
+      return;
     }
 
     const elementStream = makeElementChildStream(threadContainerElement).filter(

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -379,7 +379,7 @@ class GmailRouteView {
       }, 15_000);
     } catch {
       // if user has reading pane disabled in Gmail settings, even preview pane container is not rendered
-      // avoid throwing and error in valid case if there are thread rows available
+      // avoid throwing an error if there are thread rows available
       const rowsAvailable =
         this.#page.tree.getAllByTag('rowListElement').values().size > 0;
 


### PR DESCRIPTION
Gmail started rendering thread view asynchronously for some users, wait for thread content container element appear in the DOM before notifying with `newGmailThreadView` event