### PR TITLE
chore: bringing back getDownloadUrl on AttachmentCardView since google inbox is gone

### DIFF
--- a/src/platform-implementation-js/views/conversations/attachment-card-view.ts
+++ b/src/platform-implementation-js/views/conversations/attachment-card-view.ts
@@ -44,21 +44,7 @@ export default class AttachmentCardView extends (EventEmitter as new () => Typed
     return this.#attachmentCardImplementation.getTitle();
   }
 
-  /**
-   * @deprecated  Please use the same-named method on the AttachmentCardClickEvent object instead.
-   */
   getDownloadURL(): Promise<string | null | undefined> {
-    this.#driver
-      .getLogger()
-      .deprecationWarning(
-        'AttachmentCardView.getDownloadURL',
-        'AttachmentCardView.addButton -> onClick -> AttachmentCardClickEvent',
-      );
-
-    if (this.#driver.getOpts().REQUESTED_API_VERSION !== 1) {
-      throw new Error('This method was discontinued after API version 1');
-    }
-
     return this.#attachmentCardImplementation.getDownloadURL();
   }
 


### PR DESCRIPTION
`getDownloadURL` was removed from AttachmentCardView here: https://github.com/InboxSDK/InboxSDK/commit/c43493ebc71ce86f303ad14e990dc880ea9a4fda

but this was done for google inbox, which isn't present now, so we discussed this if we could bring it back, discussion link: https://github.com/InboxSDK/InboxSDK/issues/794#issuecomment-1279060304