### PR TITLE
Fix modifying suggestions when no suggestions are present

### DIFF
--- a/src/injected-js/gmail/modify-suggestions.ts
+++ b/src/injected-js/gmail/modify-suggestions.ts
@@ -142,7 +142,11 @@ function modifySuggestions(
       newItem[7] += ' asor_i4';
     }
 
-    parsed[0][3].push(newItem);
+    if (Array.isArray(parsed[0][3])) {
+      parsed[0][3].push(newItem);
+    } else {
+      parsed[0][3] = [newItem];
+    }
   }
   return GRP.serialize(parsed, options);
 }


### PR DESCRIPTION
Fixes our support for modifying suggestions when no suggestions from Gmail are present. Works around a Gmail behavior change where an array we expect to be present stops being present when there are no suggestions from Gmail. This seems to restore the intended behavior.