### PR TITLE
Fix gulpfile setupExamples() step

### DIFF
--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -90,6 +90,7 @@ async function setupExamples() {
     stream.on('finish', () => {
       resolve(undefined);
     });
+    stream.resume();
   });
   if (args.reloader) {
     await extReloader();


### PR DESCRIPTION
If there are more than 16 files that match the patterns `./packages/core/inboxsdk.js*` `./packages/core/platform-implementation.js*` `./packages/core/pageWorld.js*`, then builds with the --remote flag fail:

```
chris@Chriss-MacBook-Air InboxSDK % yarn gulp default --remote
[22:56:42] Requiring external module @babel/register
[22:56:43] Using gulpfile ~/Coding/streak/InboxSDK/gulpfile.babel.ts
[22:56:43] Starting 'default'...
[22:56:43] Starting 'sdk'...
[22:56:43] Starting 'types'...
asset pageWorld.js 689 KiB [emitted] (name: pageWorld) 1 related asset
runtime modules 1.71 KiB 9 modules
modules by path ./node_modules/lodash/*.js 154 KiB
  ./node_modules/lodash/find.js 1.27 KiB [built] [code generated]
  + 205 modules
modules by path ./src/ 146 KiB 39 modules
modules by path ./node_modules/@babel/runtime/helpers/*.js 4.89 KiB
  ./node_modules/@babel/runtime/helpers/interopRequireDefault.js 224 bytes [built] [code generated]
  + 11 modules
modules by path ./node_modules/ext-corb-workaround/dist/src/*.js 4.09 KiB
  ./node_modules/ext-corb-workaround/dist/src/pageWorld.js 3.17 KiB [optional] [built] [code generated]
  + 2 modules
modules by path ./node_modules/querystring-es3/*.js 5.06 KiB
  ./node_modules/querystring-es3/index.js 127 bytes [built] [code generated]
  + 2 modules
+ 12 modules
webpack 5.76.3 compiled successfully in 977 ms
asset platform-implementation.js 4.36 MiB [emitted] (name: platform-implementation) 1 related asset
asset inboxsdk.js 58.7 KiB [emitted] (name: inboxsdk) 1 related asset
runtime modules 3.19 KiB 14 modules
modules by path ./node_modules/ 2.08 MiB 360 modules
modules by path ./src/ 1010 KiB
  modules by path ./src/platform-implementation-js/ 981 KiB 242 modules
  modules by path ./src/common/*.ts 22 KiB 20 modules
  modules by path ./src/inboxsdk-js/ 2.7 KiB
    modules by path ./src/inboxsdk-js/*.ts 1.55 KiB 4 modules
    modules by path ./src/inboxsdk-js/loading/*.ts 1.16 KiB 2 modules
asset modules 696 KiB
  modules by mime type image/png 3.02 KiB
    data:image/png;base64,iVBORw0KGgoAAAAN.. 411 bytes [built] [code generated]
    data:image/png;base64,iVBORw0KGgoAAAAN.. 2.62 KiB [built] [code generated]
  ./packages/core/pageWorld.js?raw 689 KiB [built] [code generated]
  data:image/svg+xml;base64,PD94bWwgdmVyc2lv.. 3.31 KiB [built] [code generated]
webpack 5.76.3 compiled successfully in 2727 ms
[22:56:47] Finished 'types' after 4.6 s
[22:56:47] The following tasks did not complete: default, sdk
[22:56:47] Did you forget to signal async completion?
```

This failure happens because the stream in the setupExamples() function never emits the finish event. This seems to happen because gulp-dest-atomic uses through2 which has an option called highWaterMark that defaults to 16 which causes the stream to wait until it's consumed (through a resume call or data listener being added) before it keeps letting data through, and then Node exits early once there's nothing being done.

There can be over 16 files if you've done several builds of different versions because the sourcemaps now have hashes in their filenames and end up collecting in the packages/core folder.