### PR TITLE
types: allow nullish values in kefir descriptor passed to addButton

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-button.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-button.ts
@@ -1,6 +1,8 @@
 import * as Kefir from 'kefir';
 import type GmailDriver from '../../gmail-driver';
-import GmailComposeButtonView from './gmail-compose-button-view';
+import GmailComposeButtonView, {
+  type ButtonViewOptions,
+} from './gmail-compose-button-view';
 import BasicButtonViewController from '../../../../widgets/buttons/basic-button-view-controller';
 import DropdownButtonViewController from '../../../../widgets/buttons/dropdown-button-view-controller';
 import GmailDropdownView from '../../widgets/gmail-dropdown-view';
@@ -141,7 +143,7 @@ function _addButtonToSendActionArea(
   return buttonViewController;
 }
 
-function _getButtonViewController(buttonDescriptor: Record<string, any>) {
+function _getButtonViewController(buttonDescriptor: ButtonViewOptions) {
   const buttonView = new GmailComposeButtonView(buttonDescriptor);
   const options = {
     buttonView,

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-button.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-button.ts
@@ -27,7 +27,7 @@ export default function addButton(
       .takeUntilBy(gmailComposeView.getStopper())
       .onValue((buttonDescriptor) => {
         const buttonOptions = _processButtonDescriptor(
-          buttonDescriptor!,
+          buttonDescriptor,
           extraOnClickOptions,
           gmailComposeView.getGmailDriver(),
         );

--- a/src/platform-implementation-js/driver-interfaces/compose-view-driver.ts
+++ b/src/platform-implementation-js/driver-interfaces/compose-view-driver.ts
@@ -18,6 +18,9 @@ export type StatusBar = EventEmitter & {
   setHeight(height: number): void;
 };
 
+/**
+ * This type is passed into the  ComposeViewDriver#addButton method as a way to configure the button shown.
+ */
 export interface ComposeButtonDescriptor {
   title?: string;
   iconUrl?: string;

--- a/src/platform-implementation-js/views/compose-view.ts
+++ b/src/platform-implementation-js/views/compose-view.ts
@@ -19,6 +19,7 @@ import type {
   AddressChangeEventName,
   RecipientsChangedEvent,
 } from '../dom-driver/gmail/views/gmail-compose-view/get-address-changes-stream';
+import type { Descriptor } from '../../types/descriptor';
 
 interface Members {
   driver: Driver;
@@ -143,16 +144,19 @@ export default class ComposeView extends (EventEmitter as new () => TypedEventEm
     });
   }
 
+  /**
+   * Inserts a button into the compose bar. This method also accepts a stream of {@link ComposeButtonDescriptor}s so that you can change the appearance of your button after you've added it.
+   *
+   * @param buttonDescriptor The details of the button to add to the compose bar.
+   */
   addButton(
-    buttonDescriptor:
-      | ComposeButtonDescriptor
-      | Observable<ComposeButtonDescriptor, any>,
+    buttonDescriptor: Descriptor<ComposeButtonDescriptor | null | undefined>,
   ) {
     const members = get(memberMap, this);
     const buttonDescriptorStream = kefirCast(
       Kefir,
       buttonDescriptor,
-    ) as Observable<ComposeButtonDescriptor, any>;
+    ) as Observable<ComposeButtonDescriptor | null | undefined, unknown>;
 
     const optionsPromise = members.composeViewImplementation.addButton(
       buttonDescriptorStream,


### PR DESCRIPTION
Codifies existing usage of `ComposeView.prototype.addButton` upstream at [Streak](https://github.com/StreakYC/MailFoo/blob/32b9fa6882e54fe4d3e7aaf6c19c5105910d3046/extensions/common/js/modules/boxesButton/composeBoxesButton/composeBoxesButtonViewController.tsx#L248).