### PR TITLE
Misc type definition fixes

### DIFF
--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import type * as Kefir from 'kefir';
 import type TypedEmitter from 'typed-emitter';
 import AppMenu from './platform-implementation-js/namespaces/app-menu';
+import Compose from './platform-implementation-js/namespaces/compose';
 import type Global from './platform-implementation-js/namespaces/global';
 import type {
   NavItemTypes,
@@ -86,11 +87,7 @@ export interface Conversations {
   ): () => void;
 }
 
-export interface Compose {
-  openDraftByMessageID(messageId: string): Promise<ComposeView>;
-  openNewComposeView(): Promise<ComposeView>;
-  registerComposeViewHandler(handler: (composeView: ComposeView) => void): void;
-}
+export { Compose };
 
 export interface ButterBar {
   showMessage(messageDescriptor: MessageDescriptor): { destroy: () => void };

--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -217,7 +217,7 @@ export interface AppToolbarButtonDescriptor {
   titleClass?: string;
   iconUrl: string;
   iconClass?: string;
-  onClick: (e: MouseEvent) => void;
+  onClick: (e: { dropdown?: DropdownView }) => void;
   arrowColor?: string | null;
 }
 

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
@@ -94,7 +94,12 @@ import type ContentPanelViewDriver from '../../driver-common/sidebar/ContentPane
 import GmailNavItemView, {
   type NavItemDescriptor,
 } from './views/gmail-nav-item-view';
-import { AppToolbarButtonDescriptor, Contact } from '../../../inboxsdk';
+import {
+  AppToolbarButtonDescriptor,
+  Contact,
+  DropdownView,
+  ToolbarButtonDescriptor,
+} from '../../../inboxsdk';
 import GmailAttachmentCardView from './views/gmail-attachment-card-view';
 import type { PersonDetails } from '../../namespaces/user';
 import getPersonDetails from './gmail-driver/getPersonDetails';
@@ -397,7 +402,16 @@ class GmailDriver {
     } as const;
   }
 
-  registerThreadButton(options: any) {
+  registerThreadButton(
+    options: Omit<ToolbarButtonDescriptor, 'hideFor' | 'onClick'> & {
+      onClick(event: {
+        position: 'ROW' | 'LIST' | 'THREAD';
+        dropdown: DropdownView;
+        selectedThreadViewDrivers: GmailThreadView[];
+        selectedThreadRowViewDrivers: GmailThreadRowView[];
+      }): void;
+    },
+  ) {
     const unregister = kefirStopper();
 
     const removeButtonOnUnregister = (button: any) => {
@@ -420,7 +434,7 @@ class GmailDriver {
                   position: 'THREAD',
                   dropdown: event.dropdown,
                   selectedThreadViewDrivers: [
-                    gmailToolbarView.getThreadViewDriver(),
+                    gmailToolbarView.getThreadViewDriver()!,
                   ],
                   selectedThreadRowViewDrivers: [],
                 });

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
@@ -591,7 +591,7 @@ class GmailDriver {
   }
 
   addToolbarButtonForApp(
-    buttonDescriptor: Kefir.Stream<AppToolbarButtonDescriptor, any>,
+    buttonDescriptor: Kefir.Observable<AppToolbarButtonDescriptor, any>,
   ): Promise<GmailAppToolbarButtonView> {
     return addToolbarButtonForApp(this, buttonDescriptor);
   }

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-toolbar-button-for-app.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-toolbar-button-for-app.ts
@@ -6,7 +6,7 @@ import { AppToolbarButtonDescriptor } from '../../../../inboxsdk';
 
 export default function addToolbarButtonForApp(
   gmailDriver: GmailDriver,
-  buttonDescriptor: Kefir.Stream<AppToolbarButtonDescriptor, any>,
+  buttonDescriptor: Kefir.Observable<AppToolbarButtonDescriptor, any>,
 ): Promise<GmailAppToolbarButtonView> {
   return GmailElementGetter.waitForGmailModeToSettle().then(() => {
     if (GmailElementGetter.isStandalone()) {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-toolbar-button-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-toolbar-button-view.ts
@@ -9,17 +9,18 @@ import GmailTooltipView from '../widgets/gmail-tooltip-view';
 import DropdownView from '../../../widgets/buttons/dropdown-view';
 import monitorTopBannerSizeAndReact from './gmail-app-toolbar-button-view/monitor-top-banner-size-and-react';
 import type Driver from '../gmail-driver';
+import { AppToolbarButtonDescriptor } from '../../../../inboxsdk';
 export default class GmailAppToolbarButtonView {
   _stopper: Stopper;
   _iconSettings: Record<string, any>;
   _element: HTMLElement | null | undefined = null;
   _activeDropdown: DropdownView | null | undefined;
-  _buttonDescriptor: Record<string, any> | null | undefined;
+  _buttonDescriptor: AppToolbarButtonDescriptor | null | undefined;
   _driver: Driver;
 
   constructor(
     driver: Driver,
-    inButtonDescriptor: Kefir.Observable<Record<string, any>, unknown>,
+    inButtonDescriptor: Kefir.Observable<AppToolbarButtonDescriptor, unknown>,
   ) {
     this._driver = driver;
     this._stopper = kefirStopper();
@@ -76,7 +77,7 @@ export default class GmailAppToolbarButtonView {
     }
   }
 
-  _handleButtonDescriptor(buttonDescriptor: Record<string, any>) {
+  _handleButtonDescriptor(buttonDescriptor: AppToolbarButtonDescriptor) {
     if (!buttonDescriptor) {
       throw new Error(
         'The application passed an invalid value for buttonDescriptor',
@@ -164,7 +165,7 @@ export default class GmailAppToolbarButtonView {
 
 function _createAppButtonElement(
   driver: Driver,
-  onclick: (event: Record<string, any>) => void,
+  onclick: (event: MouseEvent) => void,
 ): HTMLElement {
   const element = document.createElement('div');
   element.setAttribute('class', 'inboxsdk__appButton');
@@ -215,7 +216,10 @@ function _createAppButtonElement(
   }
 }
 
-function _updateTitle(element: HTMLElement, descriptor: Record<string, any>) {
+function _updateTitle(
+  element: HTMLElement,
+  descriptor: AppToolbarButtonDescriptor,
+) {
   element.textContent = descriptor.title;
   element.className = `inboxsdk__appButton_title ${
     descriptor.titleClass || ''

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -540,7 +540,7 @@ class GmailMessageView {
   addAttachmentIcon(
     iconDescriptor:
       | MessageAttachmentIconDescriptor
-      | Kefir.Stream<MessageAttachmentIconDescriptor, never>,
+      | Kefir.Observable<MessageAttachmentIconDescriptor, never>,
   ) {
     const attachmentIcon = new AttachmentIcon();
 

--- a/src/platform-implementation-js/namespaces/compose.ts
+++ b/src/platform-implementation-js/namespaces/compose.ts
@@ -10,7 +10,7 @@ interface Members {
   driver: Driver;
   membrane: Membrane;
   handlerRegistry: HandlerRegistry<ComposeView>;
-  composeViewStream: Kefir.Stream<ComposeView, unknown>;
+  composeViewStream: Kefir.Observable<ComposeView, unknown>;
 }
 const memberMap = ud.defonce(module, () => new WeakMap<Compose, Members>());
 const SAMPLE_RATE = 0.01;

--- a/src/platform-implementation-js/namespaces/compose.ts
+++ b/src/platform-implementation-js/namespaces/compose.ts
@@ -15,7 +15,7 @@ interface Members {
 const memberMap = ud.defonce(module, () => new WeakMap<Compose, Members>());
 const SAMPLE_RATE = 0.01;
 
-class Compose {
+export default class Compose {
   constructor(driver: Driver, membrane: Membrane) {
     const members = {
       driver,
@@ -68,6 +68,7 @@ class Compose {
       .toPromise();
   }
 
+  /** @deprecated Use {@link openNewComposeView} instead */
   getComposeView(): Promise<ComposeView> {
     const { driver } = get(memberMap, this);
     driver
@@ -84,5 +85,3 @@ class Compose {
     return this.openNewComposeView();
   }
 }
-
-export default Compose;

--- a/src/platform-implementation-js/namespaces/toolbars.ts
+++ b/src/platform-implementation-js/namespaces/toolbars.ts
@@ -1,4 +1,4 @@
-import Kefir, { type Stream } from 'kefir';
+import Kefir, { type Observable } from 'kefir';
 import kefirCast from 'kefir-cast';
 import kefirStopper from 'kefir-stopper';
 import EventEmitter from '../lib/safe-event-emitter';
@@ -214,7 +214,7 @@ export default class Toolbars extends EventEmitter {
   setAppToolbarButton(
     appToolbarButtonDescriptor:
       | AppToolbarButtonDescriptor
-      | Stream<AppToolbarButtonDescriptor, any>,
+      | Observable<AppToolbarButtonDescriptor, any>,
   ) {
     this.#driver
       .getLogger()
@@ -236,9 +236,9 @@ export default class Toolbars extends EventEmitter {
   addToolbarButtonForApp(
     buttonDescriptor:
       | AppToolbarButtonDescriptor
-      | Stream<AppToolbarButtonDescriptor, any>,
+      | Observable<AppToolbarButtonDescriptor, any>,
   ) {
-    const buttonDescriptorStream: Stream<AppToolbarButtonDescriptor, any> =
+    const buttonDescriptorStream: Observable<AppToolbarButtonDescriptor, any> =
       kefirCast(Kefir, buttonDescriptor);
     const appToolbarButtonViewDriverPromise =
       this.#driver.addToolbarButtonForApp(buttonDescriptorStream);


### PR DESCRIPTION
Fixes https://github.com/InboxSDK/InboxSDK/issues/1158, https://github.com/InboxSDK/InboxSDK/issues/1159, https://github.com/InboxSDK/InboxSDK/issues/1161

Only one behavior change: an error caused by accessing a private property on the wrong `this` value is fixed in the getter of the long-deprecated `LegacyListToolbarButtonDescriptor.threadRowViews` property.