### PR TITLE
fix selector of preview pane opened thread view

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -460,7 +460,7 @@ class GmailRouteView {
     let threadContainerElement: HTMLElement | 'destroyed';
 
     const selector = 'table.Bs > tr';
-    const selector_2023_11_16 = '.ao8:has(.a98.iY), .ao9:has(.apa)';
+    const selector_2023_11_16 = '.ao9:has(.a98.iY), .ao9:has(.apa)';
 
     try {
       threadContainerElement = await waitFor(() => {


### PR DESCRIPTION
`.ao9:has(.a98.iY)` selector for preview pane with opened email.

if user navigates to inbox page with preview pane enabled, opens email, navigates to another page, and then navigates back to inbox, gmail will pre open email from earlier. Having .ao8 as a thread container was preventing MutationObserver identifiying changes to the thread view dom, moving the thread container down one node (to .ao9) allows MutationObserver to identify the changes when switching between emails.