### PR TITLE
ThreadRowView.addImage onHover callback

### DIFF
--- a/examples/thread-rows/content.js
+++ b/examples/thread-rows/content.js
@@ -39,6 +39,12 @@ InboxSDK.load(2, 'thread-rows').then(function (inboxSDK) {
         imageUrl:
           'https://lh6.googleusercontent.com/-dSK6wJEXzP8/AAAAAAAAAAI/AAAAAAAAAAA/Som6EQiIJa8/s64-c/photo.jpg',
         tooltip: 'Monkeys',
+        onHover(e) {
+          console.log('hovered over image', e);
+          e.hoverEnd.then(() => {
+            console.log('hover ended');
+          });
+        },
       }),
     );
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
@@ -509,6 +509,27 @@ class GmailThreadRowView {
           iconWrapper.removeAttribute('data-tooltip');
         }
 
+        if (iconDescriptor.onHover) {
+          const { onHover } = iconDescriptor;
+          // Using property instead of addEventListener so we replace any old handler
+          // added by a previous iconDescriptor emitted from the stream.
+          iconWrapper.onmouseenter = () => {
+            // We only add the mouseleave listener here and use addEventListener so
+            // it doesn't get replaced if a new iconDescriptor is emitted from the
+            // stream while the user is hovering.
+            const hoverEnd = new Promise<void>((resolve) => {
+              iconWrapper.addEventListener(
+                'mouseleave',
+                () => {
+                  resolve();
+                },
+                { once: true },
+              );
+            });
+            onHover({ hoverEnd });
+          };
+        }
+
         const labelParent = this._getLabelParent();
 
         if (!labelParent.contains(iconWrapper)) {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
@@ -481,6 +481,8 @@ class GmailThreadRowView {
               iconWrapper: document.createElement('div'),
 
               remove() {
+                // Trigger any mouseleave handlers that were added by onHover.
+                this.iconWrapper.dispatchEvent(new MouseEvent('mouseleave'));
                 this.iconWrapper.remove();
               },
             };

--- a/src/platform-implementation-js/views/thread-row-view.ts
+++ b/src/platform-implementation-js/views/thread-row-view.ts
@@ -15,6 +15,7 @@ export interface ImageDescriptor {
   imageClass?: string;
   tooltip?: string;
   orderHint?: number;
+  onHover?: (event: { hoverEnd: Promise<void> }) => void;
 }
 
 type EmitterType = TypedEventEmitter<{ destroy: () => void }>;


### PR DESCRIPTION
Adds an onHover callback to ThreadRowView.addImage's ImageDescriptor. The callback gives an object with a `hoverEnd: Promise<void>;` property that resolves when the hover finishes.

## Suggested Usage

Intended for event logging within Streak to see how often the addImage tooltip is used.
Highly recommend that for this use, only hovers that last for a certain amount of time like a second are logged in order to only see intentional hovers. This can be done like the following code examples, one using Kefir and one not:

```ts
threadRowView.addImage({
  // ...
  onHover(event) {
    Kefir.later(1000)
      .takeUntilBy(Kefir.fromPromise(event.hoverEnd))
      .onValue(() => {
        logHover();
      });
  }
});
```

```ts
threadRowView.addImage({
  // ...
  onHover(event) {
    const timeout = setTimeout(() => {
      logHover();
    }, 1000);
    event.hoverEnd.then(() => {
      clearTimeout(timeout);
    });
  }
});
```