### PR TITLE
Add AttachmentCardView.getElement

### DIFF
--- a/src/platform-implementation-js/views/conversations/attachment-card-view.ts
+++ b/src/platform-implementation-js/views/conversations/attachment-card-view.ts
@@ -68,4 +68,21 @@ export default class AttachmentCardView extends (EventEmitter as new () => Typed
 
     return messageViewDriver ? this.#membrane.get(messageViewDriver) : null;
   }
+
+  private get _attachmentCardImplementation() {
+    this.#driver
+      .getLogger()
+      .deprecationWarning(
+        'AttachmentCardView._attachmentCardImplementation._element',
+        'AttachmentCardView.getElement',
+      );
+
+    return {
+      _element: this.getElement(),
+    };
+  }
+
+  getElement(): HTMLElement {
+    return this.#attachmentCardImplementation.getElement();
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/InboxSDK/InboxSDK/issues/1162.

It was not possible to get the element of an AttachmentCardView except by accessing the undocumented and accidentally-exposed property `_attachmentCardImplementation._element`. This undocumented property was removed in a recent cleanup PR. This PR adds a new AttachmentCardView.getElement function and some compatibility code so that code using the old undocumented property still works (but gets a console warning recommending the new property).

Originally the InboxSDK mostly avoided adding APIs exposing Gmail elements (like `getElement()` methods) in order to encourage extensions to only inspect and modify elements through the InboxSDK so that extensions using the InboxSDK didn't do anything that didn't work in future Gmail versions or Google Inbox, but Gmail has been relatively stable, Google Inbox was discontinued, it's extremely useful to prototype features using direct access to elements outside of the InboxSDK, and some extensions want to do things that the InboxSDK doesn't want to commit to maintaining, so we're much more willing to expose Gmail elements now where it's useful to.