### PR TITLE
types: add SectionDescriptor to SectionView usages

### DIFF
--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -351,8 +351,11 @@ export interface RowDescriptor {
  * The properties required to create a {@link SectionView} or {@link CollapsibleSectionView}.
  */
 export interface SectionDescriptor {
-  /** Main title */
-  title: string;
+  /** Main title.
+   *
+   * @note required in docs, but in {@link SectionView} we have spots not passing it.
+   */
+  title?: string;
   /** Subtitle */
   subtitle?: string | null;
   /** Link to display in the summary area of the {@link SectionView}. Typically page counts are displayed here.	*/

--- a/src/platform-implementation-js/constants/router.ts
+++ b/src/platform-implementation-js/constants/router.ts
@@ -31,8 +31,8 @@ export const NATIVE_ROUTE_IDS = Object.freeze({
   /** FEB 2023 */
   MEET: 'calls',
   ANY_LIST: '*',
-} as const);
-export const NATIVE_LIST_ROUTE_IDS: Record<string, string> = Object.freeze({
+});
+export const NATIVE_LIST_ROUTE_IDS = Object.freeze({
   INBOX: NATIVE_ROUTE_IDS.INBOX,
   ALL_MAIL: NATIVE_ROUTE_IDS.ALL_MAIL,
   SENT: NATIVE_ROUTE_IDS.SENT,
@@ -48,7 +48,7 @@ export const NATIVE_LIST_ROUTE_IDS: Record<string, string> = Object.freeze({
   SEARCH: NATIVE_ROUTE_IDS.SEARCH,
   ANY_LIST: NATIVE_ROUTE_IDS.ANY_LIST,
 });
-export const ROUTE_TYPES: Record<string, string> = Object.freeze({
+export const ROUTE_TYPES = Object.freeze({
   LIST: 'LIST',
   THREAD: 'THREAD',
   SETTINGS: 'SETTINGS',

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
@@ -288,7 +288,7 @@ class GmailCollapsibleSectionView {
 
       if (this.#titleElement) {
         querySelector(this.#titleElement, selector).textContent =
-          collapsibleSectionDescriptor.title;
+          collapsibleSectionDescriptor.title!;
       }
     }
   }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -26,8 +26,9 @@ import { SelectorError } from '../../../../lib/dom/querySelectorOrFail';
 import isStreakAppId from '../../../../lib/isStreakAppId';
 import { extractDocumentHtmlAndCss } from '../../../../../common/extractDocumentHtmlAndCss';
 import { type SectionDescriptor } from '../../../../../inboxsdk';
+import type { RouteViewDriver } from '../../../../driver-interfaces/route-view-driver';
 
-class GmailRouteView {
+class GmailRouteView implements RouteViewDriver {
   _type: string;
   _hash: string;
   _name: string;

--- a/src/platform-implementation-js/driver-interfaces/route-view-driver.ts
+++ b/src/platform-implementation-js/driver-interfaces/route-view-driver.ts
@@ -1,7 +1,8 @@
 import type * as Kefir from 'kefir';
 import type GmailCollapsibleSectionView from '../dom-driver/gmail/views/gmail-collapsible-section-view';
 import { SectionDescriptor } from '../../inboxsdk';
-// The necessary interface that Router and RouteView expect.
+
+/** The necessary interface that Router and RouteView expect. */
 export type MinRouteViewDriver = {
   getRouteType(): string;
   getRouteID(): string;
@@ -9,14 +10,15 @@ export type MinRouteViewDriver = {
   getEventStream(): Kefir.Observable<Record<string, any>, unknown>;
   getStopper(): Kefir.Observable<any, unknown>;
 };
-// The necessary interface that ListRouteView and CustomRouteView expect.
+
+/** The necessary interface that ListRouteView and CustomRouteView expect. */
 export type RouteViewDriver = MinRouteViewDriver & {
   refresh(): void;
   getType(): string;
   getHash(): string;
   addSection(
     sectionDescriptorProperty: Kefir.Observable<
-      Record<string, any> | null | undefined,
+      SectionDescriptor | null | undefined,
       unknown
     >,
     groupOrderHint: any,

--- a/src/platform-implementation-js/views/route-view/dummy-route-view-driver.ts
+++ b/src/platform-implementation-js/views/route-view/dummy-route-view-driver.ts
@@ -3,13 +3,9 @@ import kefirBus from 'kefir-bus';
 import kefirStopper from 'kefir-stopper';
 import type { MinRouteViewDriver } from '../../driver-interfaces/route-view-driver';
 
-class DummyRouteViewDriver {
+class DummyRouteViewDriver implements MinRouteViewDriver {
   _eventStream = kefirBus<Record<string, any>, unknown>();
   _stopper = kefirStopper();
-
-  constructor() {
-    this as MinRouteViewDriver;
-  }
 
   getRouteType() {
     return 'UNKNOWN';

--- a/src/platform-implementation-js/views/route-view/list-route-view.ts
+++ b/src/platform-implementation-js/views/route-view/list-route-view.ts
@@ -6,6 +6,7 @@ import SectionView from '../section-view';
 import type { RouteViewDriver } from '../../driver-interfaces/route-view-driver';
 import type { Driver } from '../../driver-interfaces/driver';
 import type { SectionDescriptor } from '../../../inboxsdk';
+import type { Descriptor } from '../../../types/descriptor';
 
 /**
  * Extends {@link RouteView}. {@link ListRouteView}s represent pages within Gmail that show a list of emails. Typical examples are the Inbox, Sent Mail, Drafts, etc. However, views like the Conversation view or Settings would not be a ListRouteView.
@@ -29,11 +30,9 @@ class ListRouteView extends RouteView {
    * Adds a collapsible section to the top of the page.
    */
   addCollapsibleSection(
-    collapsibleSectionDescriptor:
-      | SectionDescriptor
-      | Observable<SectionDescriptor | null | undefined, unknown>
-      | null
-      | undefined,
+    collapsibleSectionDescriptor: Descriptor<
+      SectionDescriptor | null | undefined
+    >,
   ): CollapsibleSectionView {
     const collapsibleSectionViewDriver =
       this.#routeViewDriver.addCollapsibleSection(
@@ -56,10 +55,13 @@ class ListRouteView extends RouteView {
 
   /** Adds a non-collapsible section to the top of the page. */
   addSection(
-    sectionDescriptor: Record<string, any> | null | undefined,
+    sectionDescriptor: Descriptor<SectionDescriptor | null | undefined>,
   ): SectionView {
     const sectionViewDriver = this.#routeViewDriver.addSection(
-      kefirCast(Kefir, sectionDescriptor).toProperty(),
+      kefirCast(Kefir, sectionDescriptor).toProperty() as Observable<
+        SectionDescriptor | null | undefined,
+        unknown
+      >,
       this.#appId,
     );
     const sectionView = new SectionView(sectionViewDriver, this.#driver);

--- a/src/platform-implementation-js/views/route-view/route-view.ts
+++ b/src/platform-implementation-js/views/route-view/route-view.ts
@@ -1,53 +1,51 @@
 import EventEmitter from '../../lib/safe-event-emitter';
-import get from '../../../common/get-or-fail';
 import type { MinRouteViewDriver } from '../../driver-interfaces/route-view-driver';
-const membersMap = new WeakMap();
 
+/**
+ * {@link RouteView}s represent pages within Gmail that a user can navigate to. RouteViews can be "custom", those that the application developer registers, or they can be "builtin" which are those that the email client natively supports like "Sent", "Drafts", or "Inbox"
+
+ * This class mostly just gives you metadata about the route, most of the functionality to modify the route are defined in subclasses like ListRouteView and CustomRouteView, which you get by handling those types specifically in the Router.
+ */
 class RouteView extends EventEmitter {
   destroyed: boolean;
+  #routeID: string | null = null;
+  #routeType: string | null = null;
+  #params: Record<string, string> | null = null;
+  #routeViewDriver;
 
   constructor(routeViewDriver: MinRouteViewDriver) {
     super();
-    const members = {
-      routeID: null as string | null | undefined,
-      routeType: null as string | null | undefined,
-      params: null as Record<string, string> | null | undefined,
-      routeViewDriver,
-    };
-    membersMap.set(this, members);
     this.destroyed = false;
+    this.#routeViewDriver = routeViewDriver;
 
     _bindToEventStream(routeViewDriver, this);
   }
 
+  /**
+   * @returns a string of the ID of the RouteView. This is the same routeID that you give Router.goto() or Router.createLink(). This will be a value from NativeRouteIDs.
+   */
   getRouteID(): string {
-    const members = get(membersMap, this);
-
-    if (!members.routeID) {
-      members.routeID = members.routeViewDriver.getRouteID();
+    if (!this.#routeID) {
+      this.#routeID = this.#routeViewDriver.getRouteID();
     }
 
-    return members.routeID;
+    return this.#routeID;
   }
 
   getRouteType(): string {
-    const members = get(membersMap, this);
-
-    if (!members.routeType) {
-      members.routeType = members.routeViewDriver.getRouteType();
+    if (!this.#routeType) {
+      this.#routeType = this.#routeViewDriver.getRouteType();
     }
 
-    return members.routeType;
+    return this.#routeType;
   }
 
   getParams(): Record<string, string> {
-    const members = get(membersMap, this);
-
-    if (!members.params) {
-      members.params = members.routeViewDriver.getParams();
+    if (!this.#params) {
+      this.#params = this.#routeViewDriver.getParams();
     }
 
-    return members.params;
+    return this.#params;
   }
 }
 

--- a/src/platform-implementation-js/views/section-view.ts
+++ b/src/platform-implementation-js/views/section-view.ts
@@ -2,6 +2,11 @@ import EventEmitter from '../lib/safe-event-emitter';
 import type { Driver } from '../driver-interfaces/driver';
 import type GmailCollapsibleSectionView from '../dom-driver/gmail/views/gmail-collapsible-section-view';
 
+/**
+ * {@link SectionView}s allow you to display additional content on ListRouteViews. They are typically rendered as additional content above the list of threads below. The visual style is similar to that of multiple inbox sections used in native Gmail. Note that the rendering may vary slightly depending on the actual ListRouteView that the SectionView is rendered in. For example, SectionViews rendered on search results pages use different header styles to match Gmail's style more accurately.
+
+ * You can either render rows (that are visually similar to Gmail rows) or custom content in your SectionView. Until content is provided, the SectionView will simply display a "Loading..." indicator. See ListRouteView.addSection for more information.
+ */
 class SectionView extends EventEmitter {
   destroyed: boolean;
   #sectionViewDriver;
@@ -14,6 +19,9 @@ class SectionView extends EventEmitter {
     _bindToEventStream(this, sectionViewDriver, driver);
   }
 
+  /**
+   * Removes this section from the current Route.
+   */
   remove() {
     this.destroy();
   }

--- a/src/types/descriptor.d.ts
+++ b/src/types/descriptor.d.ts
@@ -1,0 +1,10 @@
+import { Observable } from 'kefir';
+
+/**
+ * @type {T} The descriptor as either an object or Observable<object>.
+ * @typedef {U} @optional The type of errors emitted. We use either `unknown` or `any` in most cases.
+ *
+ * We generally run passed descriptors through `kefir-cast` and flatten them
+ * to Observable<T, U>.
+ */
+export type Descriptor<T, U = unknown> = T | Observable<T, U>;


### PR DESCRIPTION
Plumb through types around `addSectionView` in `list-route-view`. `title` usage appears to be effectively optional based on our usage at Streak.