### PR TITLE
proposed fix for: SelectorError: Failed to find element with selector: table.Bs > tr, .ao8:has(.a98.iY)

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -433,8 +433,7 @@ class GmailRouteView {
         !!event.el.querySelector('.if') ||
         !!event.el.querySelector('.PeIF1d') ||
         !!event.el.querySelector('.a98.iY') ||
-        (event.el.classList.contains('a98') &&
-          event.el.classList.contains('iY')),
+        event.el.matches('.a98.iY'),
     );
 
     this._eventStream.plug(

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -397,7 +397,7 @@ class GmailRouteView {
     let threadContainerElement;
 
     const selector = 'table.Bs > tr';
-    const selector_2023_11_16 = '.ao8:has(.a98.iY)';
+    const selector_2023_11_16 = '.ao8:has(.a98.iY), .ao9:has(.apa)';
 
     try {
       threadContainerElement = await waitFor(() => {
@@ -432,7 +432,9 @@ class GmailRouteView {
       (event) =>
         !!event.el.querySelector('.if') ||
         !!event.el.querySelector('.PeIF1d') ||
-        !!event.el.querySelector('.a98.iY'),
+        !!event.el.querySelector('.a98.iY') ||
+        (event.el.classList.contains('a98') &&
+          event.el.classList.contains('iY')),
     );
 
     this._eventStream.plug(


### PR DESCRIPTION
Hi, sadly we experiencing more issues with the preview pane and the detection of a selected conversation / switch to another conversation.
As I'm able to reproduce the issue on the test account, I trying a fix.

Fill free to ask if you have any question / suggestion about this PR.

Error in the console:
<img width="769" alt="Screenshot 2023-11-22 at 11 58 46" src="https://github.com/InboxSDK/InboxSDK/assets/29271954/358338fd-44e2-416b-8ed0-1e92b2e03bae">

DOM with preview panel enabled and no conversation selected:
`.ao8` is well found but not `.a98.iY`
![Screenshot 2023-11-22 at 12 00 33](https://github.com/InboxSDK/InboxSDK/assets/29271954/ddf18240-017d-47b0-85f6-adc0bd75abc2)

DOM with preview panel enabled and a conversation selected:
`.apa` has been replaced with `.a98.iY`
![Screenshot 2023-11-22 at 12 01 28](https://github.com/InboxSDK/InboxSDK/assets/29271954/fb2194aa-b575-430e-8fa1-4b1663bceb9c)


Without the fix:

https://github.com/InboxSDK/InboxSDK/assets/29271954/33666754-2b65-40d0-b863-8b736a854ad0



With the fix:

https://github.com/InboxSDK/InboxSDK/assets/29271954/3c2363a8-d635-4cf6-9e62-83f51d3bb3eb





#1071

Closes #1078