### PR TITLE
Fix npm build source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "css-loader": "^6.7.3",
     "jest-css-modules": "^2.1.0",
     "jest-environment-jsdom": "^29.5.0",
+    "source-map-loader": "^5.0.0",
     "style-loader": "^3.3.2",
     "webpack": "^5.76.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6602,7 +6602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -6783,6 +6783,7 @@ __metadata:
     simple-encryptor: "npm:^4.0.0"
     sinon: "npm:^11.1.1"
     sinon-test: "npm:^3.1.0"
+    source-map-loader: "npm:^5.0.0"
     stdio: "npm:^0.2.6"
     style-loader: "npm:^3.3.2"
     stylelint: "npm:^15.6.2"
@@ -11125,6 +11126,18 @@ __metadata:
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
   checksum: 38e2d2dd18d2e331522001fc51b54127ef4a5d473f53b1349c5cca2123562400e0986648b52e9407e348eaaed53bce49248b6e2641e6d793ca57cb2c360d6d51
+  languageName: node
+  linkType: hard
+
+"source-map-loader@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "source-map-loader@npm:5.0.0"
+  dependencies:
+    iconv-lite: "npm:^0.6.3"
+    source-map-js: "npm:^1.0.2"
+  peerDependencies:
+    webpack: ^5.72.1
+  checksum: 9bc90a50df1a3570ddc1ea9cd1aeadb241fd6f6ddb03e72a8f45f5d3fcc357e7edcc9fff8d35d2e338d17edf13c38a7b6e530308ac263d1b462a1e6bfacaf1a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. It seems like we forgot to enable sourcemaps on our production npm build. (If args.production was on, we wouldn't make source maps, and if it was off, we'd make inline source maps. I've just made it always use external source maps now. I think I might have previously configured some things to use inline source maps in dev because I wasn't sure how to make external source map files work in an MV3 extension, but I've since figured out they work fine if you list them in the manifest's web_accessible_resources, as I've updated the [hello-world example extension](https://github.com/InboxSDK/hello-world) to.) (The "integrated page world" build still uses inline source maps because the workflow it was built for involved copying the inboxsdk.js file alone around. I think that build won't be useful at all once we're fully MV3 so I'm just not touching it.)
2. We weren't using source-map-loader, so the source map comments in some of our bundled dependencies were making it into our output files and would confuse the browser. (Ideally we wouldn't bundle dependencies or anything and wouldn't need to use source-map-loader, but I just want to fix one thing at a time here.)

I've tested with https://github.com/InboxSDK/hello-world that the InboxSDK source maps work now.