### PR TITLE
types: Remove shadow RouteView type

### DIFF
--- a/src/inboxsdk.d.ts
+++ b/src/inboxsdk.d.ts
@@ -35,7 +35,10 @@ import type {
 import type CollapsibleSectionView from './platform-implementation-js/views/collapsible-section-view';
 import type ListRouteView from './platform-implementation-js/views/route-view/list-route-view';
 import type SectionView from './platform-implementation-js/views/section-view';
-import type { RouteParams } from './platform-implementation-js/namespaces/router';
+import Router, {
+  type RouteParams,
+} from './platform-implementation-js/namespaces/router';
+import CustomRouteView from './platform-implementation-js/views/route-view/custom-route-view';
 
 export type { User };
 
@@ -131,71 +134,7 @@ export interface NavMenu {
   ): NavItemView;
 }
 
-export interface Router {
-  createLink(routeID: string, params?: any): string;
-  getCurrentRouteView(): RouteView;
-  goto(routeID: string, params?: any): Promise<void>;
-  handleAllRoutes(handler: (routeView: RouteView) => void): () => void;
-  handleCustomRoute(
-    routeID: string,
-    handler: (customRouteView: CustomRouteView) => void,
-  ): () => void;
-  handleCustomListRoute(
-    routeID: string,
-    handler: (offset: number, max: number) => void,
-  ): void;
-  handleListRoute(
-    routeID: string,
-    handler: (listRouteView: ListRouteView) => void,
-  ): () => void;
-  NativeRouteIDs: Record<NativeRouteIdTypes, string>;
-  NativeListRouteIDs: Record<
-    | 'ALL_MAIL'
-    | 'ANY_LIST'
-    | 'DRAFTS'
-    | 'IMPORTANT'
-    | 'INBOX'
-    | 'LABEL'
-    | 'SEARCH'
-    | 'SEARCH'
-    | 'SENT'
-    | 'SPAM'
-    | 'STARRED'
-    | 'TRASH',
-    string
-  >;
-  RouteTypes: Record<RouteTypes, string>;
-}
-
-type NativeRouteIdTypes =
-  | 'INBOX'
-  | 'ALL_MAIL'
-  | 'SENT'
-  | 'STARRED'
-  | 'DRAFTS'
-  | 'SNOOZED'
-  | 'DONE'
-  | 'REMINDERS'
-  | 'LABEL'
-  | 'TRASH'
-  | 'SPAM'
-  | 'IMPORTANT'
-  | 'SEARCH'
-  | 'THREAD'
-  | 'CHATS'
-  | 'CHAT'
-  | 'CONTACTS'
-  | 'CONTACT'
-  | 'SETTINGS'
-  | 'ANY_LIST';
-
-type RouteTypes =
-  | 'CHAT'
-  | 'CUSTOM'
-  | 'LIST'
-  | 'SETTINGS'
-  | 'THREAD'
-  | 'UNKNOWN';
+export { Router };
 
 export interface Widgets {
   /** check whether mole view has light title bar as part of gmail new view / original view  */
@@ -434,9 +373,7 @@ export interface SectionDescriptor {
 
 export { ListRouteView };
 
-export interface CustomRouteView extends RouteView {
-  getElement(): HTMLElement;
-}
+export { CustomRouteView };
 
 export interface CustomListDescriptor {
   hasMore?: boolean;

--- a/src/platform-implementation-js/lib/handler-registry.ts
+++ b/src/platform-implementation-js/lib/handler-registry.ts
@@ -2,7 +2,7 @@ import remove from 'lodash/remove';
 import asap from 'asap';
 import Logger from './logger';
 
-export type Handler<T> = (target: T) => void;
+export type Handler<T> = (target: T) => void | Promise<void>;
 
 export default class HandlerRegistry<T> {
   private _targets: Array<T> = [];

--- a/src/platform-implementation-js/namespaces/router.ts
+++ b/src/platform-implementation-js/namespaces/router.ts
@@ -1,8 +1,6 @@
 import find from 'lodash/find';
 import intersection from 'lodash/intersection';
-import { defonce } from 'ud';
 import HandlerRegistry from '../lib/handler-registry';
-import get from '../../common/get-or-fail';
 import RouteView from '../views/route-view/route-view';
 import ListRouteView from '../views/route-view/list-route-view';
 import CustomRouteView from '../views/route-view/custom-route-view';
@@ -16,46 +14,48 @@ import {
 import type { Driver } from '../driver-interfaces/driver';
 import type { Handler } from '../lib/handler-registry';
 import { RouteViewDriver } from '../driver-interfaces/route-view-driver';
-export type RouteParams = Record<string, string | number>;
-interface Members {
-  appId: string;
-  driver: Driver;
-  currentRouteViewDriver: RouteViewDriver | DummyRouteViewDriver;
-  allRoutesHandlerRegistry: HandlerRegistry<RouteView>;
-  customRoutes: Array<{
-    routeID: string | string[];
-    onActivate: HandlerRegistry<CustomRouteView>;
-  }>;
-  membrane: Membrane;
-  listRouteHandlerRegistries: Record<string, HandlerRegistry<ListRouteView>>;
-}
-const memberMap = defonce(module, () => new WeakMap<Router, Members>());
+
+export type RouteParams = Record<string, string | number | undefined | null>;
+
 const SAMPLE_RATE = 0.01;
 
+/**
+ * This namespace contains functionality associated with creating your own content inside Gmail. It allows you to define "Routes" which define a full page of content and an associated URL space for which they are active. You can think of routes as different pages in your application. Gmail already have a few routes built in (Inbox, Sent, Drafts, etc). This namespace allows you to define your own as well as listen in on the built in routes being navigated to.
+
+This is typically used when you want to create content to fill the main content area of Gmail. Every route has a URL associated with it and can have optional parameters. However, you never construct these URL's manually. The SDK will take care of creating a URL that will work in Gmail for your Route. Since these URL's may change due to implementations of Gmail, you should always create new links when trying to set URL on elements or simply use the goto function which naviagtes to the created link automatically. Using the handleX family of methods, you can specify which routes your application can handle. You will be called back with and instance of a RouteView or similar when the user navigates to a route you've declared you can handle. For custom routes, you'll typically add your own content and for built in routes, you'll typically modify the existing content. Route ID's are path like strings with named parameters, for example: "myroute/:someParamMyRouteNeeds".
+ */
 class Router {
   NativeRouteIDs = NATIVE_ROUTE_IDS;
   NativeListRouteIDs = NATIVE_LIST_ROUTE_IDS;
   RouteTypes = ROUTE_TYPES;
 
+  #appId: string;
+  #driver: Driver;
+  #currentRouteViewDriver: RouteViewDriver | DummyRouteViewDriver;
+  #allRoutesHandlerRegistry: HandlerRegistry<RouteView>;
+  #customRoutes: Array<{
+    routeID: string | string[];
+    onActivate: Handler<CustomRouteView>;
+  }> = [];
+  #membrane: Membrane;
+  #listRouteHandlerRegistries: Record<string, HandlerRegistry<ListRouteView>> =
+    {};
+
   constructor(appId: string, driver: Driver, membrane: Membrane) {
-    const members: Members = {
-      appId,
-      driver,
-      currentRouteViewDriver: new DummyRouteViewDriver(),
-      allRoutesHandlerRegistry: new HandlerRegistry(),
-      customRoutes: [],
-      membrane,
-      listRouteHandlerRegistries: {},
-    };
+    this.#appId = appId;
+    this.#driver = driver;
+    this.#currentRouteViewDriver = new DummyRouteViewDriver();
+    this.#allRoutesHandlerRegistry = new HandlerRegistry();
+    this.#membrane = membrane;
     Object.values(NATIVE_LIST_ROUTE_IDS).forEach((value) => {
-      members.listRouteHandlerRegistries[value] = new HandlerRegistry();
+      this.#listRouteHandlerRegistries[value] = new HandlerRegistry();
     });
-    memberMap.set(this, members);
+
     driver.getRouteViewDriverStream().onValue((routeViewDriver) => {
       driver
         .getLogger()
         .trackFunctionPerformance(
-          () => _handleRouteViewChange(this, members, routeViewDriver),
+          () => this.#handleRouteViewChange(routeViewDriver),
           SAMPLE_RATE,
           {
             type: 'handleRouteViewChange',
@@ -63,21 +63,32 @@ class Router {
           },
         );
     });
-    driver.getStopper().onValue(function () {
-      members.allRoutesHandlerRegistry.dumpHandlers();
-      Object.values(members.listRouteHandlerRegistries).forEach((reg: any) => {
+    driver.getStopper().onValue(() => {
+      this.#allRoutesHandlerRegistry.dumpHandlers();
+      Object.values(this.#listRouteHandlerRegistries).forEach((reg: any) => {
         reg.dumpHandlers();
       });
     });
   }
 
+  /**
+   * Get a URL that can be used to navigate to a view. You'll typically want to use this to set the href of an element or similar. Returns the encoded URL string.
+   *
+   * @param routeID A route specifying where the link should navigate the user to. This should either be a routeID registered with {@link Router#handleCustomRoute} or {@link Router#handleCustomListRoute}, or a value from {@link Router#NativeRouteIDs}.
+   * @param params an object containing the parameters that will be encoded in the link and decoded when the user subsequently visits the route. Handlers for the specified routeID will receive a copy of this object. This object must contain only simple key value pairs with no nested arrays/objects.
+   */
   createLink(
     routeID: string,
     params?: (RouteParams | null | undefined) | string,
   ): string {
-    return get(memberMap, this).driver.createLink(routeID, params);
+    return this.#driver.createLink(routeID, params);
   }
 
+  /**
+   * Change the route to be the one with the given ID and have the given parameters.
+   * @param routeID A route specifying where the link should navigate the user to. This should either be a routeID registered with {@link Router#handleCustomRoute} or {@link Router#handleCustomListRoute} a value from {@link Router#NativeRouteIDs}, or a value previously returned by {@link Router#createLink}. If it's a value previously returned by {@link Router#createLink} then the params argument must be omitted.
+   * @param params an object containing the parameters that will be encoded in the link and decoded when the user subsequently visits the route. Handlers for the specified routeID will receive a copy of this object. This object must contain only simple key value pairs with no nested arrays/objects.
+   */
   goto(
     routeID: string,
     params?: (RouteParams | null | undefined) | string,
@@ -86,7 +97,7 @@ class Router {
       throw new Error('routeID must be a string');
     }
 
-    const { driver } = get(memberMap, this);
+    const driver = this.#driver;
 
     if (typeof params === 'string') {
       driver
@@ -100,19 +111,23 @@ class Router {
     return driver.goto(routeID, params);
   }
 
+  /**
+   * Registers a handler (callback) to be called when the user navigates to a custom route which matches the routeID you provide. Use this to create your own routes (pages) with your own custom content. Your callback will be passed an instance of a {@link CustomRouteView} whose contents you may modify.
+   * @param routeID which route this handler is registering for
+   * @param handler The callback to call when the route changes to a custom route matching the provided routeID
+   * @returns a function which removes the handler registration.
+   */
   handleCustomRoute(
     routeID: string,
-    handler: HandlerRegistry<CustomRouteView>,
+    handler: Handler<CustomRouteView>,
   ): () => void {
     const customRouteDescriptor = {
       routeID: routeID,
       onActivate: handler,
     };
-    const removeCustomRouteFromDriver = get(
-      memberMap,
-      this,
-    ).driver.addCustomRouteID(routeID);
-    const { customRoutes, driver } = get(memberMap, this);
+    const removeCustomRouteFromDriver = this.#driver.addCustomRouteID(routeID);
+    const customRoutes = this.#customRoutes;
+    const driver = this.#driver;
     customRoutes.push(customRouteDescriptor);
     driver.getLogger().eventSdkPassive('Router.handleCustomRoute');
     return function () {
@@ -125,17 +140,33 @@ class Router {
     };
   }
 
+  /**
+   * Registers a handler (callback) to be called when the user navigates to any route (both customs and built in routes). Because this can apply to any route, your callback will be given only a generic RouteView. This is typically used when you want to monitor for page changes but don't necessarily need to modify the page.
+   * @param handler The callback to call when the route changes
+   * @returns a function which removes the handler registration.
+   */
   handleAllRoutes(handler: Handler<any>): () => void {
-    return get(memberMap, this).allRoutesHandlerRegistry.registerHandler(
-      handler,
-    );
+    return this.#allRoutesHandlerRegistry.registerHandler(handler);
   }
 
+  /**
+   * Registers a handler (callback) to be called when the user navigates to a list route which matches the routeID you provide. Gmail have several built in routes which are "Lists". These include routes like Inbox, All Mail, Sent, Drafts, etc. You'll typically use this to modify Gmail's built in List routes.
+   * @param routeID which list route this handler is registering for.
+   * @param handler The callback to call when the route changes to a list route matching the routeId.
+   * @returns a function which removes the handler registration.
+   *
+   * @example
+   *
+   * ```javascript
+   * sdk.Router.handleListRoute(sdk.Router.NativeRouteIDs.INBOX, (listRouteView) => {
+   * ```
+});
+   */
   handleListRoute(
     routeID: string,
     handler: Handler<ListRouteView>,
   ): () => void {
-    const { listRouteHandlerRegistries } = get(memberMap, this);
+    const listRouteHandlerRegistries = this.#listRouteHandlerRegistries;
 
     if (!listRouteHandlerRegistries[routeID]) {
       throw new Error('Invalid routeID specified');
@@ -144,97 +175,100 @@ class Router {
     return listRouteHandlerRegistries[routeID].registerHandler(handler);
   }
 
+  /**
+   * Used to create a custom view that shows a list of threads. When the user navigates to the given routeID, the handler function will be called. The handler function will be passed the starting offset (if the user sees 50 threads per page and is on page 2, then the offset will be 50), and a maximum number of threads to return. It must return a CustomListDescriptor, or a promise which resolves to one.
+   * @param routeID  Which route this handler is registering for.
+   * @param handler Passed a page offset and a maximum number of threads to return. Must return a CustomListDescriptor, or a promise which resolves to one.
+   * @returns a function which removes the handler registration.
+   */
   handleCustomListRoute(
     routeID: string,
     handler: (...args: Array<any>) => any,
   ): () => void {
-    return get(memberMap, this).driver.addCustomListRouteID(routeID, handler);
+    return this.#driver.addCustomListRouteID(routeID, handler);
   }
 
+  /**
+   * @returns a RouteView of the current route view
+   */
   getCurrentRouteView(): RouteView {
-    const members = get(memberMap, this);
-    return members.membrane.get(members.currentRouteViewDriver);
-  }
-}
-
-function _handleRouteViewChange(
-  router: Router,
-  members: Members,
-  routeViewDriver: RouteViewDriver,
-) {
-  if (members.currentRouteViewDriver instanceof DummyRouteViewDriver) {
-    members.currentRouteViewDriver.destroy();
+    return this.#membrane.get(this.#currentRouteViewDriver);
   }
 
-  members.currentRouteViewDriver = routeViewDriver;
-  const routeView = members.membrane.get(routeViewDriver);
-
-  _updateNavMenu(members, routeViewDriver);
-
-  if (routeView.getRouteType() === ROUTE_TYPES.CUSTOM) {
-    _informRelevantCustomRoutes(members, routeViewDriver, routeView);
-  }
-
-  members.allRoutesHandlerRegistry.addTarget(routeView);
-
-  if (routeView.getRouteType() === ROUTE_TYPES.LIST) {
-    const listRouteView = new ListRouteView(
-      routeViewDriver,
-      members.driver,
-      members.appId,
-    );
-    const listRouteHandlerRegistry =
-      members.listRouteHandlerRegistries[routeView.getRouteID()];
-
-    if (listRouteHandlerRegistry) {
-      listRouteHandlerRegistry.addTarget(listRouteView);
+  #handleRouteViewChange(routeViewDriver: RouteViewDriver) {
+    if (this.#currentRouteViewDriver instanceof DummyRouteViewDriver) {
+      this.#currentRouteViewDriver.destroy();
     }
 
-    members.listRouteHandlerRegistries[NATIVE_ROUTE_IDS.ANY_LIST].addTarget(
-      listRouteView,
-    );
-  }
-}
+    this.#currentRouteViewDriver = routeViewDriver;
+    const routeView = this.#membrane.get(routeViewDriver);
 
-function _informRelevantCustomRoutes(
-  members: Members,
-  routeViewDriver: RouteViewDriver,
-  routeView: RouteView,
-) {
-  const routeID = routeView.getRouteID();
-  const routeIDArray = Array.isArray(routeID) ? routeID : [routeID];
-  const relevantCustomRoute = find(
-    members.customRoutes,
-    (customRoute) =>
-      intersection(
-        Array.isArray(customRoute.routeID)
-          ? customRoute.routeID
-          : [customRoute.routeID],
-        routeIDArray,
-      ).length,
-  );
+    this.#updateNavMenu(routeViewDriver);
 
-  if (relevantCustomRoute) {
-    const customRouteView = new CustomRouteView(routeViewDriver);
-    const customViewElement = routeViewDriver.getCustomViewElement();
-    if (!customViewElement) throw new Error('should not happen');
-    members.driver.showCustomRouteView(customViewElement);
+    if (routeView.getRouteType() === ROUTE_TYPES.CUSTOM) {
+      this.#informRelevantCustomRoutes(routeViewDriver, routeView);
+    }
 
-    try {
-      (relevantCustomRoute as any).onActivate(customRouteView);
-    } catch (err) {
-      members.driver.getLogger().error(err);
+    this.#allRoutesHandlerRegistry.addTarget(routeView);
+
+    if (routeView.getRouteType() === ROUTE_TYPES.LIST) {
+      const listRouteView = new ListRouteView(
+        routeViewDriver,
+        this.#driver,
+        this.#appId,
+      );
+      const listRouteHandlerRegistry =
+        this.#listRouteHandlerRegistries[routeView.getRouteID()];
+
+      if (listRouteHandlerRegistry) {
+        listRouteHandlerRegistry.addTarget(listRouteView);
+      }
+
+      this.#listRouteHandlerRegistries[NATIVE_ROUTE_IDS.ANY_LIST].addTarget(
+        listRouteView,
+      );
     }
   }
-}
 
-function _updateNavMenu(members: Members, newRouteViewDriver: RouteViewDriver) {
-  members.driver.setShowNativeNavMarker(
-    newRouteViewDriver.getType() !== ROUTE_TYPES.CUSTOM,
-  );
-  members.driver.setShowNativeAddonSidebar(
-    newRouteViewDriver.getType() !== ROUTE_TYPES.CUSTOM,
-  );
+  #informRelevantCustomRoutes(
+    routeViewDriver: RouteViewDriver,
+    routeView: RouteView,
+  ) {
+    const routeID = routeView.getRouteID();
+    const routeIDArray = Array.isArray(routeID) ? routeID : [routeID];
+    const relevantCustomRoute = find(
+      this.#customRoutes,
+      (customRoute) =>
+        intersection(
+          Array.isArray(customRoute.routeID)
+            ? customRoute.routeID
+            : [customRoute.routeID],
+          routeIDArray,
+        ).length,
+    );
+
+    if (relevantCustomRoute) {
+      const customRouteView = new CustomRouteView(routeViewDriver);
+      const customViewElement = routeViewDriver.getCustomViewElement();
+      if (!customViewElement) throw new Error('should not happen');
+      this.#driver.showCustomRouteView(customViewElement);
+
+      try {
+        (relevantCustomRoute as any).onActivate(customRouteView);
+      } catch (err) {
+        this.#driver.getLogger().error(err);
+      }
+    }
+  }
+
+  #updateNavMenu(newRouteViewDriver: RouteViewDriver) {
+    this.#driver.setShowNativeNavMarker(
+      newRouteViewDriver.getType() !== ROUTE_TYPES.CUSTOM,
+    );
+    this.#driver.setShowNativeAddonSidebar(
+      newRouteViewDriver.getType() !== ROUTE_TYPES.CUSTOM,
+    );
+  }
 }
 
 export default Router;

--- a/src/platform-implementation-js/namespaces/router.ts
+++ b/src/platform-implementation-js/namespaces/router.ts
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import intersection from 'lodash/intersection';
 import HandlerRegistry from '../lib/handler-registry';
 import RouteView from '../views/route-view/route-view';
@@ -65,7 +64,7 @@ class Router {
     });
     driver.getStopper().onValue(() => {
       this.#allRoutesHandlerRegistry.dumpHandlers();
-      Object.values(this.#listRouteHandlerRegistries).forEach((reg: any) => {
+      Object.values(this.#listRouteHandlerRegistries).forEach((reg) => {
         reg.dumpHandlers();
       });
     });
@@ -236,8 +235,7 @@ class Router {
   ) {
     const routeID = routeView.getRouteID();
     const routeIDArray = Array.isArray(routeID) ? routeID : [routeID];
-    const relevantCustomRoute = find(
-      this.#customRoutes,
+    const relevantCustomRoute = this.#customRoutes.find(
       (customRoute) =>
         intersection(
           Array.isArray(customRoute.routeID)
@@ -254,7 +252,7 @@ class Router {
       this.#driver.showCustomRouteView(customViewElement);
 
       try {
-        (relevantCustomRoute as any).onActivate(customRouteView);
+        relevantCustomRoute.onActivate(customRouteView);
       } catch (err) {
         this.#driver.getLogger().error(err);
       }


### PR DESCRIPTION
This type was a remnant from when we had three parallel type definitions: Flow, our external typescript interface, and our internal typescript interface.

Addresses @amiram's [comment](https://github.com/InboxSDK/InboxSDK/issues/1161#issuecomment-2038953192). 