### PR TITLE
types: typed events for section views

### DIFF
--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -410,7 +410,7 @@ export interface SectionDescriptor {
   /** Link to display in the summary area of the {@link SectionView}. Typically page counts are displayed here.	*/
   titleLinkText?: string;
   /** A function to call when the title link has been clicked. */
-  onTitleLinkClick?(e: MouseEvent): void;
+  onTitleLinkClick?(e: CollapsibleSectionView | SectionView): void;
   /** Whether to display a dropdown arrow for more options on the collapsible section. */
   hasDropdown?: boolean;
   /**
@@ -424,7 +424,7 @@ export interface SectionDescriptor {
   /** A link to place in the footer of the {@link SectionView}.	 */
   footerLinkText?: string;
   /** A function to call when the link in the footer is clicked. */
-  onFooterLinkClick?(e: MouseEvent): void;
+  onFooterLinkClick?(e: CollapsibleSectionView | SectionView): void;
   /** @internal */
   orderHint?: unknown;
   /** @internal */

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-collapsible-section-view.ts
@@ -33,6 +33,31 @@ const enum CustomSelector {
   title_2024_01_29 = 'h3 > .Wn',
 }
 
+type ViewEvent =
+  | {
+      type: 'update';
+      property: 'orderHint';
+      sectionDescriptor?: SectionDescriptor;
+    }
+  | {
+      eventName: 'titleLinkClicked';
+      sectionDescriptor: SectionDescriptor;
+    }
+  | {
+      eventName: 'rowClicked';
+      rowDescriptor: RowDescriptor;
+    }
+  | {
+      eventName: 'footerClicked';
+      sectionDescriptor: SectionDescriptor;
+    }
+  | {
+      eventName: 'collapsed';
+    }
+  | {
+      eventName: 'expanded';
+    };
+
 class GmailCollapsibleSectionView {
   #groupOrderHint: number;
   #isReadyDeferred;
@@ -48,7 +73,7 @@ class GmailCollapsibleSectionView {
   #collapsedContainer: HTMLElement | null = null;
   #messageElement: HTMLElement | null = null;
   #footerElement: HTMLElement | null = null;
-  #eventStream: Bus<any, unknown>;
+  #eventStream: Bus<ViewEvent, unknown>;
   #isCollapsed: boolean = false;
   #inboxDropdownButtonView: InboxDropdownButtonView | null = null;
   #dropdownViewController: DropdownButtonViewController | null = null;
@@ -95,7 +120,7 @@ class GmailCollapsibleSectionView {
     return element;
   }
 
-  getEventStream() {
+  get eventStream() {
     return this.#eventStream;
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -237,8 +237,12 @@ class GmailRouteView implements RouteViewDriver {
 
     Kefir.combine([
       this.#getSectionsContainer(),
-      gmailResultsSectionView.getEventStream().filter((event) => {
-        return event.type === 'update' && event.property === 'orderHint';
+      gmailResultsSectionView.eventStream.filter((event) => {
+        return (
+          'type' in event &&
+          event.type === 'update' &&
+          event.property === 'orderHint'
+        );
       }),
     ]).onValue(([sectionsContainer]) => {
       const children = sectionsContainer.children;

--- a/src/platform-implementation-js/views/section-view.ts
+++ b/src/platform-implementation-js/views/section-view.ts
@@ -1,13 +1,15 @@
 import EventEmitter from '../lib/safe-event-emitter';
 import type { Driver } from '../driver-interfaces/driver';
 import type GmailCollapsibleSectionView from '../dom-driver/gmail/views/gmail-collapsible-section-view';
+import type TypedEventEmitter from 'typed-emitter';
+import type { ViewEvent } from './collapsible-section-view';
 
 /**
  * {@link SectionView}s allow you to display additional content on ListRouteViews. They are typically rendered as additional content above the list of threads below. The visual style is similar to that of multiple inbox sections used in native Gmail. Note that the rendering may vary slightly depending on the actual ListRouteView that the SectionView is rendered in. For example, SectionViews rendered on search results pages use different header styles to match Gmail's style more accurately.
 
  * You can either render rows (that are visually similar to Gmail rows) or custom content in your SectionView. Until content is provided, the SectionView will simply display a "Loading..." indicator. See ListRouteView.addSection for more information.
  */
-class SectionView extends EventEmitter {
+class SectionView extends (EventEmitter as new () => TypedEventEmitter<ViewEvent>) {
   destroyed: boolean;
   #sectionViewDriver;
 
@@ -37,46 +39,50 @@ function _bindToEventStream(
   sectionViewDriver: GmailCollapsibleSectionView,
   driver: Driver,
 ) {
-  sectionViewDriver.getEventStream().onValue((e) => {
-    sectionView.emit(e.eventName);
+  sectionViewDriver.eventStream.onValue((e) => {
+    if (e != null && 'eventName' in e) {
+      sectionView.emit(e.eventName);
+    }
   });
-  sectionViewDriver
-    .getEventStream()
-    .filter(
-      ({ eventName }: { eventName: unknown }) => eventName === 'rowClicked',
-    )
-    .onValue(
-      ({
-        rowDescriptor,
-      }: {
-        rowDescriptor: { routeID?: string; routeParams: any; onClick: unknown };
-      }) => {
-        if (rowDescriptor.routeID) {
-          driver.goto(rowDescriptor.routeID, rowDescriptor.routeParams);
-        }
+  sectionViewDriver.eventStream.onValue((event) => {
+    if (!('eventName' in event) || event.eventName !== 'rowClicked') {
+      return;
+    }
 
-        if (typeof rowDescriptor.onClick === 'function') {
-          rowDescriptor.onClick();
-        }
-      },
-    );
-  sectionViewDriver
-    .getEventStream()
-    .filter(({ eventName }) => eventName === 'summaryClicked')
-    .onValue(({ sectionDescriptor }) => {
-      if (sectionDescriptor.onTitleLinkClick) {
-        sectionDescriptor.onTitleLinkClick(sectionView);
-      }
-    });
-  sectionViewDriver
-    .getEventStream()
-    .filter(({ eventName }) => eventName === 'footerClicked')
-    .onValue(({ sectionDescriptor }) => {
-      if (sectionDescriptor.onFooterLinkClick) {
-        sectionDescriptor.onFooterLinkClick(sectionView);
-      }
-    });
-  sectionViewDriver.getEventStream().onEnd(() => {
+    const { rowDescriptor } = event;
+
+    if (rowDescriptor.routeID) {
+      driver.goto(rowDescriptor.routeID, rowDescriptor.routeParams);
+    }
+
+    if (typeof rowDescriptor.onClick === 'function') {
+      rowDescriptor.onClick();
+    }
+  });
+
+  sectionViewDriver.eventStream.onValue((event) => {
+    if (!('eventName' in event) || event.eventName !== 'titleLinkClicked') {
+      return;
+    }
+
+    const { sectionDescriptor } = event;
+
+    if (sectionDescriptor.onTitleLinkClick) {
+      sectionDescriptor.onTitleLinkClick(sectionView);
+    }
+  });
+
+  sectionViewDriver.eventStream.onValue((event) => {
+    if (!('eventName' in event) || event.eventName !== 'footerClicked') {
+      return;
+    }
+    const { sectionDescriptor } = event;
+
+    if (sectionDescriptor?.onFooterLinkClick) {
+      sectionDescriptor.onFooterLinkClick(sectionView);
+    }
+  });
+  sectionViewDriver.eventStream.onEnd(() => {
     sectionView.destroyed = true;
     sectionView.emit('destroy');
   });


### PR DESCRIPTION
Prep for layout work around `CollapsibleSectionView`.

Runs types through events for `SectionView` and `CollapsibleSectionView`. Requires a bit of runtime rejiggering to narrow event types.

tip: ignore whitespace.
