### PR TITLE
Make html-to-text work without dompurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "combokeys-capture": "^2.4.2",
     "concat-stream": "^2.0.0",
     "contain-by-screen": "^1.0.3",
-    "dompurify": "^3.0.8",
     "eslint": "^8.41.0",
     "eslint-plugin-deprecate": "^0.7.0",
     "eslint-plugin-react": "^7.32.2",
@@ -126,7 +125,6 @@
   ],
   "packageManager": "yarn@4.0.1",
   "devDependencies": {
-    "@types/dompurify": "^3",
     "babel-loader": "^9.1.2",
     "css-loader": "^6.7.3",
     "jest-css-modules": "^2.1.0",

--- a/src/common/html-to-text.test.ts
+++ b/src/common/html-to-text.test.ts
@@ -4,4 +4,7 @@ test('works', () => {
   expect(htmlToText('foo &gt; &amp;gt; <br> <b>foooo</b> aa')).toBe(
     'foo > &gt;  foooo aa',
   );
+  expect(htmlToText('String with <b>html</b> &amp; entities &lt;&gt;')).toBe(
+    'String with html & entities <>',
+  );
 });

--- a/src/common/html-to-text.ts
+++ b/src/common/html-to-text.ts
@@ -25,8 +25,8 @@ function removeHtmlTags(html: string): string {
   return html.replace(/<[^>]*>?/g, '');
 }
 
-const escapeHTMLPolicy = globalThis.trustedTypes?.createPolicy(
-  'inboxSdkEscapePolicy',
+const removeHtmlTagsPolicy = globalThis.trustedTypes?.createPolicy(
+  'inboxSdk__removeHtmlTagsPolicy',
   {
     createHTML(string: string) {
       return removeHtmlTags(string);
@@ -41,9 +41,14 @@ const escapeHTMLPolicy = globalThis.trustedTypes?.createPolicy(
 /**
  * Quick function for converting HTML with entities into text without
  * introducing an XSS vulnerability.
+ * Converts text like "&amp;" into "&" and "&lt;" into "<".
+ *
+ * This is *not* for creating "safe HTML" from user input to assign to
+ * an element's innerHTML. The result of this function should not be treated
+ * as HTML.
  */
 export default function htmlToText(html: string): string {
   const div = document.createElement('div');
-  div.innerHTML = escapeHTMLPolicy.createHTML(html);
+  div.innerHTML = removeHtmlTagsPolicy.createHTML(html);
   return div.textContent!;
 }

--- a/src/common/html-to-text.ts
+++ b/src/common/html-to-text.ts
@@ -1,5 +1,3 @@
-import { sanitize } from 'dompurify';
-
 interface Policy {
   /**
    * This method returns a {@link TrustedTypePolicy},
@@ -23,14 +21,20 @@ declare global {
     | undefined;
 }
 
+function removeHtmlTags(html: string): string {
+  return html.replace(/<[^>]*>?/g, '');
+}
+
 const escapeHTMLPolicy = globalThis.trustedTypes?.createPolicy(
   'inboxSdkEscapePolicy',
   {
-    createHTML: (string: string) => sanitize(string),
+    createHTML(string: string) {
+      return removeHtmlTags(string);
+    },
   },
 ) ?? {
   createHTML(string: string) {
-    return sanitize(string);
+    return removeHtmlTags(string);
   },
 };
 

--- a/src/common/removeHtmlTags.test.ts
+++ b/src/common/removeHtmlTags.test.ts
@@ -1,0 +1,16 @@
+import { removeHtmlTagsPolicy } from './removeHtmlTags';
+
+test('output never contains <', () => {
+  expect(removeHtmlTagsPolicy.createHTML('<')).toBe('');
+  expect(removeHtmlTagsPolicy.createHTML('a<b')).toBe('a');
+  expect(removeHtmlTagsPolicy.createHTML('a<b<c<d')).toBe('a');
+  expect(removeHtmlTagsPolicy.createHTML('a<b>c<d')).toBe('ac');
+  expect(removeHtmlTagsPolicy.createHTML('a<<<<b')).toBe('a');
+  expect(removeHtmlTagsPolicy.createHTML('a<<<<b>c>d>e')).toBe('ac>d>e');
+
+  expect(
+    removeHtmlTagsPolicy.createHTML(
+      'String with <b>html</b> &amp; entities &lt;&gt;',
+    ),
+  ).toBe('String with html &amp; entities &lt;&gt;');
+});

--- a/src/common/removeHtmlTags.ts
+++ b/src/common/removeHtmlTags.ts
@@ -1,0 +1,53 @@
+interface Policy {
+  /**
+   * This method returns a {@link TrustedTypePolicy},
+   * but typescript@5.3.3's lib.dom doesn't support assigning non-strings
+   * to {@link HTMLElement.innerHTML}.
+   */
+  createHTML(string: string): string;
+}
+
+declare global {
+  /**
+   * typescript@5.3.3 doesn't ship types for trustedTypes yet.
+   * Safari 17.2 doesn't support it either, so a fallback is needed if
+   * it's not defined.
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/TrustedHTML
+   */
+  var trustedTypes:
+    | {
+        createPolicy(name: string, policy: Policy): Policy;
+      }
+    | undefined;
+}
+
+/**
+ * This function removes all HTML tags from a string.
+ * The resulting string may still contain HTML entities and not be suitable to display as plain text.
+ *
+ * This function's output will never contain `<` and therefore will never contain any HTML
+ * tags, so it's safe to use this on arbitrary input and assign the result to an element's
+ * innerHTML property.
+ *
+ * @see Use [htmlToText](./html-to-text.ts) instead if you want to convert HTML to
+ * unformatted text to display.
+ */
+function removeHtmlTags(html: string): string {
+  return html.replace(/<[^>]*>?/g, '');
+}
+
+/**
+ * This policy object is used to strip HTML tags from a string.
+ */
+export const removeHtmlTagsPolicy = globalThis.trustedTypes?.createPolicy(
+  'inboxSdk__removeHtmlTagsPolicy',
+  {
+    createHTML(string: string) {
+      return removeHtmlTags(string);
+    },
+  },
+) ?? {
+  createHTML(string: string) {
+    return removeHtmlTags(string);
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "allowSyntheticDefaultImports": true,
     "target": "ES2022",
     "moduleResolution": "node",
-    "isolatedModules": true
+    "isolatedModules": true,
+    "moduleDetection": "force"
   },
   "exclude": ["packages/core"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,15 +2210,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/dompurify@npm:^3":
-  version: 3.0.5
-  resolution: "@types/dompurify@npm:3.0.5"
-  dependencies:
-    "@types/trusted-types": "npm:*"
-  checksum: e544b3ce53c41215cabff3d89256ff707c7ee8e0c9a1b5034b22014725d288b16e6942cdcdeeb4221c578c3421a6a4721aa0676431f55d7abd18c07368855c5e
-  languageName: node
-  linkType: hard
-
 "@types/eslint-scope@npm:^3.7.3":
   version: 3.7.4
   resolution: "@types/eslint-scope@npm:3.7.4"
@@ -2506,13 +2497,6 @@ __metadata:
   version: 0.3.0
   resolution: "@types/transducers.js@npm:0.3.0"
   checksum: 93fe162520b6875cf08463ca049be8cce4e85ae40103a57453b5c352682aff30a275a79f1e0d2c10b51bb28859a466cee638ae7c524e58e2b6d3a0f34d71b76c
-  languageName: node
-  linkType: hard
-
-"@types/trusted-types@npm:*":
-  version: 2.0.7
-  resolution: "@types/trusted-types@npm:2.0.7"
-  checksum: 8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
   languageName: node
   linkType: hard
 
@@ -4822,13 +4806,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.0.8":
-  version: 3.0.8
-  resolution: "dompurify@npm:3.0.8"
-  checksum: 671fa18bd4bcb1a6ff2e59ecf919f807615b551e7add8834b27751d4e0f3d754a67725482d1efdd259317cadcaaccb72a8afc3aba829ac59730e760041591a1a
-  languageName: node
-  linkType: hard
-
 "duplexify@npm:^3.6.0":
   version: 3.7.1
   resolution: "duplexify@npm:3.7.1"
@@ -6732,7 +6709,6 @@ __metadata:
     "@macil/simple-base-converter": "npm:^1.0.0"
     "@types/asap": "npm:^2.0.0"
     "@types/classnames": "npm:^2.2.8"
-    "@types/dompurify": "npm:^3"
     "@types/gulp": "npm:^4.0.6"
     "@types/http-server": "npm:^0.10.1"
     "@types/jest": "npm:^29"
@@ -6762,7 +6738,6 @@ __metadata:
     concat-stream: "npm:^2.0.0"
     contain-by-screen: "npm:^1.0.3"
     css-loader: "npm:^6.7.3"
-    dompurify: "npm:^3.0.8"
     eslint: "npm:^8.41.0"
     eslint-plugin-deprecate: "npm:^0.7.0"
     eslint-plugin-react: "npm:^7.32.2"


### PR DESCRIPTION
Follow-up to https://github.com/InboxSDK/InboxSDK/pull/1126. Removes dompurify which was more heavyweight and unnecessary here.

No visible behavior changes.