### PR TITLE
feat(SectionView): update title and subtitle support

### DIFF
--- a/examples/search-results/content.js
+++ b/examples/search-results/content.js
@@ -1,11 +1,22 @@
 /// <reference path="../types.d.ts" />
 
 InboxSDK.load(1.0, 'search-example').then(function (inboxSDK) {
+  const sheet = new CSSStyleSheet();
+  sheet.insertRule(`.titleTest {
+    color: hotpink !important;
+  }`);
+  sheet.insertRule('.subtitleTest { margin: 0;  } ');
+  document.adoptedStyleSheets.push(sheet);
+
   inboxSDK.Router.handleListRoute(
     inboxSDK.Router.NativeRouteIDs.INBOX,
     (listRouteView) => {
       listRouteView.addCollapsibleSection({
         title: 'Inbox Monkeys',
+        titleClass: 'titleTest',
+        subtitle: 'Subtitle',
+        subtitleClass: 'subtitleTest',
+        subtitleTextTransform: (s) => s,
         titleLinkText: 'View All',
         hasDropdown: true,
         /** A dropdown would go here, but isn't hooked up in this example. */

--- a/examples/search-results/content.js
+++ b/examples/search-results/content.js
@@ -3,16 +3,19 @@
 InboxSDK.load(1.0, 'search-example').then(function (inboxSDK) {
   const sheet = new CSSStyleSheet();
   sheet.insertRule(`.titleTest {
-    color: hotpink !important;
+    color: hsla(0, 0%, 0%, 0.54) !important;
   }`);
-  sheet.insertRule('.subtitleTest { margin: 0;  } ');
+  sheet.insertRule(`.subtitleTest {
+    margin: 0;
+    color: hsla(0, 0%, 0%, 87%) !important;
+  }`);
   document.adoptedStyleSheets.push(sheet);
 
   inboxSDK.Router.handleListRoute(
     inboxSDK.Router.NativeRouteIDs.INBOX,
     (listRouteView) => {
       listRouteView.addCollapsibleSection({
-        title: 'Inbox Monkeys',
+        title: 'Inbox Monkeys / ',
         titleClass: 'titleTest',
         subtitle: 'Subtitle',
         subtitleClass: 'subtitleTest',

--- a/examples/search-results/content.js
+++ b/examples/search-results/content.js
@@ -1,25 +1,12 @@
 /// <reference path="../types.d.ts" />
 
 InboxSDK.load(1.0, 'search-example').then(function (inboxSDK) {
-  const sheet = new CSSStyleSheet();
-  sheet.insertRule(`.titleTest {
-    color: hsla(0, 0%, 0%, 0.54) !important;
-  }`);
-  sheet.insertRule(`.subtitleTest {
-    margin: 0;
-    color: hsla(0, 0%, 0%, 87%) !important;
-  }`);
-  document.adoptedStyleSheets.push(sheet);
-
   inboxSDK.Router.handleListRoute(
     inboxSDK.Router.NativeRouteIDs.INBOX,
     (listRouteView) => {
       listRouteView.addCollapsibleSection({
         title: 'Inbox Monkeys / ',
-        titleClass: 'titleTest',
         subtitle: 'Subtitle',
-        subtitleClass: 'subtitleTest',
-        subtitleTextTransform: (s) => s,
         titleLinkText: 'View All',
         hasDropdown: true,
         /** A dropdown would go here, but isn't hooked up in this example. */

--- a/examples/search-results/content.js
+++ b/examples/search-results/content.js
@@ -5,8 +5,8 @@ InboxSDK.load(1.0, 'search-example').then(function (inboxSDK) {
     inboxSDK.Router.NativeRouteIDs.INBOX,
     (listRouteView) => {
       listRouteView.addCollapsibleSection({
-        title: 'Inbox Monkeys / ',
-        subtitle: 'Subtitle',
+        title: ' Inbox Monkeys',
+        subtitle: 'Subtitle /',
         titleLinkText: 'View All',
         hasDropdown: true,
         /** A dropdown would go here, but isn't hooked up in this example. */

--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -356,8 +356,14 @@ export interface SectionDescriptor {
    * @note required in docs, but in {@link SectionView} we have spots not passing it.
    */
   title?: string;
+  /** @internal CSS class applied to {@link SectionDescriptor#title} parent. */
+  titleClass?: string;
   /** Subtitle */
   subtitle?: string | null;
+  /** @internal CSS class applied to {@link SectionDescriptor#subtitle} parent. */
+  subtitleClass?: string;
+  /** @internal Defaults to wrapping the {@link SectionDescriptor#subtitle} in parens. */
+  subtitleTextTransform?(subtitle: string | undefined): string | null;
   /** Link to display in the summary area of the {@link SectionView}. Typically page counts are displayed here.	*/
   titleLinkText?: string;
   /** A function to call when the title link has been clicked. */

--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -356,14 +356,8 @@ export interface SectionDescriptor {
    * @note required in docs, but in {@link SectionView} we have spots not passing it.
    */
   title?: string;
-  /** @internal CSS class applied to {@link SectionDescriptor#title} parent. */
-  titleClass?: string;
   /** Subtitle */
   subtitle?: string | null;
-  /** @internal CSS class applied to {@link SectionDescriptor#subtitle} parent. */
-  subtitleClass?: string;
-  /** @internal Defaults to wrapping the {@link SectionDescriptor#subtitle} in parens. */
-  subtitleTextTransform?(subtitle: string | undefined): string | null;
   /** Link to display in the summary area of the {@link SectionView}. Typically page counts are displayed here.	*/
   titleLinkText?: string;
   /** A function to call when the title link has been clicked. */

--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -351,7 +351,8 @@ export interface RowDescriptor {
  * The properties required to create a {@link SectionView} or {@link CollapsibleSectionView}.
  */
 export interface SectionDescriptor {
-  /** Main title.
+  /**
+   * Main title. After @inboxsdk/core@2.1.32, {@link SectionDescriptor#title} is placed after {@link SectionDescriptor#subtitle} if both are provided. If this behavior is not desired, we're open to a PR to add an option to configure it.
    *
    * @note required in docs, but in {@link SectionView} we have spots not passing it.
    */

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.module.css
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.module.css
@@ -1,0 +1,4 @@
+.subtitle {
+  margin-left: 1em;
+  color: rgb(94 94 94);
+}

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.module.css
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.module.css
@@ -1,11 +1,11 @@
 :global(.Wn) {
-  --inboxsdk-title-color: rgb(0 0 0 / 54%);
-  --inboxsdk-subtitle-color: rgb(0 0 0 / 87%);
+  --inboxsdk-title-color: rgb(0 0 0 / 87%);
+  --inboxsdk-subtitle-color: rgb(0 0 0 / 54%);
 }
 
 :global(.inboxsdk__gmail_dark_theme .Wn) {
-  --inboxsdk-title-color: rgb(255 255 255 / 70%);
-  --inboxsdk-subtitle-color: rgb(255 255 255);
+  --inboxsdk-title-color: rgb(255 255 255);
+  --inboxsdk-subtitle-color: rgb(255 255 255 / 70%);
 }
 
 :global(.Wn).title {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.module.css
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.module.css
@@ -1,16 +1,17 @@
-.title {
-  color: rgb(0 0 0 / 54%) !important;
+:global(.Wn) {
+  --inboxsdk-title-color: rgb(0 0 0 / 54%);
+  --inboxsdk-subtitle-color: rgb(0 0 0 / 87%);
 }
 
-.subtitle {
-  margin: 0;
-  color: rgb(0 0 0 / 87%) !important;
+:global(.inboxsdk__gmail_dark_theme .Wn) {
+  --inboxsdk-title-color: rgb(255 255 255 / 70%);
+  --inboxsdk-subtitle-color: rgb(255 255 255);
 }
 
-:global(.inboxsdk__gmail_dark_theme) .title {
-  color: rgb(255 255 255 / 70%) !important;
+:global(.Wn).title {
+  color: var(--inboxsdk-title-color);
 }
 
-:global(.inboxsdk__gmail_dark_theme) .subtitle {
-  color: rgb(255 255 255) !important;
+:global(.Wn) .subtitle {
+  color: var(--inboxsdk-subtitle-color);
 }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.module.css
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.module.css
@@ -1,4 +1,16 @@
+.title {
+  color: rgb(0 0 0 / 54%) !important;
+}
+
 .subtitle {
-  margin-left: 1em;
-  color: rgb(94 94 94);
+  margin: 0;
+  color: rgb(0 0 0 / 87%) !important;
+}
+
+:global(.inboxsdk__gmail_dark_theme) .title {
+  color: rgb(255 255 255 / 70%) !important;
+}
+
+:global(.inboxsdk__gmail_dark_theme) .subtitle {
+  color: rgb(255 255 255) !important;
 }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
@@ -14,15 +14,23 @@ import type {
   RowDescriptor,
   SectionDescriptor,
 } from '../../../../inboxsdk';
+import * as s from './gmail-collapsible-section-view.module.css';
 
 const enum GmailClass {
   titleRight_2015 = 'Cr',
   titleRight_2024_01_25 = 'chp5lb',
+  /** Adds en dash before the subtitle */
+  subtitle_2018_04_16 = 'aw5',
 }
 
 const enum GmailSelector {
   titleRight_2015 = `.${GmailClass.titleRight_2015}`,
   titleRight_2024_01_25 = `.${GmailClass.titleRight_2024_01_25}`,
+}
+
+const enum CustomSelector {
+  subtitleInsert = '.Wn',
+  title_2024_01_29 = 'h3 > .Wn',
 }
 
 class GmailCollapsibleSectionView {
@@ -228,6 +236,11 @@ class GmailCollapsibleSectionView {
       '</div>',
       '</h3>',
     ].join('');
+    if (collapsibleSectionDescriptor.titleClass) {
+      titleElement
+        .querySelector(CustomSelector.subtitleInsert)!
+        .classList.add(collapsibleSectionDescriptor.titleClass);
+    }
     const headerRightElement = document.createElement('div');
     headerRightElement.classList.add(GmailClass.titleRight_2024_01_25);
     headerElement.appendChild(titleElement);
@@ -281,11 +294,11 @@ class GmailCollapsibleSectionView {
       this.#collapsibleSectionDescriptor.title !==
       collapsibleSectionDescriptor.title
     ) {
-      const selector = 'h3 > .Wn';
-
       if (this.#titleElement) {
-        querySelector(this.#titleElement, selector).textContent =
-          collapsibleSectionDescriptor.title!;
+        querySelector(
+          this.#titleElement,
+          CustomSelector.title_2024_01_29,
+        ).textContent = collapsibleSectionDescriptor.title!;
       }
     }
   }
@@ -293,9 +306,7 @@ class GmailCollapsibleSectionView {
   #updateSubtitle(collapsibleSectionDescriptor: SectionDescriptor) {
     const titleElement = this.#titleElement;
     if (!titleElement) return;
-    let subtitleElement = titleElement.querySelector(
-      '.inboxsdk__resultsSection_title_subtitle',
-    );
+    let subtitleElement = titleElement.getElementsByClassName(s.subtitle)[0];
 
     if (!collapsibleSectionDescriptor.subtitle) {
       if (subtitleElement) {
@@ -309,20 +320,31 @@ class GmailCollapsibleSectionView {
         subtitleElement = document.createElement('span');
 
         if (subtitleElement && titleElement) {
-          subtitleElement.classList.add(
-            'inboxsdk__resultsSection_title_subtitle',
+          subtitleElement.classList.add(s.subtitle);
+          const insertionPoint = titleElement.querySelector(
+            CustomSelector.subtitleInsert,
           );
-          const insertionPoint = titleElement.querySelector('.Wn');
 
           if (insertionPoint) {
-            subtitleElement.classList.add('aw5');
+            const className =
+              collapsibleSectionDescriptor.subtitleClass ??
+              GmailClass.subtitle_2018_04_16;
+            subtitleElement.classList.add(className);
             insertionPoint.appendChild(subtitleElement);
           }
         }
       }
 
-      subtitleElement.textContent =
-        '(' + collapsibleSectionDescriptor.subtitle + ')';
+      /**
+       * @TODO Do we need the parens wrapping default for the subtitle still? This may be from before 2014.
+       * https://github.com/InboxSDK/InboxSDK/blame/ac83a7899f770d4ffab2e0a7bb422cd5eea5ee56/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.js#L291
+       */
+      const textTransform =
+        collapsibleSectionDescriptor.subtitleTextTransform ?? ((x) => `(${x})`);
+
+      subtitleElement.textContent = textTransform(
+        collapsibleSectionDescriptor.subtitle,
+      );
     }
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
@@ -231,16 +231,12 @@ class GmailCollapsibleSectionView {
     titleElement.innerHTML = [
       '<h3 class="Wr iR">',
       '<img alt="" src="//ssl.gstatic.com/ui/v1/icons/mail/images/cleardot.gif" class="qi Wp Wq">',
-      '<div class="Wn">',
+      `<div class="Wn ${s.title}">`,
       escape(collapsibleSectionDescriptor.title),
       '</div>',
       '</h3>',
     ].join('');
-    if (collapsibleSectionDescriptor.titleClass) {
-      titleElement
-        .querySelector(CustomSelector.subtitleInsert)!
-        .classList.add(collapsibleSectionDescriptor.titleClass);
-    }
+
     const headerRightElement = document.createElement('div');
     headerRightElement.classList.add(GmailClass.titleRight_2024_01_25);
     headerElement.appendChild(titleElement);
@@ -326,25 +322,12 @@ class GmailCollapsibleSectionView {
           );
 
           if (insertionPoint) {
-            const className =
-              collapsibleSectionDescriptor.subtitleClass ??
-              GmailClass.subtitle_2018_04_16;
-            subtitleElement.classList.add(className);
             insertionPoint.appendChild(subtitleElement);
           }
         }
       }
 
-      /**
-       * @TODO Do we need the parens wrapping default for the subtitle still? This may be from before 2014.
-       * https://github.com/InboxSDK/InboxSDK/blame/ac83a7899f770d4ffab2e0a7bb422cd5eea5ee56/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.js#L291
-       */
-      const textTransform =
-        collapsibleSectionDescriptor.subtitleTextTransform ?? ((x) => `(${x})`);
-
-      subtitleElement.textContent = textTransform(
-        collapsibleSectionDescriptor.subtitle,
-      );
+      subtitleElement.textContent = collapsibleSectionDescriptor.subtitle;
     }
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
@@ -26,34 +26,31 @@ const enum GmailSelector {
 }
 
 class GmailCollapsibleSectionView {
-  #driver: GmailDriver;
   #groupOrderHint: number;
   #isReadyDeferred;
   #isCollapsible: boolean;
   #collapsibleSectionDescriptor: SectionDescriptor = {} as SectionDescriptor;
   #isSearch: boolean;
-  #element: HTMLElement | null | undefined = null;
-  #headerElement: HTMLElement | null | undefined = null;
-  #titleElement: HTMLElement | null | undefined = null;
-  #bodyElement: HTMLElement | null | undefined = null;
-  #contentElement: HTMLElement | null | undefined = null;
-  #tableBodyElement: HTMLElement | null | undefined = null;
-  #collapsedContainer: HTMLElement | null | undefined = null;
-  #messageElement: HTMLElement | null | undefined = null;
-  #footerElement: HTMLElement | null | undefined = null;
+  #element: HTMLElement | null = null;
+  #headerElement: HTMLElement | null = null;
+  #titleElement: HTMLElement | null = null;
+  #bodyElement: HTMLElement | null = null;
+  #contentElement: HTMLElement | null = null;
+  #tableBodyElement: HTMLElement | null = null;
+  #collapsedContainer: HTMLElement | null = null;
+  #messageElement: HTMLElement | null = null;
+  #footerElement: HTMLElement | null = null;
   #eventStream: Bus<any, unknown>;
   #isCollapsed: boolean = false;
-  #inboxDropdownButtonView: InboxDropdownButtonView | null | undefined = null;
-  #dropdownViewController: DropdownButtonViewController | null | undefined =
-    null;
+  #inboxDropdownButtonView: InboxDropdownButtonView | null = null;
+  #dropdownViewController: DropdownButtonViewController | null = null;
 
   constructor(
-    driver: GmailDriver,
+    _driver: GmailDriver,
     groupOrderHint: number,
     isSearch: boolean,
     isCollapsible: boolean,
   ) {
-    this.#driver = driver;
     this.#isSearch = isSearch;
     this.#groupOrderHint = groupOrderHint;
     this.#isCollapsible = isCollapsible;
@@ -62,17 +59,17 @@ class GmailCollapsibleSectionView {
   }
 
   destroy() {
-    if (this.#element) this.#element.remove();
+    this.#element?.remove();
     if (this.#eventStream) this.#eventStream.end();
-    if (this.#headerElement) this.#headerElement.remove();
-    if (this.#titleElement) this.#titleElement.remove();
-    if (this.#bodyElement) this.#bodyElement.remove();
-    if (this.#contentElement) this.#contentElement.remove();
-    if (this.#tableBodyElement) this.#tableBodyElement.remove();
-    if (this.#collapsedContainer) this.#collapsedContainer.remove();
-    if (this.#messageElement) this.#messageElement.remove();
-    if (this.#inboxDropdownButtonView) this.#inboxDropdownButtonView.destroy();
-    if (this.#dropdownViewController) this.#dropdownViewController.destroy();
+    this.#headerElement?.remove();
+    this.#titleElement?.remove();
+    this.#bodyElement?.remove();
+    this.#contentElement?.remove();
+    this.#tableBodyElement?.remove();
+    this.#collapsedContainer?.remove();
+    this.#messageElement?.remove();
+    this.#inboxDropdownButtonView?.destroy();
+    this.#dropdownViewController?.destroy();
   }
 
   getElement(): HTMLElement {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
@@ -322,7 +322,7 @@ class GmailCollapsibleSectionView {
           );
 
           if (insertionPoint) {
-            insertionPoint.appendChild(subtitleElement);
+            insertionPoint.prepend(subtitleElement);
           }
         }
       }


### PR DESCRIPTION
It may be simpler to just update to the newer styles without configurability. We can always add classname configuration later.

# Screenshots

## Light theme

### Before
<figure>
<img width="1512" alt="Screenshot 2024-02-16 at 09 21 34" src="https://github.com/InboxSDK/InboxSDK/assets/5156873/83de2f17-cbe6-4f01-a07d-4ed710b305d0">
<figcaption>Note the hyphen between 'Inbox Monkeys' and 'Subtitle'. Also note the parens around 'Subtitle'.</figcaption>
</figure>


### After

<img width="1512" alt="Screenshot 2024-02-16 at 09 22 02" src="https://github.com/InboxSDK/InboxSDK/assets/5156873/298a2c12-cf41-4c3c-8b9a-084526474992">

## Dark theme

### Before

<img width="1512" alt="Screenshot 2024-02-21 at 14 52 14" src="https://github.com/InboxSDK/InboxSDK/assets/5156873/72ff338c-de2e-4b1c-817c-3edf84eadfcf">

### After

<img width="1512" alt="Screenshot 2024-02-21 at 14 26 46" src="https://github.com/InboxSDK/InboxSDK/assets/5156873/c9da9712-f0cc-4d1a-836f-260a3b1c2016">
