### PR TITLE
chore: prep for CollapsibleSectionView work

### DIFF
--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -33,6 +33,8 @@ import type {
   default as Toolbars,
   LegacyToolbarButtonDescriptor,
 } from './platform-implementation-js/namespaces/toolbars';
+import type CollapsibleSectionView from './platform-implementation-js/views/collapsible-section-view';
+import ListRouteView from './platform-implementation-js/views/route-view/list-route-view';
 
 export type { User };
 
@@ -277,9 +279,7 @@ export interface SectionView extends EventEmitter {
   remove(): void;
 }
 
-export interface CollapsibleSectionView extends SectionView {
-  setCollapsed(value: boolean): void;
-}
+export { CollapsibleSectionView };
 
 export class RouteView extends EventEmitter {
   constructor(
@@ -297,11 +297,70 @@ export class RouteView extends EventEmitter {
   isCustomRouteBelongingToApp(): boolean;
 }
 
-export interface ListRouteView extends RouteView {
-  addCollapsibleSection(options: any): CollapsibleSectionView;
-  addSection(options: any): SectionView;
-  refresh(): void;
+/** Represents the a single row to render in SectionViews and CollapsibleSectionViews
+ */
+interface RowDescriptor {
+  /** First textual column */
+  title: string;
+  /** Second textual column */
+  body: string;
+  /** Last text right-aligned. Often used for dates. */
+  shortDetailText: string;
+  /**
+   * Whether the row should be rendered as read or unread similar to Gmail styles.
+   *
+   * @TODO is this actually required like the docs say?
+   */
+  isRead?: string;
+  /** Any labels that should be rendered. */
+  labels: LabelDescriptor[];
+  /** An optional class to apply to the icon. */
+  iconClass?: string;
+  /** An optional HTML to an icon to display on the left side of the row */
+  iconHtml?: string;
+  /** An optional url to an icon to display on the left side of the row */
+  iconUrl?: string;
+  /** The name of the route to navigate to when the row is clicked on. */
+  routeID?: string;
+  /** The parameters of the route being navigated to when the row is clicked on. */
+  routeParams?: string[];
+  /** Callback for when the row is clicked on. */
+  onClick?(e: unknown): void;
 }
+
+/** The properties required to create a SectionView or CollapsibleSectionView. */
+export interface SectionDescriptor {
+  /** Main title */
+  title: string;
+  /** Subtitle */
+  subtitle?: string | null;
+  /** Link to display in the summary area of the SectionView. Typically page counts are displayed here.	*/
+  /** A function to call when the title link has been clicked. */
+  titleLinkText?: string;
+  onTitleLinkClick?(e: MouseEvent): void;
+  /** Whether to display a dropdown arrow for more options on the collapsible section. */
+  hasDropdown?: boolean;
+  /**
+   * A function to call when the dropdown is opened. Your function is passed an event object with a single dropdown property.
+   */
+  onDropdownClick?(e: unknown): void;
+  /** The rows that should be shown. */
+  tableRows?: RowDescriptor[];
+  /** An arbitrary HTML element to place above the table rows but below the title. */
+  contentElement?: HTMLElement;
+  /** A link to place in the footer of the SectionView.	 */
+  footerLinkText?: string;
+  /** A function to call when the link in the footer is clicked. */
+  onFooterLinkClick?(e: MouseEvent): void;
+  /** @internal */
+  orderHint?: unknown;
+  /** @internal */
+  footerLinkIconUrl?: unknown;
+  /** @internal */
+  footerLinkIconClass?: unknown;
+}
+
+export { ListRouteView };
 
 export interface CustomRouteView extends RouteView {
   getElement(): HTMLElement;

--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -348,7 +348,7 @@ export interface RowDescriptor {
 }
 
 /**
- * The properties required to create a {@link SectionVie}w or {@link CollapsibleSectionView}.
+ * The properties required to create a {@link SectionView} or {@link CollapsibleSectionView}.
  */
 export interface SectionDescriptor {
   /** Main title */

--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -34,7 +34,8 @@ import type {
   LegacyToolbarButtonDescriptor,
 } from './platform-implementation-js/namespaces/toolbars';
 import type CollapsibleSectionView from './platform-implementation-js/views/collapsible-section-view';
-import ListRouteView from './platform-implementation-js/views/route-view/list-route-view';
+import type ListRouteView from './platform-implementation-js/views/route-view/list-route-view';
+import type SectionView from './platform-implementation-js/views/section-view';
 
 export type { User };
 
@@ -275,11 +276,7 @@ export interface ThreadRowAttachmentIconDescriptor {
 
 export { NavItemView };
 
-export interface SectionView extends EventEmitter {
-  remove(): void;
-}
-
-export { CollapsibleSectionView };
+export { SectionView, CollapsibleSectionView };
 
 export class RouteView extends EventEmitter {
   constructor(

--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -356,8 +356,8 @@ export interface SectionDescriptor {
   /** Subtitle */
   subtitle?: string | null;
   /** Link to display in the summary area of the {@link SectionView}. Typically page counts are displayed here.	*/
-  /** A function to call when the title link has been clicked. */
   titleLinkText?: string;
+  /** A function to call when the title link has been clicked. */
   onTitleLinkClick?(e: MouseEvent): void;
   /** Whether to display a dropdown arrow for more options on the collapsible section. */
   hasDropdown?: boolean;

--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -257,14 +257,35 @@ export interface DraftLabelDescriptor {
   count?: string | number;
 }
 
+/**
+ * This type is used to describe labels that you add to {@link ThreadRowView} and {@link CollapsibleSectionView}.
+ */
 export interface LabelDescriptor {
+  /**
+   * Text of the label.
+   *
+   * @todo marked as required in the docs.
+   */
   title?: string;
+  /** @internal is this still used? */
   titleHtml?: string;
+  /** A background color to put on the icon element if present. */
+  iconBackgroundColor?: string;
+  /**
+   * URL for the icon to show on the label. Should be a local extension file URL or a HTTPS URL.
+   *
+   * @todo marked as required in the docs
+   */
   iconUrl?: string;
+  /** A CSS class to apply to the icon. */
   iconClass?: string;
+  /** Html for the icon to show on the label. This property can't be used with iconUrl or iconClass. */
   iconHtml?: string;
+  /** The text color of the label. */
   foregroundColor?: string;
+  /** The background color of the label. */
   backgroundColor?: string;
+  /** Max width for the label title.The default label title max-width is 90px */
   maxWidth?: string;
 }
 
@@ -294,9 +315,10 @@ export class RouteView extends EventEmitter {
   isCustomRouteBelongingToApp(): boolean;
 }
 
-/** Represents the a single row to render in SectionViews and CollapsibleSectionViews
+/**
+ * Represents the a single row to render in {@link SectionView}s and {@link CollapsibleSectionView}s
  */
-interface RowDescriptor {
+export interface RowDescriptor {
   /** First textual column */
   title: string;
   /** Second textual column */
@@ -325,13 +347,15 @@ interface RowDescriptor {
   onClick?(e: unknown): void;
 }
 
-/** The properties required to create a SectionView or CollapsibleSectionView. */
+/**
+ * The properties required to create a {@link SectionVie}w or {@link CollapsibleSectionView}.
+ */
 export interface SectionDescriptor {
   /** Main title */
   title: string;
   /** Subtitle */
   subtitle?: string | null;
-  /** Link to display in the summary area of the SectionView. Typically page counts are displayed here.	*/
+  /** Link to display in the summary area of the {@link SectionView}. Typically page counts are displayed here.	*/
   /** A function to call when the title link has been clicked. */
   titleLinkText?: string;
   onTitleLinkClick?(e: MouseEvent): void;
@@ -345,7 +369,7 @@ export interface SectionDescriptor {
   tableRows?: RowDescriptor[];
   /** An arbitrary HTML element to place above the table rows but below the title. */
   contentElement?: HTMLElement;
-  /** A link to place in the footer of the SectionView.	 */
+  /** A link to place in the footer of the {@link SectionView}.	 */
   footerLinkText?: string;
   /** A function to call when the link in the footer is clicked. */
   onFooterLinkClick?(e: MouseEvent): void;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
@@ -11,25 +11,25 @@ import DropdownButtonViewController from '../../../widgets/buttons/dropdown-butt
 import type GmailDriver from '../gmail-driver';
 
 class GmailCollapsibleSectionView {
-  _driver: GmailDriver;
-  _groupOrderHint: number;
-  _isReadyDeferred: Record<string, any>;
-  _isCollapsible: boolean;
-  _collapsibleSectionDescriptor: Record<string, any> = {};
-  _isSearch: boolean;
-  _element: HTMLElement | null | undefined = null;
-  _headerElement: HTMLElement | null | undefined = null;
-  _titleElement: HTMLElement | null | undefined = null;
-  _bodyElement: HTMLElement | null | undefined = null;
-  _contentElement: HTMLElement | null | undefined = null;
-  _tableBodyElement: HTMLElement | null | undefined = null;
-  _collapsedContainer: HTMLElement | null | undefined = null;
-  _messageElement: HTMLElement | null | undefined = null;
-  _footerElement: HTMLElement | null | undefined = null;
-  _eventStream: Bus<any, unknown>;
-  _isCollapsed: boolean = false;
-  _inboxDropdownButtonView: Record<string, any> | null | undefined = null;
-  _dropdownViewController: Record<string, any> | null | undefined = null;
+  #driver: GmailDriver;
+  #groupOrderHint: number;
+  #isReadyDeferred: Record<string, any>;
+  #isCollapsible: boolean;
+  #collapsibleSectionDescriptor: Record<string, any> = {};
+  #isSearch: boolean;
+  #element: HTMLElement | null | undefined = null;
+  #headerElement: HTMLElement | null | undefined = null;
+  #titleElement: HTMLElement | null | undefined = null;
+  #bodyElement: HTMLElement | null | undefined = null;
+  #contentElement: HTMLElement | null | undefined = null;
+  #tableBodyElement: HTMLElement | null | undefined = null;
+  #collapsedContainer: HTMLElement | null | undefined = null;
+  #messageElement: HTMLElement | null | undefined = null;
+  #footerElement: HTMLElement | null | undefined = null;
+  #eventStream: Bus<any, unknown>;
+  #isCollapsed: boolean = false;
+  #inboxDropdownButtonView: Record<string, any> | null | undefined = null;
+  #dropdownViewController: Record<string, any> | null | undefined = null;
 
   constructor(
     driver: GmailDriver,
@@ -37,37 +37,37 @@ class GmailCollapsibleSectionView {
     isSearch: boolean,
     isCollapsible: boolean,
   ) {
-    this._driver = driver;
-    this._isSearch = isSearch;
-    this._groupOrderHint = groupOrderHint;
-    this._isCollapsible = isCollapsible;
-    this._eventStream = kefirBus();
-    this._isReadyDeferred = new (defer as any)();
+    this.#driver = driver;
+    this.#isSearch = isSearch;
+    this.#groupOrderHint = groupOrderHint;
+    this.#isCollapsible = isCollapsible;
+    this.#eventStream = kefirBus();
+    this.#isReadyDeferred = new (defer as any)();
   }
 
   destroy() {
-    if (this._element) this._element.remove();
-    if (this._eventStream) this._eventStream.end();
-    if (this._headerElement) this._headerElement.remove();
-    if (this._titleElement) this._titleElement.remove();
-    if (this._bodyElement) this._bodyElement.remove();
-    if (this._contentElement) this._contentElement.remove();
-    if (this._tableBodyElement) this._tableBodyElement.remove();
-    if (this._collapsedContainer) this._collapsedContainer.remove();
-    if (this._messageElement) this._messageElement.remove();
-    if (this._inboxDropdownButtonView) this._inboxDropdownButtonView.destroy();
-    if (this._dropdownViewController) this._dropdownViewController.destroy();
+    if (this.#element) this.#element.remove();
+    if (this.#eventStream) this.#eventStream.end();
+    if (this.#headerElement) this.#headerElement.remove();
+    if (this.#titleElement) this.#titleElement.remove();
+    if (this.#bodyElement) this.#bodyElement.remove();
+    if (this.#contentElement) this.#contentElement.remove();
+    if (this.#tableBodyElement) this.#tableBodyElement.remove();
+    if (this.#collapsedContainer) this.#collapsedContainer.remove();
+    if (this.#messageElement) this.#messageElement.remove();
+    if (this.#inboxDropdownButtonView) this.#inboxDropdownButtonView.destroy();
+    if (this.#dropdownViewController) this.#dropdownViewController.destroy();
   }
 
   getElement(): HTMLElement {
-    const element = this._element;
+    const element = this.#element;
     if (!element)
       throw new Error('tried to access element that does not exist');
     return element;
   }
 
   getEventStream() {
-    return this._eventStream;
+    return this.#eventStream;
   }
 
   setCollapsibleSectionDescriptorProperty(
@@ -77,27 +77,27 @@ class GmailCollapsibleSectionView {
     >,
   ) {
     const stoppedProperty = collapsibleSectionDescriptorProperty.takeUntilBy(
-      this._eventStream.filter(() => false).beforeEnd(() => null),
+      this.#eventStream.filter(() => false).beforeEnd(() => null),
     );
-    stoppedProperty.onValue((x) => this._updateValues(x));
-    stoppedProperty.take(1).onValue(() => this._isReadyDeferred.resolve(this));
+    stoppedProperty.onValue((x) => this.#updateValues(x));
+    stoppedProperty.take(1).onValue(() => this.#isReadyDeferred.resolve(this));
   }
 
   setCollapsed(value: boolean) {
-    if (!this._isCollapsible) {
+    if (!this.#isCollapsible) {
       return;
     }
 
-    this._isReadyDeferred.promise.then(() => {
-      if (value) this._collapse();
-      else this._expand();
+    this.#isReadyDeferred.promise.then(() => {
+      if (value) this.#collapse();
+      else this.#expand();
     });
   }
 
-  _updateValues(
+  #updateValues(
     collapsibleSectionDescriptor: Record<string, any> | null | undefined,
   ) {
-    const element = this._element;
+    const element = this.#element;
 
     if (!collapsibleSectionDescriptor) {
       if (element) {
@@ -112,36 +112,36 @@ class GmailCollapsibleSectionView {
     if (!element) {
       this._setupElement(collapsibleSectionDescriptor);
 
-      this._showLoadingMessage();
+      this.#showLoadingMessage();
     } else {
       this._updateElement(collapsibleSectionDescriptor);
     }
 
-    this._updateHeader(collapsibleSectionDescriptor);
+    this.#updateHeader(collapsibleSectionDescriptor);
 
-    this._updateTitle(collapsibleSectionDescriptor);
+    this.#updateTitle(collapsibleSectionDescriptor);
 
-    this._updateSubtitle(collapsibleSectionDescriptor);
+    this.#updateSubtitle(collapsibleSectionDescriptor);
 
-    this._updateSummaryText(collapsibleSectionDescriptor);
+    this.#updateSummaryText(collapsibleSectionDescriptor);
 
-    this._updateDropdown(collapsibleSectionDescriptor);
+    this.#updateDropdown(collapsibleSectionDescriptor);
 
-    this._updateContentElement(collapsibleSectionDescriptor);
+    this.#updateContentElement(collapsibleSectionDescriptor);
 
-    this._updateTableRows(collapsibleSectionDescriptor);
+    this.#updateTableRows(collapsibleSectionDescriptor);
 
-    this._updateMessageElement(collapsibleSectionDescriptor);
+    this.#updateMessageElement(collapsibleSectionDescriptor);
 
-    this._updateFooter(collapsibleSectionDescriptor);
+    this.#updateFooter(collapsibleSectionDescriptor);
 
-    this._collapsibleSectionDescriptor = collapsibleSectionDescriptor;
+    this.#collapsibleSectionDescriptor = collapsibleSectionDescriptor;
   }
 
   _setupElement(collapsibleSectionDescriptor: Record<string, any>) {
-    const element = (this._element = document.createElement('div'));
+    const element = (this.#element = document.createElement('div'));
     element.setAttribute('class', 'inboxsdk__resultsSection');
-    element.setAttribute('data-group-order-hint', String(this._groupOrderHint));
+    element.setAttribute('data-group-order-hint', String(this.#groupOrderHint));
     element.setAttribute(
       'data-order-hint',
       String(
@@ -150,42 +150,42 @@ class GmailCollapsibleSectionView {
           : 0,
       ),
     );
-    if (!this._isCollapsible)
+    if (!this.#isCollapsible)
       element.classList.add('inboxsdk__resultsSection_nonCollapsible');
 
     this._setupHeader(collapsibleSectionDescriptor);
 
-    const bodyElement = (this._bodyElement = document.createElement('div'));
+    const bodyElement = (this.#bodyElement = document.createElement('div'));
     const bodyContentsElement = document.createElement('div');
     bodyContentsElement.classList.add('zE');
     bodyElement.appendChild(bodyContentsElement);
     element.appendChild(bodyElement);
-    const contentElement = (this._contentElement =
+    const contentElement = (this.#contentElement =
       document.createElement('div'));
     bodyContentsElement.appendChild(contentElement);
-    const messageElement = (this._messageElement =
+    const messageElement = (this.#messageElement =
       document.createElement('div'));
     bodyContentsElement.appendChild(messageElement);
-    const tableBodyElement = (this._tableBodyElement =
+    const tableBodyElement = (this.#tableBodyElement =
       document.createElement('div'));
     bodyContentsElement.appendChild(tableBodyElement);
 
     this._setupFooter();
 
-    if (this._isCollapsible && this._titleElement) {
-      Kefir.fromEvents(this._titleElement, 'click').onValue(() =>
-        this._toggleCollapseState(),
+    if (this.#isCollapsible && this.#titleElement) {
+      Kefir.fromEvents(this.#titleElement, 'click').onValue(() =>
+        this.#toggleCollapseState(),
       );
     }
 
     Kefir.fromEvents(element, 'removeCollapsedContainer').onValue(() =>
-      this._destroyCollapsedContainer(),
+      this.#destroyCollapsedContainer(),
     );
     Kefir.fromEvents(element, 'readdToCollapsedContainer').onValue(() =>
-      this._addToCollapsedContainer(),
+      this.#addToCollapsedContainer(),
     );
 
-    this._eventStream.emit({
+    this.#eventStream.emit({
       type: 'update',
       property: 'orderHint',
       sectionDescriptor: collapsibleSectionDescriptor,
@@ -193,19 +193,19 @@ class GmailCollapsibleSectionView {
   }
 
   _setupHeader(collapsibleSectionDescriptor: Record<string, any>) {
-    const headerElement = (this._headerElement = document.createElement('div'));
+    const headerElement = (this.#headerElement = document.createElement('div'));
     headerElement.classList.add('inboxsdk__resultsSection_header', 'Wg');
 
     this._setupGmailv2Header(headerElement, collapsibleSectionDescriptor);
 
-    if (this._element) this._element.appendChild(headerElement);
+    if (this.#element) this.#element.appendChild(headerElement);
   }
 
   _setupGmailv2Header(
     headerElement: HTMLElement,
     collapsibleSectionDescriptor: Record<string, any>,
   ) {
-    const titleElement = (this._titleElement = document.createElement('div'));
+    const titleElement = (this.#titleElement = document.createElement('div'));
     titleElement.setAttribute('class', 'inboxsdk__resultsSection_title');
     titleElement.innerHTML = [
       '<h3 class="Wr iR">',
@@ -217,23 +217,23 @@ class GmailCollapsibleSectionView {
     ].join('');
     const floatRightElement = document.createElement('div');
     floatRightElement.classList.add('Cr');
-    if (this._isSearch) floatRightElement.classList.add('Wg');
+    if (this.#isSearch) floatRightElement.classList.add('Wg');
     headerElement.appendChild(titleElement);
     headerElement.appendChild(floatRightElement);
   }
 
   _setupFooter() {
-    const footerElement = (this._footerElement = document.createElement('div'));
+    const footerElement = (this.#footerElement = document.createElement('div'));
     footerElement.classList.add('inboxsdk__resultsSection_footer');
-    if (this._bodyElement) this._bodyElement.appendChild(footerElement);
+    if (this.#bodyElement) this.#bodyElement.appendChild(footerElement);
   }
 
   _updateElement(collapsibleSectionDescriptor: Record<string, any>) {
     if (
-      this._collapsibleSectionDescriptor.orderHint !==
+      this.#collapsibleSectionDescriptor.orderHint !==
       collapsibleSectionDescriptor.orderHint
     ) {
-      const element = this._element;
+      const element = this.#element;
       if (element)
         element.setAttribute(
           'data-order-hint',
@@ -243,43 +243,43 @@ class GmailCollapsibleSectionView {
               : 0),
         );
 
-      this._eventStream.emit({
+      this.#eventStream.emit({
         type: 'update',
         property: 'orderHint',
       });
     }
   }
 
-  _updateHeader(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateHeader(collapsibleSectionDescriptor: Record<string, any>) {
     if (
-      this._isCollapsible ||
+      this.#isCollapsible ||
       collapsibleSectionDescriptor.title ||
       collapsibleSectionDescriptor.subtitle ||
       collapsibleSectionDescriptor.titleLinkText ||
       collapsibleSectionDescriptor.hasDropdown
     ) {
-      if (this._headerElement) this._headerElement.style.display = '';
+      if (this.#headerElement) this.#headerElement.style.display = '';
     } else {
-      if (this._headerElement) this._headerElement.style.display = 'none';
+      if (this.#headerElement) this.#headerElement.style.display = 'none';
     }
   }
 
-  _updateTitle(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateTitle(collapsibleSectionDescriptor: Record<string, any>) {
     if (
-      this._collapsibleSectionDescriptor.title !==
+      this.#collapsibleSectionDescriptor.title !==
       collapsibleSectionDescriptor.title
     ) {
       const selector = 'h3 > .Wn';
 
-      if (this._titleElement) {
-        querySelector(this._titleElement, selector).textContent =
+      if (this.#titleElement) {
+        querySelector(this.#titleElement, selector).textContent =
           collapsibleSectionDescriptor.title;
       }
     }
   }
 
-  _updateSubtitle(collapsibleSectionDescriptor: Record<string, any>) {
-    const titleElement = this._titleElement;
+  #updateSubtitle(collapsibleSectionDescriptor: Record<string, any>) {
+    const titleElement = this.#titleElement;
     if (!titleElement) return;
     let subtitleElement = titleElement.querySelector(
       '.inboxsdk__resultsSection_title_subtitle',
@@ -290,7 +290,7 @@ class GmailCollapsibleSectionView {
         subtitleElement.remove();
       }
     } else if (
-      this._collapsibleSectionDescriptor.subtitle !==
+      this.#collapsibleSectionDescriptor.subtitle !==
       collapsibleSectionDescriptor.subtitle
     ) {
       if (!subtitleElement) {
@@ -314,8 +314,8 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  _updateSummaryText(collapsibleSectionDescriptor: Record<string, any>) {
-    const headerElement = this._headerElement;
+  #updateSummaryText(collapsibleSectionDescriptor: Record<string, any>) {
+    const headerElement = this.#headerElement;
     if (!headerElement) return;
     let summaryTextElement = headerElement.querySelector(
       '.inboxsdk__resultsSection_header_summaryText',
@@ -327,7 +327,7 @@ class GmailCollapsibleSectionView {
       }
     } else if (
       collapsibleSectionDescriptor.titleLinkText !==
-      this._collapsibleSectionDescriptor.titleLinkText
+      this.#collapsibleSectionDescriptor.titleLinkText
     ) {
       if (!summaryTextElement) {
         summaryTextElement = document.createElement('div');
@@ -346,10 +346,10 @@ class GmailCollapsibleSectionView {
           '</span>',
         ].join('');
 
-        this._eventStream.plug(
+        this.#eventStream.plug(
           Kefir.fromEvents(summaryTextElement, 'click').map(() => ({
             eventName: 'titleLinkClicked',
-            sectionDescriptor: this._collapsibleSectionDescriptor,
+            sectionDescriptor: this.#collapsibleSectionDescriptor,
           })),
         );
 
@@ -373,27 +373,27 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  _updateDropdown(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateDropdown(collapsibleSectionDescriptor: Record<string, any>) {
     if (
       !collapsibleSectionDescriptor.hasDropdown ||
       !collapsibleSectionDescriptor.onDropdownClick
     ) {
-      if (this._inboxDropdownButtonView)
-        this._inboxDropdownButtonView.destroy();
-      if (this._dropdownViewController) this._dropdownViewController.destroy();
+      if (this.#inboxDropdownButtonView)
+        this.#inboxDropdownButtonView.destroy();
+      if (this.#dropdownViewController) this.#dropdownViewController.destroy();
     } else if (
       collapsibleSectionDescriptor.hasDropdown &&
       collapsibleSectionDescriptor.onDropdownClick
     ) {
-      if (!this._inboxDropdownButtonView || !this._dropdownViewController) {
-        const inboxDropdownButtonView = (this._inboxDropdownButtonView =
+      if (!this.#inboxDropdownButtonView || !this.#dropdownViewController) {
+        const inboxDropdownButtonView = (this.#inboxDropdownButtonView =
           new InboxDropdownButtonView());
-        this._dropdownViewController = new DropdownButtonViewController({
+        this.#dropdownViewController = new DropdownButtonViewController({
           buttonView: inboxDropdownButtonView,
           dropdownViewDriverClass: GmailDropdownView,
           dropdownShowFunction: collapsibleSectionDescriptor.onDropdownClick,
         });
-        const headerElement = this._headerElement;
+        const headerElement = this.#headerElement;
 
         if (headerElement) {
           const childElement = headerElement.querySelector('.Cr');
@@ -402,18 +402,18 @@ class GmailCollapsibleSectionView {
         }
       } else if (
         collapsibleSectionDescriptor.onDropdownClick !==
-        this._collapsibleSectionDescriptor.onDropdownClick
+        this.#collapsibleSectionDescriptor.onDropdownClick
       ) {
-        if (this._dropdownViewController)
-          this._dropdownViewController.setDropdownShowFunction(
+        if (this.#dropdownViewController)
+          this.#dropdownViewController.setDropdownShowFunction(
             collapsibleSectionDescriptor.onDropdownClick,
           );
       }
     }
   }
 
-  _updateContentElement(collapsibleSectionDescriptor: Record<string, any>) {
-    const contentElement = this._contentElement;
+  #updateContentElement(collapsibleSectionDescriptor: Record<string, any>) {
+    const contentElement = this.#contentElement;
     if (!contentElement) return;
     contentElement.innerHTML = '';
 
@@ -425,9 +425,9 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  _updateTableRows(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateTableRows(collapsibleSectionDescriptor: Record<string, any>) {
     const { tableRows } = collapsibleSectionDescriptor;
-    const tableBodyElement = this._tableBodyElement;
+    const tableBodyElement = this.#tableBodyElement;
     if (!tableBodyElement) return;
     tableBodyElement.innerHTML = '';
 
@@ -436,18 +436,18 @@ class GmailCollapsibleSectionView {
     } else {
       tableBodyElement.style.display = '';
 
-      this._renderTable(tableRows);
+      this.#renderTable(tableRows);
     }
   }
 
-  _renderTable(tableRows: Array<Record<string, any>>) {
+  #renderTable(tableRows: Array<Record<string, any>>) {
     const tableElement = document.createElement('table');
     tableElement.setAttribute('class', 'F cf zt');
     tableElement.innerHTML = _getTableHTML();
-    if (this._tableBodyElement)
-      this._tableBodyElement.appendChild(tableElement);
+    if (this.#tableBodyElement)
+      this.#tableBodyElement.appendChild(tableElement);
     const tbody = tableElement.querySelector('tbody');
-    const eventStream = this._eventStream;
+    const eventStream = this.#eventStream;
     tableRows.forEach((result) => {
       const rowElement = document.createElement('tr');
       rowElement.setAttribute(
@@ -466,8 +466,8 @@ class GmailCollapsibleSectionView {
     });
   }
 
-  _updateMessageElement(collapsibleSectionDescriptor: Record<string, any>) {
-    const messageElement = this._messageElement;
+  #updateMessageElement(collapsibleSectionDescriptor: Record<string, any>) {
+    const messageElement = this.#messageElement;
 
     if (
       (collapsibleSectionDescriptor.tableRows &&
@@ -483,12 +483,12 @@ class GmailCollapsibleSectionView {
       collapsibleSectionDescriptor.tableRows.length === 0 &&
       !collapsibleSectionDescriptor.contentElement
     ) {
-      this._showEmptyMessage();
+      this.#showEmptyMessage();
     }
   }
 
-  _showLoadingMessage() {
-    const messageElement = this._messageElement;
+  #showLoadingMessage() {
+    const messageElement = this.#messageElement;
 
     if (messageElement) {
       messageElement.setAttribute(
@@ -501,8 +501,8 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  _showEmptyMessage() {
-    const messageElement = this._messageElement;
+  #showEmptyMessage() {
+    const messageElement = this.#messageElement;
 
     if (messageElement) {
       messageElement.setAttribute('class', 'TB TC');
@@ -512,8 +512,8 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  _updateFooter(collapsibleSectionDescriptor: Record<string, any>) {
-    const footerElement = this._footerElement;
+  #updateFooter(collapsibleSectionDescriptor: Record<string, any>) {
+    const footerElement = this.#footerElement;
     if (!footerElement) return;
     footerElement.innerHTML = '';
 
@@ -530,11 +530,11 @@ class GmailCollapsibleSectionView {
       footerLinkElement.textContent =
         collapsibleSectionDescriptor.footerLinkText;
 
-      this._eventStream.plug(
+      this.#eventStream.plug(
         Kefir.fromEvents(footerLinkElement, 'click').map(() => {
           return {
             eventName: 'footerClicked',
-            sectionDescriptor: this._collapsibleSectionDescriptor,
+            sectionDescriptor: this.#collapsibleSectionDescriptor,
           };
         }),
       );
@@ -544,16 +544,16 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  _toggleCollapseState() {
-    if (this._isCollapsed) {
-      this._expand();
+  #toggleCollapseState() {
+    if (this.#isCollapsed) {
+      this.#expand();
     } else {
-      this._collapse();
+      this.#collapse();
     }
   }
 
-  _collapse() {
-    const element = this._element;
+  #collapse() {
+    const element = this.#element;
 
     if (!element) {
       return;
@@ -561,14 +561,14 @@ class GmailCollapsibleSectionView {
 
     element.classList.add('inboxsdk__resultsSection_collapsed');
 
-    if (!this._isSearch) {
-      this._addToCollapsedContainer();
+    if (!this.#isSearch) {
+      this.#addToCollapsedContainer();
     }
 
     const selector = 'h3 > img.Wp';
 
-    if (this._titleElement) {
-      const arrowSpan = querySelector(this._titleElement, selector);
+    if (this.#titleElement) {
+      const arrowSpan = querySelector(this.#titleElement, selector);
 
       if (arrowSpan) {
         arrowSpan.classList.remove('Wq');
@@ -576,16 +576,16 @@ class GmailCollapsibleSectionView {
       }
     }
 
-    if (this._bodyElement) this._bodyElement.style.display = 'none';
-    this._isCollapsed = true;
+    if (this.#bodyElement) this.#bodyElement.style.display = 'none';
+    this.#isCollapsed = true;
 
-    this._eventStream.emit({
+    this.#eventStream.emit({
       eventName: 'collapsed',
     });
   }
 
-  _expand() {
-    const element = this._element;
+  #expand() {
+    const element = this.#element;
 
     if (!element) {
       return;
@@ -593,14 +593,14 @@ class GmailCollapsibleSectionView {
 
     element.classList.remove('inboxsdk__resultsSection_collapsed');
 
-    if (!this._isSearch) {
-      this._removeFromCollapsedContainer();
+    if (!this.#isSearch) {
+      this.#removeFromCollapsedContainer();
     }
 
     const selector = 'h3 > img.Wp';
 
-    if (this._titleElement) {
-      const arrowSpan = querySelector(this._titleElement, selector);
+    if (this.#titleElement) {
+      const arrowSpan = querySelector(this.#titleElement, selector);
 
       if (arrowSpan) {
         arrowSpan.classList.remove('Wo');
@@ -608,22 +608,22 @@ class GmailCollapsibleSectionView {
       }
     }
 
-    if (this._bodyElement) this._bodyElement.style.display = '';
-    this._isCollapsed = false;
+    if (this.#bodyElement) this.#bodyElement.style.display = '';
+    this.#isCollapsed = false;
 
-    this._eventStream.emit({
+    this.#eventStream.emit({
       eventName: 'expanded',
     });
   }
 
-  _addToCollapsedContainer() {
-    const element = this._element;
+  #addToCollapsedContainer() {
+    const element = this.#element;
     if (!element) return;
-    if (this._headerElement) this._headerElement.classList.remove('Wg');
+    if (this.#headerElement) this.#headerElement.classList.remove('Wg');
 
     if (
-      this._isCollapsedContainer(element.previousElementSibling) &&
-      this._isCollapsedContainer(element.nextElementSibling)
+      this.#isCollapsedContainer(element.previousElementSibling) &&
+      this.#isCollapsedContainer(element.nextElementSibling)
     ) {
       //we are surrounded by collapse containers, let's favor our previous sibling
       const otherCollapseContainer = element.nextElementSibling;
@@ -638,19 +638,19 @@ class GmailCollapsibleSectionView {
         otherCollapseContainer.children[0].children,
       ).concat(Array.from(otherCollapseContainer.children[1].children));
       if (otherCollapseContainer)
-        this._pulloutSectionsFromCollapsedContainer(
+        this.#pulloutSectionsFromCollapsedContainer(
           otherCollapseContainer as any,
         );
 
-      this._recollapse(elementsToRecollapse);
+      this.#recollapse(elementsToRecollapse);
     } else {
-      this._readdToCollapsedContainer();
+      this.#readdToCollapsedContainer();
     }
   }
 
-  _removeFromCollapsedContainer() {
-    if (this._headerElement) this._headerElement.classList.add('Wg');
-    const element = this._element;
+  #removeFromCollapsedContainer() {
+    if (this.#headerElement) this.#headerElement.classList.add('Wg');
+    const element = this.#element;
     if (!element) return;
     const parentElement = element.parentElement;
     if (!parentElement) return;
@@ -667,14 +667,14 @@ class GmailCollapsibleSectionView {
       container.children[0].children,
     ).concat(Array.from(container.children[1].children));
 
-    this._pulloutSectionsFromCollapsedContainer(container as any);
+    this.#pulloutSectionsFromCollapsedContainer(container as any);
 
-    this._destroyCollapsedContainer();
+    this.#destroyCollapsedContainer();
 
-    this._recollapse(elementsToRecollapse.filter((child) => child !== element));
+    this.#recollapse(elementsToRecollapse.filter((child) => child !== element));
   }
 
-  _pulloutSectionsFromCollapsedContainer(container: HTMLElement) {
+  #pulloutSectionsFromCollapsedContainer(container: HTMLElement) {
     const prependedChildren = Array.from(container.children[0].children);
     prependedChildren.forEach((child) =>
       (container as any).insertAdjacentElement('beforebegin', child),
@@ -687,14 +687,14 @@ class GmailCollapsibleSectionView {
     );
   }
 
-  _readdToCollapsedContainer() {
-    const element = this._element;
+  #readdToCollapsedContainer() {
+    const element = this.#element;
     if (!element) return;
 
-    if (this._collapsedContainer) {
-      this._collapsedContainer.children[0].insertBefore(
+    if (this.#collapsedContainer) {
+      this.#collapsedContainer.children[0].insertBefore(
         element,
-        this._collapsedContainer.children[1].firstElementChild,
+        this.#collapsedContainer.children[1].firstElementChild,
       );
 
       return;
@@ -703,18 +703,18 @@ class GmailCollapsibleSectionView {
     let collapsedContainer;
     let isPrepend;
 
-    if (this._isCollapsedContainer(element.previousElementSibling)) {
+    if (this.#isCollapsedContainer(element.previousElementSibling)) {
       isPrepend = false;
       collapsedContainer = element.previousElementSibling;
-    } else if (this._isCollapsedContainer(element.nextElementSibling)) {
+    } else if (this.#isCollapsedContainer(element.nextElementSibling)) {
       isPrepend = true;
       collapsedContainer = element.nextElementSibling;
     } else {
       isPrepend = true;
 
-      this._createCollapsedContainer();
+      this.#createCollapsedContainer();
 
-      collapsedContainer = this._collapsedContainer;
+      collapsedContainer = this.#collapsedContainer;
     }
 
     if (isPrepend && collapsedContainer) {
@@ -727,14 +727,14 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  _isCollapsedContainer(element: any) {
+  #isCollapsedContainer(element: any) {
     return (
       element &&
       element.classList.contains('inboxsdk__results_collapsedContainer')
     );
   }
 
-  _recollapse(children: Array<Record<string, any>>) {
+  #recollapse(children: Array<Record<string, any>>) {
     children.forEach((child) => {
       const removeEvent = document.createEvent('CustomEvent');
       (removeEvent as any).initCustomEvent(
@@ -755,8 +755,8 @@ class GmailCollapsibleSectionView {
     });
   }
 
-  _createCollapsedContainer() {
-    const collapsedContainer = (this._collapsedContainer =
+  #createCollapsedContainer() {
+    const collapsedContainer = (this.#collapsedContainer =
       document.createElement('div'));
     collapsedContainer.setAttribute(
       'class',
@@ -764,16 +764,16 @@ class GmailCollapsibleSectionView {
     );
     collapsedContainer.innerHTML =
       '<div class="inboxsdk__results_collapsedContainer_prepend"></div><div class="inboxsdk__results_collapsedContainer_append"></div>';
-    const element = this._element;
+    const element = this.#element;
     if (element)
       (element as any).insertAdjacentElement('afterend', collapsedContainer);
   }
 
-  _destroyCollapsedContainer() {
-    if (this._collapsedContainer) {
-      this._collapsedContainer.remove();
+  #destroyCollapsedContainer() {
+    if (this.#collapsedContainer) {
+      this.#collapsedContainer.remove();
 
-      this._collapsedContainer = null;
+      this.#collapsedContainer = null;
     }
   }
 }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
@@ -9,13 +9,14 @@ import InboxDropdownButtonView from '../widgets/buttons/inbox-dropdown-button-vi
 import GmailDropdownView from '../widgets/gmail-dropdown-view';
 import DropdownButtonViewController from '../../../widgets/buttons/dropdown-button-view-controller';
 import type GmailDriver from '../gmail-driver';
+import { type SectionDescriptor } from '../../../../inboxsdk';
 
 class GmailCollapsibleSectionView {
   #driver: GmailDriver;
   #groupOrderHint: number;
   #isReadyDeferred: Record<string, any>;
   #isCollapsible: boolean;
-  #collapsibleSectionDescriptor: Record<string, any> = {};
+  #collapsibleSectionDescriptor: SectionDescriptor = {} as SectionDescriptor;
   #isSearch: boolean;
   #element: HTMLElement | null | undefined = null;
   #headerElement: HTMLElement | null | undefined = null;
@@ -42,7 +43,7 @@ class GmailCollapsibleSectionView {
     this.#groupOrderHint = groupOrderHint;
     this.#isCollapsible = isCollapsible;
     this.#eventStream = kefirBus();
-    this.#isReadyDeferred = new (defer as any)();
+    this.#isReadyDeferred = defer();
   }
 
   destroy() {
@@ -72,7 +73,7 @@ class GmailCollapsibleSectionView {
 
   setCollapsibleSectionDescriptorProperty(
     collapsibleSectionDescriptorProperty: Kefir.Observable<
-      Record<string, any> | null | undefined,
+      SectionDescriptor | null | undefined,
       unknown
     >,
   ) {
@@ -95,7 +96,7 @@ class GmailCollapsibleSectionView {
   }
 
   #updateValues(
-    collapsibleSectionDescriptor: Record<string, any> | null | undefined,
+    collapsibleSectionDescriptor: SectionDescriptor | null | undefined,
   ) {
     const element = this.#element;
 
@@ -138,7 +139,7 @@ class GmailCollapsibleSectionView {
     this.#collapsibleSectionDescriptor = collapsibleSectionDescriptor;
   }
 
-  _setupElement(collapsibleSectionDescriptor: Record<string, any>) {
+  _setupElement(collapsibleSectionDescriptor: SectionDescriptor) {
     const element = (this.#element = document.createElement('div'));
     element.setAttribute('class', 'inboxsdk__resultsSection');
     element.setAttribute('data-group-order-hint', String(this.#groupOrderHint));
@@ -192,7 +193,7 @@ class GmailCollapsibleSectionView {
     });
   }
 
-  _setupHeader(collapsibleSectionDescriptor: Record<string, any>) {
+  _setupHeader(collapsibleSectionDescriptor: SectionDescriptor) {
     const headerElement = (this.#headerElement = document.createElement('div'));
     headerElement.classList.add('inboxsdk__resultsSection_header', 'Wg');
 
@@ -203,7 +204,7 @@ class GmailCollapsibleSectionView {
 
   _setupGmailv2Header(
     headerElement: HTMLElement,
-    collapsibleSectionDescriptor: Record<string, any>,
+    collapsibleSectionDescriptor: SectionDescriptor,
   ) {
     const titleElement = (this.#titleElement = document.createElement('div'));
     titleElement.setAttribute('class', 'inboxsdk__resultsSection_title');
@@ -228,7 +229,7 @@ class GmailCollapsibleSectionView {
     if (this.#bodyElement) this.#bodyElement.appendChild(footerElement);
   }
 
-  _updateElement(collapsibleSectionDescriptor: Record<string, any>) {
+  _updateElement(collapsibleSectionDescriptor: SectionDescriptor) {
     if (
       this.#collapsibleSectionDescriptor.orderHint !==
       collapsibleSectionDescriptor.orderHint
@@ -250,7 +251,7 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  #updateHeader(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateHeader(collapsibleSectionDescriptor: SectionDescriptor) {
     if (
       this.#isCollapsible ||
       collapsibleSectionDescriptor.title ||
@@ -264,7 +265,7 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  #updateTitle(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateTitle(collapsibleSectionDescriptor: SectionDescriptor) {
     if (
       this.#collapsibleSectionDescriptor.title !==
       collapsibleSectionDescriptor.title
@@ -278,7 +279,7 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  #updateSubtitle(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateSubtitle(collapsibleSectionDescriptor: SectionDescriptor) {
     const titleElement = this.#titleElement;
     if (!titleElement) return;
     let subtitleElement = titleElement.querySelector(
@@ -314,7 +315,7 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  #updateSummaryText(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateSummaryText(collapsibleSectionDescriptor: SectionDescriptor) {
     const headerElement = this.#headerElement;
     if (!headerElement) return;
     let summaryTextElement = headerElement.querySelector(
@@ -373,7 +374,7 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  #updateDropdown(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateDropdown(collapsibleSectionDescriptor: SectionDescriptor) {
     if (
       !collapsibleSectionDescriptor.hasDropdown ||
       !collapsibleSectionDescriptor.onDropdownClick
@@ -412,7 +413,7 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  #updateContentElement(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateContentElement(collapsibleSectionDescriptor: SectionDescriptor) {
     const contentElement = this.#contentElement;
     if (!contentElement) return;
     contentElement.innerHTML = '';
@@ -425,7 +426,7 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  #updateTableRows(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateTableRows(collapsibleSectionDescriptor: SectionDescriptor) {
     const { tableRows } = collapsibleSectionDescriptor;
     const tableBodyElement = this.#tableBodyElement;
     if (!tableBodyElement) return;
@@ -466,7 +467,7 @@ class GmailCollapsibleSectionView {
     });
   }
 
-  #updateMessageElement(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateMessageElement(collapsibleSectionDescriptor: SectionDescriptor) {
     const messageElement = this.#messageElement;
 
     if (
@@ -512,7 +513,7 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  #updateFooter(collapsibleSectionDescriptor: Record<string, any>) {
+  #updateFooter(collapsibleSectionDescriptor: SectionDescriptor) {
     const footerElement = this.#footerElement;
     if (!footerElement) return;
     footerElement.innerHTML = '';
@@ -528,7 +529,7 @@ class GmailCollapsibleSectionView {
       const footerLinkElement = document.createElement('span');
       footerLinkElement.setAttribute('class', 'e Wb');
       footerLinkElement.textContent =
-        collapsibleSectionDescriptor.footerLinkText;
+        collapsibleSectionDescriptor.footerLinkText!;
 
       this.#eventStream.plug(
         Kefir.fromEvents(footerLinkElement, 'click').map(() => {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
@@ -9,12 +9,16 @@ import InboxDropdownButtonView from '../widgets/buttons/inbox-dropdown-button-vi
 import GmailDropdownView from '../widgets/gmail-dropdown-view';
 import DropdownButtonViewController from '../../../widgets/buttons/dropdown-button-view-controller';
 import type GmailDriver from '../gmail-driver';
-import { type SectionDescriptor } from '../../../../inboxsdk';
+import type {
+  LabelDescriptor,
+  RowDescriptor,
+  SectionDescriptor,
+} from '../../../../inboxsdk';
 
 class GmailCollapsibleSectionView {
   #driver: GmailDriver;
   #groupOrderHint: number;
-  #isReadyDeferred: Record<string, any>;
+  #isReadyDeferred;
   #isCollapsible: boolean;
   #collapsibleSectionDescriptor: SectionDescriptor = {} as SectionDescriptor;
   #isSearch: boolean;
@@ -29,8 +33,9 @@ class GmailCollapsibleSectionView {
   #footerElement: HTMLElement | null | undefined = null;
   #eventStream: Bus<any, unknown>;
   #isCollapsed: boolean = false;
-  #inboxDropdownButtonView: Record<string, any> | null | undefined = null;
-  #dropdownViewController: Record<string, any> | null | undefined = null;
+  #inboxDropdownButtonView: InboxDropdownButtonView | null | undefined = null;
+  #dropdownViewController: DropdownButtonViewController | null | undefined =
+    null;
 
   constructor(
     driver: GmailDriver,
@@ -305,7 +310,7 @@ class GmailCollapsibleSectionView {
 
           if (insertionPoint) {
             subtitleElement.classList.add('aw5');
-            (insertionPoint as any).appendChild(subtitleElement);
+            insertionPoint.appendChild(subtitleElement);
           }
         }
       }
@@ -363,7 +368,7 @@ class GmailCollapsibleSectionView {
         });
         const insertionPoint = headerElement.querySelector('.Cr');
         if (insertionPoint)
-          (insertionPoint as any).insertAdjacentElement(
+          insertionPoint.insertAdjacentElement(
             'afterbegin',
             summaryTextElement,
           );
@@ -441,7 +446,7 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  #renderTable(tableRows: Array<Record<string, any>>) {
+  #renderTable(tableRows: RowDescriptor[]) {
     const tableElement = document.createElement('table');
     tableElement.setAttribute('class', 'F cf zt');
     tableElement.innerHTML = _getTableHTML();
@@ -639,9 +644,7 @@ class GmailCollapsibleSectionView {
         otherCollapseContainer.children[0].children,
       ).concat(Array.from(otherCollapseContainer.children[1].children));
       if (otherCollapseContainer)
-        this.#pulloutSectionsFromCollapsedContainer(
-          otherCollapseContainer as any,
-        );
+        this.#pulloutSectionsFromCollapsedContainer(otherCollapseContainer);
 
       this.#recollapse(elementsToRecollapse);
     } else {
@@ -668,23 +671,23 @@ class GmailCollapsibleSectionView {
       container.children[0].children,
     ).concat(Array.from(container.children[1].children));
 
-    this.#pulloutSectionsFromCollapsedContainer(container as any);
+    this.#pulloutSectionsFromCollapsedContainer(container);
 
     this.#destroyCollapsedContainer();
 
     this.#recollapse(elementsToRecollapse.filter((child) => child !== element));
   }
 
-  #pulloutSectionsFromCollapsedContainer(container: HTMLElement) {
+  #pulloutSectionsFromCollapsedContainer(container: Element) {
     const prependedChildren = Array.from(container.children[0].children);
     prependedChildren.forEach((child) =>
-      (container as any).insertAdjacentElement('beforebegin', child),
+      container.insertAdjacentElement('beforebegin', child),
     );
     const appendedChildren = Array.from(
       container.children[1].children,
     ).reverse();
     appendedChildren.forEach((child) =>
-      (container as any).insertAdjacentElement('afterend', child),
+      container.insertAdjacentElement('afterend', child),
     );
   }
 
@@ -728,17 +731,17 @@ class GmailCollapsibleSectionView {
     }
   }
 
-  #isCollapsedContainer(element: any) {
+  #isCollapsedContainer(element: Element | null) {
     return (
       element &&
       element.classList.contains('inboxsdk__results_collapsedContainer')
     );
   }
 
-  #recollapse(children: Array<Record<string, any>>) {
+  #recollapse(children: Element[]) {
     children.forEach((child) => {
       const removeEvent = document.createEvent('CustomEvent');
-      (removeEvent as any).initCustomEvent(
+      removeEvent.initCustomEvent(
         'removeCollapsedContainer',
         false,
         false,
@@ -746,7 +749,7 @@ class GmailCollapsibleSectionView {
       );
       child.dispatchEvent(removeEvent);
       const readdEvent = document.createEvent('CustomEvent');
-      (readdEvent as any).initCustomEvent(
+      readdEvent.initCustomEvent(
         'readdToCollapsedContainer',
         false,
         false,
@@ -766,8 +769,7 @@ class GmailCollapsibleSectionView {
     collapsedContainer.innerHTML =
       '<div class="inboxsdk__results_collapsedContainer_prepend"></div><div class="inboxsdk__results_collapsedContainer_append"></div>';
     const element = this.#element;
-    if (element)
-      (element as any).insertAdjacentElement('afterend', collapsedContainer);
+    if (element) element.insertAdjacentElement('afterend', collapsedContainer);
   }
 
   #destroyCollapsedContainer() {
@@ -795,7 +797,7 @@ function _getTableHTML() {
   ].join('');
 }
 
-function _getRowHTML(result: Record<string, any>) {
+function _getRowHTML(result: RowDescriptor) {
   let iconHtml = '';
 
   if (result.iconHtml != null) {
@@ -853,14 +855,14 @@ function _getRowHTML(result: Record<string, any>) {
   return rowArr.join('');
 }
 
-function _getLabelHTML(label: Record<string, any>) {
+function _getLabelHTML(label: LabelDescriptor) {
   const backgroundColor = label.backgroundColor || 'rgb(194, 194, 194)'; //grey
 
   const foregroundColor = label.foregroundColor || 'rgb(255, 255, 255)'; //white
 
   const maxWidth = label.maxWidth || '90px';
   const retArray = [
-    autoHtml`<div class="ar as" data-tooltip="${label.title}">
+    autoHtml`<div class="ar as" data-tooltip="${label.title!}">
       <div class="at" style="background-color: ${backgroundColor}; border-color: ${backgroundColor};">
         <div class="au" style="border-color: ${backgroundColor};">`,
   ];
@@ -897,7 +899,7 @@ function _getLabelHTML(label: Record<string, any>) {
 
   retArray.push(autoHtml`
           <div class="av" style="color: ${foregroundColor}; max-width: ${maxWidth}">
-            ${label.title}
+            ${label.title!}
           </div>
         </div>
       </div>

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
@@ -111,11 +111,11 @@ class GmailCollapsibleSectionView {
     }
 
     if (!element) {
-      this._setupElement(collapsibleSectionDescriptor);
+      this.#setupElement(collapsibleSectionDescriptor);
 
       this.#showLoadingMessage();
     } else {
-      this._updateElement(collapsibleSectionDescriptor);
+      this.#updateElement(collapsibleSectionDescriptor);
     }
 
     this.#updateHeader(collapsibleSectionDescriptor);
@@ -139,7 +139,7 @@ class GmailCollapsibleSectionView {
     this.#collapsibleSectionDescriptor = collapsibleSectionDescriptor;
   }
 
-  _setupElement(collapsibleSectionDescriptor: SectionDescriptor) {
+  #setupElement(collapsibleSectionDescriptor: SectionDescriptor) {
     const element = (this.#element = document.createElement('div'));
     element.setAttribute('class', 'inboxsdk__resultsSection');
     element.setAttribute('data-group-order-hint', String(this.#groupOrderHint));
@@ -154,7 +154,7 @@ class GmailCollapsibleSectionView {
     if (!this.#isCollapsible)
       element.classList.add('inboxsdk__resultsSection_nonCollapsible');
 
-    this._setupHeader(collapsibleSectionDescriptor);
+    this.#setupHeader(collapsibleSectionDescriptor);
 
     const bodyElement = (this.#bodyElement = document.createElement('div'));
     const bodyContentsElement = document.createElement('div');
@@ -171,7 +171,7 @@ class GmailCollapsibleSectionView {
       document.createElement('div'));
     bodyContentsElement.appendChild(tableBodyElement);
 
-    this._setupFooter();
+    this.#setupFooter();
 
     if (this.#isCollapsible && this.#titleElement) {
       Kefir.fromEvents(this.#titleElement, 'click').onValue(() =>
@@ -193,16 +193,16 @@ class GmailCollapsibleSectionView {
     });
   }
 
-  _setupHeader(collapsibleSectionDescriptor: SectionDescriptor) {
+  #setupHeader(collapsibleSectionDescriptor: SectionDescriptor) {
     const headerElement = (this.#headerElement = document.createElement('div'));
     headerElement.classList.add('inboxsdk__resultsSection_header', 'Wg');
 
-    this._setupGmailv2Header(headerElement, collapsibleSectionDescriptor);
+    this.#setupGmailv2Header(headerElement, collapsibleSectionDescriptor);
 
     if (this.#element) this.#element.appendChild(headerElement);
   }
 
-  _setupGmailv2Header(
+  #setupGmailv2Header(
     headerElement: HTMLElement,
     collapsibleSectionDescriptor: SectionDescriptor,
   ) {
@@ -223,13 +223,13 @@ class GmailCollapsibleSectionView {
     headerElement.appendChild(floatRightElement);
   }
 
-  _setupFooter() {
+  #setupFooter() {
     const footerElement = (this.#footerElement = document.createElement('div'));
     footerElement.classList.add('inboxsdk__resultsSection_footer');
     if (this.#bodyElement) this.#bodyElement.appendChild(footerElement);
   }
 
-  _updateElement(collapsibleSectionDescriptor: SectionDescriptor) {
+  #updateElement(collapsibleSectionDescriptor: SectionDescriptor) {
     if (
       this.#collapsibleSectionDescriptor.orderHint !==
       collapsibleSectionDescriptor.orderHint

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -25,6 +25,7 @@ import waitFor from '../../../../lib/wait-for';
 import { SelectorError } from '../../../../lib/dom/querySelectorOrFail';
 import isStreakAppId from '../../../../lib/isStreakAppId';
 import { extractDocumentHtmlAndCss } from '../../../../../common/extractDocumentHtmlAndCss';
+import { type SectionDescriptor } from '../../../../../inboxsdk';
 
 class GmailRouteView {
   _type: string;
@@ -191,10 +192,10 @@ class GmailRouteView {
 
   addCollapsibleSection(
     sectionDescriptorProperty: Kefir.Observable<
-      Record<string, any> | null | undefined,
+      SectionDescriptor | null | undefined,
       unknown
     >,
-    groupOrderHint: any,
+    groupOrderHint: number,
   ): GmailCollapsibleSectionView {
     return this.#addCollapsibleSection(
       sectionDescriptorProperty,
@@ -205,10 +206,10 @@ class GmailRouteView {
 
   addSection(
     sectionDescriptorProperty: Kefir.Observable<
-      Record<string, any> | null | undefined,
+      SectionDescriptor | null | undefined,
       unknown
     >,
-    groupOrderHint: any,
+    groupOrderHint: number,
   ): GmailCollapsibleSectionView {
     return this.#addCollapsibleSection(
       sectionDescriptorProperty,
@@ -218,8 +219,11 @@ class GmailRouteView {
   }
 
   #addCollapsibleSection(
-    collapsibleSectionDescriptorProperty: any,
-    groupOrderHint: any,
+    collapsibleSectionDescriptorProperty: Kefir.Observable<
+      SectionDescriptor | null | undefined,
+      unknown
+    >,
+    groupOrderHint: number,
     isCollapsible: boolean,
   ): GmailCollapsibleSectionView {
     this._hasAddedCollapsibleSection = true;

--- a/src/platform-implementation-js/driver-interfaces/route-view-driver.ts
+++ b/src/platform-implementation-js/driver-interfaces/route-view-driver.ts
@@ -1,5 +1,6 @@
 import type * as Kefir from 'kefir';
 import type GmailCollapsibleSectionView from '../dom-driver/gmail/views/gmail-collapsible-section-view';
+import { SectionDescriptor } from '../../inboxsdk';
 // The necessary interface that Router and RouteView expect.
 export type MinRouteViewDriver = {
   getRouteType(): string;
@@ -22,7 +23,7 @@ export type RouteViewDriver = MinRouteViewDriver & {
   ): GmailCollapsibleSectionView;
   addCollapsibleSection(
     sectionDescriptorProperty: Kefir.Observable<
-      Record<string, any> | null | undefined,
+      SectionDescriptor | null | undefined,
       unknown
     >,
     groupOrderHint: any,

--- a/src/platform-implementation-js/views/collapsible-section-view.ts
+++ b/src/platform-implementation-js/views/collapsible-section-view.ts
@@ -2,7 +2,16 @@ import EventEmitter from '../lib/safe-event-emitter';
 import type { Driver } from '../driver-interfaces/driver';
 import type GmailCollapsibleSectionView from '../dom-driver/gmail/views/gmail-collapsible-section-view';
 
+/**
+* {@link CollapsibleSectionView}s allow you to display additional content on ListRouteViews. They are typically rendered as additional content above the list of threads below. The visual style is similar to that of multiple inbox sections used in native Gmail. Note that the rendering may vary slightly depending on the actual ListRouteView that the {@link CollapsibleSectionView} is rendered in. For example, {@link CollapsibleSectionViews} rendered on search results pages use different header styles to match Gmail's style more accurately.
+
+ * You can either render rows (that are visually similar to Gmail rows) or custom content in your {@link CollapsibleSectionView}. Until content is provided, the SectionView will simply display a "Loading..." indicator.
+ *
+ * @see ListRouteView.addCollapsibleSection for more information.
+ * @todo the docs mention this class extending SectionView. That doesn't seem to be the case.
+*/
 class CollapsibleSectionView extends EventEmitter {
+  /** This property is set to true once the view is destroyed. */
   destroyed: boolean;
   #collapsibleSectionViewDriver: GmailCollapsibleSectionView;
 
@@ -21,6 +30,7 @@ class CollapsibleSectionView extends EventEmitter {
     this.#collapsibleSectionViewDriver.setCollapsed(value);
   }
 
+  /** Removes this section from the current Route */
   remove() {
     this.destroy();
   }

--- a/src/platform-implementation-js/views/collapsible-section-view.ts
+++ b/src/platform-implementation-js/views/collapsible-section-view.ts
@@ -1,28 +1,24 @@
 import EventEmitter from '../lib/safe-event-emitter';
-import get from '../../common/get-or-fail';
 import type { Driver } from '../driver-interfaces/driver';
 import type GmailCollapsibleSectionView from '../dom-driver/gmail/views/gmail-collapsible-section-view';
-const membersMap = new WeakMap();
 
 class CollapsibleSectionView extends EventEmitter {
   destroyed: boolean;
+  #collapsibleSectionViewDriver: GmailCollapsibleSectionView;
 
   constructor(
     collapsibleSectionViewDriver: GmailCollapsibleSectionView,
     driver: Driver,
   ) {
     super();
-    const members = {
-      collapsibleSectionViewDriver,
-    };
-    membersMap.set(this, members);
+    this.#collapsibleSectionViewDriver = collapsibleSectionViewDriver;
     this.destroyed = false;
 
     _bindToEventStream(this, collapsibleSectionViewDriver, driver);
   }
 
   setCollapsed(value: boolean) {
-    get(membersMap, this).collapsibleSectionViewDriver.setCollapsed(value);
+    this.#collapsibleSectionViewDriver.setCollapsed(value);
   }
 
   remove() {
@@ -30,8 +26,7 @@ class CollapsibleSectionView extends EventEmitter {
   }
 
   destroy() {
-    const members = get(membersMap, this);
-    members.collapsibleSectionViewDriver.destroy();
+    this.#collapsibleSectionViewDriver.destroy();
     this.removeAllListeners();
   }
 }

--- a/src/platform-implementation-js/views/route-view/list-route-view.ts
+++ b/src/platform-implementation-js/views/route-view/list-route-view.ts
@@ -7,6 +7,9 @@ import type { RouteViewDriver } from '../../driver-interfaces/route-view-driver'
 import type { Driver } from '../../driver-interfaces/driver';
 import type { SectionDescriptor } from '../../../inboxsdk';
 
+/**
+ * Extends {@link RouteView}. {@link ListRouteView}s represent pages within Gmail that show a list of emails. Typical examples are the Inbox, Sent Mail, Drafts, etc. However, views like the Conversation view or Settings would not be a ListRouteView.
+ */
 class ListRouteView extends RouteView {
   #routeViewDriver;
   #driver;
@@ -22,6 +25,9 @@ class ListRouteView extends RouteView {
     this.#bindToEventStream();
   }
 
+  /**
+   * Adds a collapsible section to the top of the page.
+   */
   addCollapsibleSection(
     collapsibleSectionDescriptor:
       | SectionDescriptor
@@ -48,6 +54,7 @@ class ListRouteView extends RouteView {
     return collapsibleSectionView;
   }
 
+  /** Adds a non-collapsible section to the top of the page. */
   addSection(
     sectionDescriptor: Record<string, any> | null | undefined,
   ): SectionView {
@@ -60,6 +67,7 @@ class ListRouteView extends RouteView {
     return sectionView;
   }
 
+  /** Simulates a click on the Gmail thread list refresh button. */
   refresh() {
     this.#routeViewDriver.refresh();
   }

--- a/src/platform-implementation-js/views/route-view/list-route-view.ts
+++ b/src/platform-implementation-js/views/route-view/list-route-view.ts
@@ -3,71 +3,63 @@ import Kefir from 'kefir';
 import kefirCast from 'kefir-cast';
 import CollapsibleSectionView from '../collapsible-section-view';
 import SectionView from '../section-view';
-import get from '../../../common/get-or-fail';
 import type { RouteViewDriver } from '../../driver-interfaces/route-view-driver';
 import type { Driver } from '../../driver-interfaces/driver';
 
 class ListRouteView extends RouteView {
+  #routeViewDriver;
+  #driver;
+  #appId;
+  #sectionViews: { destroy(): void }[] = [];
+
   constructor(routeViewDriver: RouteViewDriver, driver: Driver, appId: string) {
     super(routeViewDriver);
-    const members = {
-      routeViewDriver,
-      driver,
-      appId,
-      sectionViews: [],
-    };
-    membersMap.set(this, members);
+    this.#routeViewDriver = routeViewDriver;
+    this.#driver = driver;
+    this.#appId = appId;
 
-    _bindToEventStream(routeViewDriver, this);
+    this.#bindToEventStream();
   }
 
   addCollapsibleSection(
     collapsibleSectionDescriptor: Record<string, any> | null | undefined,
   ): CollapsibleSectionView {
-    const members = get(membersMap, this);
     const collapsibleSectionViewDriver =
-      members.routeViewDriver.addCollapsibleSection(
-        kefirCast(Kefir as any, collapsibleSectionDescriptor).toProperty(),
-        members.appId,
+      this.#routeViewDriver.addCollapsibleSection(
+        kefirCast(Kefir, collapsibleSectionDescriptor).toProperty(),
+        this.#appId,
       );
     const collapsibleSectionView = new CollapsibleSectionView(
       collapsibleSectionViewDriver,
-      members.driver,
+      this.#driver,
     );
-    members.sectionViews.push(collapsibleSectionView);
+    this.#sectionViews.push(collapsibleSectionView);
     return collapsibleSectionView;
   }
 
   addSection(
     sectionDescriptor: Record<string, any> | null | undefined,
   ): SectionView {
-    const members = get(membersMap, this);
-    const sectionViewDriver = members.routeViewDriver.addSection(
-      kefirCast(Kefir as any, sectionDescriptor).toProperty(),
-      members.appId,
+    const sectionViewDriver = this.#routeViewDriver.addSection(
+      kefirCast(Kefir, sectionDescriptor).toProperty(),
+      this.#appId,
     );
-    const sectionView = new SectionView(sectionViewDriver, members.driver);
-    members.sectionViews.push(sectionView);
+    const sectionView = new SectionView(sectionViewDriver, this.#driver);
+    this.#sectionViews.push(sectionView);
     return sectionView;
   }
 
   refresh() {
-    get(membersMap, this).routeViewDriver.refresh();
+    this.#routeViewDriver.refresh();
   }
-}
 
-const membersMap = new WeakMap();
-
-function _bindToEventStream(
-  routeViewDriver: RouteViewDriver,
-  routeView: ListRouteView,
-) {
-  routeViewDriver.getEventStream().onEnd(() => {
-    const members = get(membersMap, routeView);
-    members.sectionViews.forEach((sectionView: { destroy(): void }) => {
-      sectionView.destroy();
+  #bindToEventStream() {
+    this.#routeViewDriver.getEventStream().onEnd(() => {
+      this.#sectionViews.forEach((sectionView) => {
+        sectionView.destroy();
+      });
     });
-  });
+  }
 }
 
 export default ListRouteView;

--- a/src/platform-implementation-js/views/route-view/list-route-view.ts
+++ b/src/platform-implementation-js/views/route-view/list-route-view.ts
@@ -1,10 +1,11 @@
 import RouteView from './route-view';
-import Kefir from 'kefir';
+import Kefir, { Observable } from 'kefir';
 import kefirCast from 'kefir-cast';
 import CollapsibleSectionView from '../collapsible-section-view';
 import SectionView from '../section-view';
 import type { RouteViewDriver } from '../../driver-interfaces/route-view-driver';
 import type { Driver } from '../../driver-interfaces/driver';
+import type { SectionDescriptor } from '../../../inboxsdk';
 
 class ListRouteView extends RouteView {
   #routeViewDriver;
@@ -22,11 +23,21 @@ class ListRouteView extends RouteView {
   }
 
   addCollapsibleSection(
-    collapsibleSectionDescriptor: Record<string, any> | null | undefined,
+    collapsibleSectionDescriptor:
+      | SectionDescriptor
+      | Observable<SectionDescriptor | null | undefined, unknown>
+      | null
+      | undefined,
   ): CollapsibleSectionView {
     const collapsibleSectionViewDriver =
       this.#routeViewDriver.addCollapsibleSection(
-        kefirCast(Kefir, collapsibleSectionDescriptor).toProperty(),
+        kefirCast(
+          Kefir,
+          collapsibleSectionDescriptor,
+        ).toProperty() as Observable<
+          SectionDescriptor | null | undefined,
+          unknown
+        >,
         this.#appId,
       );
     const collapsibleSectionView = new CollapsibleSectionView(

--- a/src/platform-implementation-js/views/section-view.ts
+++ b/src/platform-implementation-js/views/section-view.ts
@@ -1,18 +1,14 @@
 import EventEmitter from '../lib/safe-event-emitter';
-import get from '../../common/get-or-fail';
 import type { Driver } from '../driver-interfaces/driver';
 import type GmailCollapsibleSectionView from '../dom-driver/gmail/views/gmail-collapsible-section-view';
-const membersMap = new WeakMap();
 
 class SectionView extends EventEmitter {
   destroyed: boolean;
+  #sectionViewDriver;
 
   constructor(sectionViewDriver: GmailCollapsibleSectionView, driver: Driver) {
     super();
-    const members = {
-      sectionViewDriver,
-    };
-    membersMap.set(this, members);
+    this.#sectionViewDriver = sectionViewDriver;
     this.destroyed = false;
 
     _bindToEventStream(this, sectionViewDriver, driver);
@@ -23,8 +19,7 @@ class SectionView extends EventEmitter {
   }
 
   destroy() {
-    const members = get(membersMap, this);
-    members.sectionViewDriver.destroy();
+    this.#sectionViewDriver.destroy();
     this.removeAllListeners();
   }
 }


### PR DESCRIPTION
The public interface in this PR should be unchanged.

# In brief

- Add doc strings to:
  - `CollapsibleSectionView`
  - `ListRouteView`

- remove a number of `any`s in `GmailCollapsibleSectionView`
- true private in 
  - `CollapsibleSectionView`
  - `GmailCollapsibleSectionView`
  - `ListRouteView`
  - `SectionView`
- instead of impressionistic type from `src/inboxsdk.d.ts`, export source
  - `SectionView`
  - `CollapsibleSectionView`
  - `ListRouteView`

# Runtime changes

Move from untyped `WeakMap` membersMap in to modern private syntax:

- src/platform-implementation-js/views/collapsible-section-view.ts 
- src/platform-implementation-js/views/route-view/list-route-view.ts
- src/platform-implementation-js/views/section-view.ts 