### PR TITLE
fix(ComposeView): clean up dropdown to prevent empty dropdown from toggling

### DIFF
--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -635,9 +635,12 @@ export type ComposeViewDestroyEvent = Parameters<
 
 export { ComposeButtonDescriptor };
 
+/**
+ * If the associated {@link ComposeButtonDescriptor#hasDropdown} is true, `dropdown` will be defined.
+ */
 export interface ComposeViewButtonOnClickEvent {
   composeView: ComposeView;
-  dropdown: DropdownView;
+  dropdown?: DropdownView;
 }
 
 export interface RecipientRowOptions {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
@@ -696,13 +696,7 @@ class GmailComposeView {
     extraOnClickOptions: Record<string, any>,
     bus: Bus<AddedButtonEvents, unknown>,
   ) {
-    return addButton(
-      this,
-      buttonDescriptor,
-      groupOrderHint,
-      extraOnClickOptions,
-      bus,
-    );
+    addButton(this, buttonDescriptor, groupOrderHint, extraOnClickOptions, bus);
   }
 
   addTooltipToButton(

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
@@ -39,7 +39,9 @@ import ensureAppButtonToolbarsAreClosed from './gmail-compose-view/ensure-app-bu
 import sizeFixer from './gmail-compose-view/size-fixer';
 import addTooltipToButton from './gmail-compose-view/add-tooltip-to-button';
 import addRecipientRow from './gmail-compose-view/add-recipient-row';
-import addButton from './gmail-compose-view/add-button';
+import addButton, {
+  type AddedButtonEvents,
+} from './gmail-compose-view/add-button';
 import setRecipients from './gmail-compose-view/set-recipients';
 import focus from './gmail-compose-view/focus';
 import monitorSelectionRange from './gmail-compose-view/monitor-selection-range';
@@ -692,12 +694,14 @@ class GmailComposeView {
     >,
     groupOrderHint: string,
     extraOnClickOptions: Record<string, any>,
+    bus: Bus<AddedButtonEvents, unknown>,
   ) {
     return addButton(
       this,
       buttonDescriptor,
       groupOrderHint,
       extraOnClickOptions,
+      bus,
     );
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-button.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-button.ts
@@ -34,6 +34,14 @@ export default function addButton(
           gmailComposeView.getGmailDriver(),
         );
 
+        if (
+          buttonViewController instanceof DropdownButtonViewController &&
+          buttonOptions?.hasDropdown !== true
+        ) {
+          buttonViewController.destroy();
+          buttonViewController = undefined;
+        }
+
         if (!buttonViewController) {
           if (buttonOptions) {
             buttonViewController = _addButton(
@@ -186,7 +194,7 @@ function _processButtonDescriptor(
   };
   const oldOnClick = buttonOptions.onClick;
 
-  buttonOptions.onClick = function (event: any) {
+  buttonOptions.onClick = function (event) {
     driver.getLogger().eventSdkActive('composeView.addedButton.click');
     oldOnClick({ ...extraOnClickOptions, ...event });
   };

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-button.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/add-button.ts
@@ -8,8 +8,17 @@ import DropdownButtonViewController from '../../../../widgets/buttons/dropdown-b
 import GmailDropdownView from '../../widgets/gmail-dropdown-view';
 import insertElementInOrder from '../../../../lib/dom/insert-element-in-order';
 import type GmailComposeView from '../gmail-compose-view';
-import { ComposeButtonDescriptor } from '../../../../driver-interfaces/compose-view-driver';
-import { Options } from '../../../../views/compose-button-view';
+import type { ComposeButtonDescriptor } from '../../../../driver-interfaces/compose-view-driver';
+import type { Options } from '../../../../views/compose-button-view';
+import type { Bus } from 'kefir-bus';
+
+export type AddedButtonEvents = {
+  buttonViewController:
+    | BasicButtonViewController
+    | DropdownButtonViewController
+    | undefined;
+  buttonDescriptor: ComposeButtonDescriptor | null | undefined;
+};
 
 export default function addButton(
   gmailComposeView: GmailComposeView,
@@ -19,6 +28,7 @@ export default function addButton(
   >,
   groupOrderHint: string,
   extraOnClickOptions: Record<string, any>,
+  bus: Bus<AddedButtonEvents, unknown>,
 ) {
   return new Promise<Options | null>((resolve) => {
     let buttonViewController:
@@ -35,8 +45,10 @@ export default function addButton(
         );
 
         if (
-          buttonViewController instanceof DropdownButtonViewController &&
-          buttonOptions?.hasDropdown !== true
+          (buttonViewController instanceof DropdownButtonViewController &&
+            buttonOptions?.hasDropdown !== true) ||
+          (buttonViewController instanceof BasicButtonViewController &&
+            buttonOptions?.hasDropdown === true)
         ) {
           buttonViewController.destroy();
           buttonViewController = undefined;
@@ -49,13 +61,12 @@ export default function addButton(
               buttonOptions,
               groupOrderHint,
             );
-            resolve({
+            bus.emit({
               buttonViewController: buttonViewController,
               buttonDescriptor: buttonDescriptor,
             });
           }
         } else {
-          // This
           buttonViewController.update(buttonOptions as any);
         }
       })


### PR DESCRIPTION
This particular bug triggers when a ComposeView.addButton is used with a descriptor. If the descriptor goes from hasDropdown === true to false, we currently trigger an empty dropdown when the button is subsequently clicked.

[Loom](https://www.loom.com/share/6a1fbcb560aa43088b3da5957bbfc149)