### PR TITLE
Fix InboxSDK loading in preloaded page in MV3 extension

### DIFF
--- a/packages/core/background.js
+++ b/packages/core/background.js
@@ -4,7 +4,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (chrome.scripting) {
       // MV3
       chrome.scripting.executeScript({
-        target: { tabId: sender.tab.id },
+        target: { tabId: sender.tab.id, frameIds: [sender.frameId] },
         world: 'MAIN',
         files: ['pageWorld.js'],
       });


### PR DESCRIPTION
I've figured out that sometimes when opening a new Gmail tab, Chrome preloads Gmail including extension content scripts before Gmail is shown, but the InboxSDK fails to initialize in this case because the extension service worker fails to inject the page-world script because the tab is still at the Chrome new tab and not Gmail. (The InboxSDK would initialize correctly if the user refreshes in the new tab.) Specifying the frame id to inject the page-world script into fixes this.