### PR TITLE
chore: build examples like InboxSDK/hello-world

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,21 @@ jobs:
       - run:
           name: Clean
           command: yarn gulp clean
+  'build inboxsdk core examples':
+    executor: sdk
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn-berry
+      - run:
+          name: Build
+          command: yarn gulp --examples
+      - run:
+          name: Check output files exist
+          command: ls packages/app-menu/dist/content.js
+      - run:
+          name: Clean
+          command: yarn gulp clean
   # MV2 Remote Build
   'build REMOTE':
     executor: sdk
@@ -95,6 +110,10 @@ jobs:
       - checkout
       - node/install-packages:
           pkg-manager: yarn-berry
+
+      - run:
+          name: Build
+          command: yarn gulp
       - run:
           name: Typecheck (tsc)
           command: yarn tsc

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,9 @@
 /node_modules
 /dist
 /coverage
-/examples/*/inboxsdk.js*
+/examples/*/dist/
 /examples/*/pageWorld.js*
 /examples/*/background.js*
-/examples/*/platform-implementation.js*
 *~
 npm-debug.log
 yarn-debug.log

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ feature themselves.
 # Development Cycle Essentials
 
 Run `yarn` to install the necessary dependencies, and run `yarn start` to start
-the automatic builder. Then load `examples/hello-world/` as an unpacked
-extension into Google Chrome.
+the automatic builder. Then load `examples/app-menu/` as an unpacked extension
+into Google Chrome.
 
 The
 [Chrome Extensions Reloader](https://chrome.google.com/webstore/detail/extensions-reloader/fimgfedafeadlieiabdeeaodndnlbhid)

--- a/examples/Basic InboxSDK.safariextension/Info.plist
+++ b/examples/Basic InboxSDK.safariextension/Info.plist
@@ -24,7 +24,7 @@
 			<array>
 				<string>inboxsdk.js</string>
 				<string>kefir.js</string>
-				<string>content.js</string>
+				<string>dist/content.js</string>
 			</array>
 		</dict>
 		<key>Whitelist</key>

--- a/examples/add-route-view-sections/content.js
+++ b/examples/add-route-view-sections/content.js
@@ -1,4 +1,4 @@
-'use strict';
+import * as InboxSDK from '@inboxsdk/core';
 
 InboxSDK.load(1.0, 'route-view-sections-example').then(function (inboxSDK) {
   window._sdk = inboxSDK;

--- a/examples/add-route-view-sections/manifest.json
+++ b/examples/add-route-view-sections/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "bacon.js", "content.js"],
+      "js": ["bacon.js", "dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,13 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "monkey-face.jpg", "lion.png", "monkey.png"]
+      "resources": [
+        "pageWorld.js",
+        "monkey-face.jpg",
+        "lion.png",
+        "monkey.png",
+        "*.map"
+      ]
     }
   ],
   "background": {

--- a/examples/app-menu/content.ts
+++ b/examples/app-menu/content.ts
@@ -1,11 +1,13 @@
-/// <reference path="../types.d.ts" />
+import * as InboxSDK from '@inboxsdk/core';
 
-function log() {
-  console.log(...['app-menu'].concat(arguments));
+function log(...args: any[]) {
+  console.log(...['app-menu'].concat(args));
 }
 
+var chrome = (globalThis as any).chrome
+
 InboxSDK.load(2, 'app-menu').then(async (sdk) => {
-  var appendStylesheet = function (url) {
+  var appendStylesheet = function (url: string) {
     const css =
       '.inboxsdk__button_icon.bentoBoxIndicator { background: transparent url(https://assets.streak.com/clientjs-commit-builds/assets/pipelineIndicator.ebfc97a74f09365a433e8537ff414815.png) no-repeat; height: 18px; width: 18px; }';
     const head = document.head || document.getElementsByTagName('head')[0];
@@ -76,15 +78,15 @@ InboxSDK.load(2, 'app-menu').then(async (sdk) => {
         lightTheme: chrome.runtime.getURL('monkey-face.jpg'),
       },
     }),
-    panel1 = await customItem1.addCollapsiblePanel({
+    panel1 = (await customItem1.addCollapsiblePanel({
       // title: 'Lion panel',
       primaryButton: {
         name: 'Lion panel',
         onClick: () => alert('clicked custom panel 1'),
         iconUrl: { lightTheme: chrome.runtime.getURL('lion.png') },
       },
-    }),
-    panel2 = await customItem2.addCollapsiblePanel({
+    }))!,
+    panel2 = (await customItem2.addCollapsiblePanel({
       loadingIcon: `<div>
         Slow loading...20s&nbsp;
         <img src="${chrome.runtime.getURL(
@@ -96,12 +98,12 @@ InboxSDK.load(2, 'app-menu').then(async (sdk) => {
         onClick: () => alert('clicked custom panel 2'),
         iconUrl: { lightTheme: chrome.runtime.getURL('monkey.png') },
       },
-    });
+    }))!;
 
   panel2.setLoading(true);
 
   // Simulate very slow loading.
-  new Promise((resolve) => {
+  new Promise<void>((resolve) => {
     setTimeout(() => {
       resolve();
     }, 20_000);
@@ -115,7 +117,7 @@ InboxSDK.load(2, 'app-menu').then(async (sdk) => {
   });
 
   sdk.AppMenu.events
-    .filter((event) => event.type === 'collapseToggled')
+    .filter((event) => event.name === 'collapseToggled')
     .onValue((event) => {
       console.log('collapseToggled', event);
     });

--- a/examples/app-menu/manifest.json
+++ b/examples/app-menu/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,13 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "monkey-face.jpg", "monkey.png", "lion.png"]
+      "resources": [
+        "pageWorld.js",
+        "monkey-face.jpg",
+        "monkey.png",
+        "lion.png",
+        "*.map"
+      ]
     }
   ],
   "background": {

--- a/examples/attachment-card/content.js
+++ b/examples/attachment-card/content.js
@@ -1,4 +1,4 @@
-/// <reference path="../types.d.ts" />
+import * as InboxSDK from '@inboxsdk/core';
 
 function kefirStopper() {
   var emitter = null;

--- a/examples/attachment-card/manifest.json
+++ b/examples/attachment-card/manifest.json
@@ -8,8 +8,8 @@
         "kefir.min.js",
         "react.production.min.js",
         "react-dom.production.min.js",
-        "inboxsdk.js",
-        "content.js"
+
+        "dist/content.js"
       ],
       "css": ["app.css"],
       "run_at": "document_end"
@@ -19,7 +19,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "partycat.jpg", "zipicon.png"]
+      "resources": ["pageWorld.js", "partycat.jpg", "zipicon.png", "*.map"]
     }
   ],
   "background": {

--- a/examples/browser-test/content.js
+++ b/examples/browser-test/content.js
@@ -1,4 +1,4 @@
-'use strict';
+import * as InboxSDK from '@inboxsdk/core';
 
 function setupErrorTracking() {
   // Make a "_errors" global in the page's execution context that puppeteer can access.

--- a/examples/browser-test/manifest.json
+++ b/examples/browser-test/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_start"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "monkey.png"]
+      "resources": ["pageWorld.js", "monkey.png", "*.map"]
     }
   ],
   "background": {

--- a/examples/build.ts
+++ b/examples/build.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import esbuild from 'esbuild';
+
+type BuildConfig = Parameters<typeof esbuild.build>[0];
+type Watcher = ReturnType<typeof esbuild.context>;
+
+let watchingContentScripts: undefined | Watcher;
+let watchingSdkOutput: undefined | Watcher;
+const TIMING_LABEL = 'building ./examples took';
+
+const buildSdkFiles = ['@inboxsdk/core/pageWorld', '@inboxsdk/core/background'];
+
+// for each folder in examples, build and output the example with esbuild
+export async function buildExamples({
+  contentScriptFps,
+  minify,
+  watch,
+}: {
+  contentScriptFps: string[];
+  minify: boolean;
+  watch: boolean;
+}) {
+  console.time(TIMING_LABEL);
+
+  const sharedConfig: BuildConfig = {
+    define: {
+      // closest-ng depends on node `global`.
+      global: 'globalThis',
+    },
+    entryNames: '[name]',
+    bundle: true,
+    loader: {
+      '.tsx': 'tsx',
+      '.ts': 'ts',
+      '.js': 'js',
+    },
+    tsconfig: './tsconfig.json',
+    platform: 'browser',
+    sourcemap: 'linked',
+    target: 'es2022',
+    minify,
+  };
+
+  await fs.mkdir('examples/dist', { recursive: true });
+
+  const sdkBuildConfig: BuildConfig = {
+    ...sharedConfig,
+    entryPoints: buildSdkFiles,
+    outbase: '',
+    outdir: 'examples/dist',
+  };
+
+  const sdkFileBuild = watchOrBuild({
+    awaitRebuild: true,
+    config: sdkBuildConfig,
+    state: watchingSdkOutput,
+    watch,
+  });
+
+  const copyingFiles = contentScriptFps.map((examplePath) => {
+    (async () => {
+      await sdkFileBuild;
+      const dirname = path.dirname(examplePath);
+      return fs.cp('examples/dist', dirname, {
+        force: true,
+        // This key doesn't exist in @types/node@18 (but does in @types/node@20)
+        ...{ mode: fs.constants.COPYFILE_FICLONE },
+        preserveTimestamps: true,
+        recursive: true,
+      });
+    })();
+  });
+
+  const contentScriptOpts = {
+    ...sharedConfig,
+    entryPoints: contentScriptFps,
+    entryNames: '[dir]/dist/[name]',
+    outdir: 'examples',
+  } as const;
+
+  const contentScriptBuild = await watchOrBuild({
+    config: contentScriptOpts,
+    awaitRebuild: false,
+    state: watchingContentScripts,
+    watch,
+  });
+
+  await Promise.all([sdkFileBuild, ...copyingFiles, contentScriptBuild]);
+  console.timeEnd(TIMING_LABEL);
+}
+
+async function watchOrBuild({
+  awaitRebuild,
+  config,
+  state,
+  watch,
+}: {
+  awaitRebuild: boolean;
+  config: BuildConfig;
+  state: Promise<esbuild.BuildContext<esbuild.BuildOptions>> | undefined;
+  watch: boolean;
+}) {
+  if (watch) {
+    const watcher = await state;
+    if (watcher == null) {
+      state = esbuild.context({
+        logLevel: 'info',
+        ...config,
+      });
+
+      (await state).watch();
+    } else {
+      if (awaitRebuild) {
+        await watcher.cancel();
+        await watcher.rebuild();
+      }
+    }
+  } else {
+    await esbuild.build(config);
+  }
+}

--- a/examples/compose-dropdown-button/content.js
+++ b/examples/compose-dropdown-button/content.js
@@ -1,3 +1,5 @@
+import * as InboxSDK from '@inboxsdk/core';
+
 InboxSDK.load(1, 'simple-example', {
   iconImageUrl: chrome.runtime.getURL('monkey.png'),
 }).then(function (inboxSDK) {

--- a/examples/compose-dropdown-button/manifest.json
+++ b/examples/compose-dropdown-button/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "css": ["content.css"],
       "run_at": "document_end"
     }
@@ -14,7 +14,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "monkey.png"]
+      "resources": ["pageWorld.js", "monkey.png", "*.map"]
     }
   ],
   "background": {

--- a/examples/compose-stream/content.js
+++ b/examples/compose-stream/content.js
@@ -1,5 +1,4 @@
-/// <reference path="../types.d.ts" />
-'use strict';
+import * as InboxSDK from '@inboxsdk/core';
 
 InboxSDK.load(2, 'compose-stream-example').then((inboxSDK) => {
   window._sdk = inboxSDK;

--- a/examples/compose-stream/manifest.json
+++ b/examples/compose-stream/manifest.json
@@ -6,7 +6,7 @@
     {
       "matches": ["https://mail.google.com/*"],
       "css": ["content.css"],
-      "js": ["inboxsdk.js", "bacon.js", "content.js"],
+      "js": ["bacon.js", "dist/content.js"],
       "run_at": "document_start"
     }
   ],
@@ -14,7 +14,13 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "monkey.png", "monkey-face.jpg", "lion.png"]
+      "resources": [
+        "pageWorld.js",
+        "monkey.png",
+        "monkey-face.jpg",
+        "lion.png",
+        "*.map"
+      ]
     }
   ],
   "background": {

--- a/examples/compose-tooltip-button/content.js
+++ b/examples/compose-tooltip-button/content.js
@@ -1,4 +1,4 @@
-/// <reference path="../types.d.ts" />
+import * as InboxSDK from '@inboxsdk/core';
 
 InboxSDK.load(2, 'simple-example').then(function (inboxSDK) {
   inboxSDK.Compose.registerComposeViewHandler(function (composeView) {

--- a/examples/compose-tooltip-button/manifest.json
+++ b/examples/compose-tooltip-button/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "css": ["content.css"],
       "run_at": "document_end"
     }
@@ -14,7 +14,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "monkey.png", "partycat.jpg"]
+      "resources": ["pageWorld.js", "monkey.png", "partycat.jpg", "*.map"]
     }
   ],
   "background": {

--- a/examples/contact-hover-example/app.js
+++ b/examples/contact-hover-example/app.js
@@ -1,3 +1,5 @@
+import * as InboxSDK from '@inboxsdk/core';
+
 InboxSDK.load(1, 'contact-hover-example').then(function(sdk){
 
   window._sdk = sdk;

--- a/examples/contact-hover-example/manifest.json
+++ b/examples/contact-hover-example/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "app.js"],
+      "js": ["app.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["monkey-face.jpg", "pageWorld.js"]
+      "resources": ["monkey-face.jpg", "pageWorld.js", "*.map"]
     }
   ],
   "background": {

--- a/examples/custom-thread-list/content.js
+++ b/examples/custom-thread-list/content.js
@@ -1,3 +1,5 @@
+import * as InboxSDK from '@inboxsdk/core';
+
 function log() {
   console.log.apply(
     console,

--- a/examples/custom-thread-list/manifest.json
+++ b/examples/custom-thread-list/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["monkey-face.jpg", "pageWorld.js"]
+      "resources": ["monkey-face.jpg", "pageWorld.js", "*.map"]
     }
   ],
   "background": {

--- a/examples/custom-view/content.js
+++ b/examples/custom-view/content.js
@@ -1,3 +1,5 @@
+import * as InboxSDK from '@inboxsdk/core';
+
 function log() {
   console.log.apply(
     console,

--- a/examples/custom-view/manifest.json
+++ b/examples/custom-view/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,13 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "monkey-face.jpg", "lion.png", "monkey.png"]
+      "resources": [
+        "pageWorld.js",
+        "monkey-face.jpg",
+        "lion.png",
+        "monkey.png",
+        "*.map"
+      ]
     }
   ],
   "background": {

--- a/examples/header-support/content.js
+++ b/examples/header-support/content.js
@@ -1,3 +1,5 @@
+import * as InboxSDK from '@inboxsdk/core';
+
 InboxSDK.load(2, 'header support button').then(function (sdk) {
   window._sdk = sdk;
 

--- a/examples/header-support/manifest.json
+++ b/examples/header-support/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js"]
+      "resources": ["pageWorld.js", "*.map"]
     }
   ],
   "background": {

--- a/examples/hello-world/content.js
+++ b/examples/hello-world/content.js
@@ -1,3 +1,5 @@
+import * as InboxSDK from '@inboxsdk/core';
+
 InboxSDK.load(2, 'Hello World!').then(function (sdk) {
   sdk.Router.handleAllRoutes(function (routeView) {
     console.log('got a routeView', routeView);

--- a/examples/hello-world/manifest.json
+++ b/examples/hello-world/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js"]
+      "resources": ["pageWorld.js", "*.map"]
     }
   ],
   "background": {

--- a/examples/link-popovers/content.js
+++ b/examples/link-popovers/content.js
@@ -1,3 +1,5 @@
+import * as InboxSDK from '@inboxsdk/core';
+
 InboxSDK.load(2, 'popover-example').then(function (sdk) {
   sdk.Compose.registerComposeViewHandler(function (composeView) {
     // Watch for gmail's link popover to appear

--- a/examples/link-popovers/manifest.json
+++ b/examples/link-popovers/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js"]
+      "resources": ["pageWorld.js", "*.map"]
     }
   ],
   "background": {

--- a/examples/modal-example/content.js
+++ b/examples/modal-example/content.js
@@ -1,6 +1,4 @@
-/// <reference path="../types.d.ts" />
-
-'use strict';
+import * as InboxSDK from '@inboxsdk/core';
 
 var div = document.createElement('div');
 div.style.width = '800px';

--- a/examples/modal-example/manifest.json
+++ b/examples/modal-example/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js"]
+      "resources": ["pageWorld.js", "*.map"]
     }
   ],
   "background": {

--- a/examples/mole-example/content.js
+++ b/examples/mole-example/content.js
@@ -1,6 +1,4 @@
-/// <reference path="../types.d.ts" />
-
-'use strict';
+import * as InboxSDK from '@inboxsdk/core';
 
 InboxSDK.load(2, 'simple-example').then(function (inboxSDK) {
   let i = 0;

--- a/examples/mole-example/manifest.json
+++ b/examples/mole-example/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -15,7 +15,12 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["inboxsdk.js.map", "pageWorld.js", "pageWorld.js.map"]
+      "resources": [
+        "inboxsdk.js.map",
+        "pageWorld.js",
+        "pageWorld.js.map",
+        "*.map"
+      ]
     }
   ],
   "background": {

--- a/examples/nav-menu/content.js
+++ b/examples/nav-menu/content.js
@@ -1,3 +1,5 @@
+import * as InboxSDK from '@inboxsdk/core';
+
 function log() {
   console.log.apply(
     console,

--- a/examples/nav-menu/manifest.json
+++ b/examples/nav-menu/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "monkey-face.jpg"]
+      "resources": ["pageWorld.js", "monkey-face.jpg", "*.map"]
     }
   ],
   "background": {

--- a/examples/open-compose/content.js
+++ b/examples/open-compose/content.js
@@ -1,3 +1,5 @@
+import * as InboxSDK from '@inboxsdk/core';
+
 InboxSDK.load(1, 'open-compose').then(function (inboxSDK) {
   inboxSDK.Compose.getComposeView().then(function (composeView) {
     composeView.setToRecipients(['oismail@gmail.com']);

--- a/examples/open-compose/manifest.json
+++ b/examples/open-compose/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js"]
+      "resources": ["pageWorld.js", "*.map"]
     }
   ],
   "background": {

--- a/examples/override-edit-subject/content.js
+++ b/examples/override-edit-subject/content.js
@@ -1,3 +1,5 @@
+import * as InboxSDK from '@inboxsdk/core';
+
 InboxSDK.load(1, 'simple-example', {}).then(function (inboxSDK) {
   inboxSDK.Compose.registerComposeViewHandler(function (composeView) {
     window.composeView = composeView;

--- a/examples/override-edit-subject/manifest.json
+++ b/examples/override-edit-subject/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "monkey.png", "partycat.jpg"]
+      "resources": ["pageWorld.js", "monkey.png", "partycat.jpg", "*.map"]
     }
   ],
   "background": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@inboxsdk/examples",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@inboxsdk/core": "workspace:*",
+    "esbuild": "^0.20.2"
+  }
+}

--- a/examples/search-results/content.js
+++ b/examples/search-results/content.js
@@ -1,4 +1,4 @@
-/// <reference path="../types.d.ts" />
+import * as InboxSDK from '@inboxsdk/core';
 
 InboxSDK.load(1.0, 'search-example').then(function (inboxSDK) {
   inboxSDK.Router.handleListRoute(

--- a/examples/search-results/manifest.json
+++ b/examples/search-results/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,13 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "monkey-face.jpg", "lion.png", "monkey.png"]
+      "resources": [
+        "pageWorld.js",
+        "monkey-face.jpg",
+        "lion.png",
+        "monkey.png",
+        "*.map"
+      ]
     }
   ],
   "background": {

--- a/examples/search-suggestions/content.js
+++ b/examples/search-suggestions/content.js
@@ -1,4 +1,4 @@
-'use strict';
+import * as InboxSDK from '@inboxsdk/core';
 
 function log(...args) {
   console.log('search-suggestions', ...args);

--- a/examples/search-suggestions/manifest.json
+++ b/examples/search-suggestions/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js"]
+      "resources": ["pageWorld.js", "*.map"]
     }
   ],
   "background": {

--- a/examples/search-term/content.js
+++ b/examples/search-term/content.js
@@ -1,3 +1,5 @@
+import * as InboxSDK from '@inboxsdk/core';
+
 function log() {
   console.log.apply(
     console,

--- a/examples/search-term/manifest.json
+++ b/examples/search-term/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "Bacon.min.js", "content.js"],
+      "js": ["Bacon.min.js", "dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js"]
+      "resources": ["pageWorld.js", "*.map"]
     }
   ],
   "background": {

--- a/examples/sidebar-contact-example/content.js
+++ b/examples/sidebar-contact-example/content.js
@@ -1,3 +1,5 @@
+import * as InboxSDK from '@inboxsdk/core';
+
 InboxSDK.load(2, 'sidebar-contact-example').then(function (sdk) {
   window._sdk = sdk;
 

--- a/examples/sidebar-contact-example/manifest.json
+++ b/examples/sidebar-contact-example/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js"]
+      "resources": ["pageWorld.js", "*.map"]
     }
   ],
   "background": {

--- a/examples/sidebar-example/content.js
+++ b/examples/sidebar-example/content.js
@@ -1,4 +1,4 @@
-'use strict';
+import * as InboxSDK from '@inboxsdk/core';
 
 InboxSDK.load(2, 'sidebar-example', {
   appName: 'Twitter',

--- a/examples/sidebar-example/manifest.json
+++ b/examples/sidebar-example/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "bacon.js", "content.js"],
+      "js": ["bacon.js", "dist/content.js"],
       "css": ["extension.css"],
       "run_at": "document_end"
     }
@@ -14,7 +14,13 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "monkey.png", "monkey-face.jpg", "lion.png"]
+      "resources": [
+        "pageWorld.js",
+        "monkey.png",
+        "monkey-face.jpg",
+        "lion.png",
+        "*.map"
+      ]
     }
   ],
   "background": {

--- a/examples/thread-rows/content.js
+++ b/examples/thread-rows/content.js
@@ -1,4 +1,4 @@
-/// <reference path="../types.d.ts" />
+import * as InboxSDK from '@inboxsdk/core';
 
 function log() {
   console.log.apply(

--- a/examples/thread-rows/manifest.json
+++ b/examples/thread-rows/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "kefir.js", "content.js"],
+      "js": ["kefir.js", "dist/content.js"],
       "css": ["content.css"],
       "run_at": "document_start"
     }
@@ -14,7 +14,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js"]
+      "resources": ["pageWorld.js", "*.map"]
     }
   ],
   "background": {

--- a/examples/thread-test/content.js
+++ b/examples/thread-test/content.js
@@ -1,4 +1,4 @@
-/// <reference path="../types.d.ts" />
+import * as InboxSDK from '@inboxsdk/core';
 
 function addCustomMessage(sortDate) {
   const collapsedEl = document.createElement('div');

--- a/examples/thread-test/manifest.json
+++ b/examples/thread-test/manifest.json
@@ -6,7 +6,7 @@
     {
       "matches": ["https://mail.google.com/*"],
       "css": [],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_start"
     }
   ],
@@ -14,7 +14,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js"]
+      "resources": ["pageWorld.js", "*.map"]
     }
   ],
   "background": {

--- a/examples/toolbar-button/content.js
+++ b/examples/toolbar-button/content.js
@@ -1,4 +1,4 @@
-'use strict';
+import * as InboxSDK from '@inboxsdk/core';
 
 InboxSDK.load(1, 'toolbar-example', {
   appIconUrl: chrome.runtime.getURL('monkey.png'),

--- a/examples/toolbar-button/manifest.json
+++ b/examples/toolbar-button/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["inboxsdk.js", "content.js"],
+      "js": ["dist/content.js"],
       "run_at": "document_end"
     }
   ],
@@ -13,7 +13,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://mail.google.com/*"],
-      "resources": ["pageWorld.js", "monkey.png"]
+      "resources": ["pageWorld.js", "monkey.png", "*.map"]
     }
   ],
   "background": {

--- a/examples/types.d.ts
+++ b/examples/types.d.ts
@@ -1,7 +1,0 @@
-import { InboxSDK as InboxSDK_ } from '../src/inboxsdk';
-
-declare global {
-  var InboxSDK: {
-    load(version: string, moduleName: string): Promise<InboxSDK_>;
-  };
-}

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "@babel/node": "^7.22.19",
     "@babel/plugin-transform-runtime": "^7.22.15",
     "@babel/preset-env": "^7.22.20",
-    "@babel/preset-flow": "^7.22.15",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
     "@babel/register": "^7.22.15",
+    "@inboxsdk/examples": "workspace:*",
     "@macil/simple-base-converter": "^1.0.0",
     "@types/asap": "^2.0.0",
     "@types/classnames": "^2.2.8",
@@ -113,7 +113,7 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "puppeteer": "jest -c test/chrome/jest.config.js --runInBand",
-    "start": "gulp default -w --reloader",
+    "start": "gulp default -w --reloader --examples",
     "test": "jest"
   },
   "lint-staged": {
@@ -121,6 +121,7 @@
   },
   "version": "0.7.25",
   "workspaces": [
+    "examples",
     "packages/*"
   ],
   "packageManager": "yarn@4.0.1",

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -208,9 +208,7 @@ const GmailElementGetter = {
   },
 
   isAppBurgerMenuOpen() {
-    return (
-      this.getAppBurgerMenu()?.getAttribute('aria-expanded') === 'true' ?? false
-    );
+    return this.getAppBurgerMenu()?.getAttribute('aria-expanded') === 'true';
   },
 
   getAppMenuContainer() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,17 +480,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-flow@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/plugin-syntax-flow@npm:7.22.5"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.22.5"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 84c8c40fcfe8e78cecdd6fb90e8f97f419e3f3b27a33de8324ae97d5ce1b87cdd98a636fa21a68d4d2c37c7d63f3a279bb84b6956b849921affed6b806b6ffe7
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-syntax-import-assertions@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-syntax-import-assertions@npm:7.22.5"
@@ -840,18 +829,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 73af5883a321ed56a4bfd43c8a7de0164faebe619287706896fc6ee2f7a4e69042adaa1338c0b8b4bdb9f7e5fdceb016fb1d40694cb43ca3b8827429e8aac4bf
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-flow-strip-types@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/plugin-transform-flow-strip-types@npm:7.22.5"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.22.5"
-    "@babel/plugin-syntax-flow": "npm:^7.22.5"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 0657042178061517cd5641a9a5eed1251aa1d8cf93a4111568ae663773854a1e8f6af167ecae042237d261389751dc5ee32ba12a15e65e41af29d04150005cab
   languageName: node
   linkType: hard
 
@@ -1418,19 +1395,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-flow@npm:^7.22.15":
-  version: 7.22.15
-  resolution: "@babel/preset-flow@npm:7.22.15"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.22.5"
-    "@babel/helper-validator-option": "npm:^7.22.15"
-    "@babel/plugin-transform-flow-strip-types": "npm:^7.22.5"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 17f8b80b1012802f983227b423c8823990db9748aec4f8bfd56ff774d8d954e9bdea67377788abac526754b3d307215c063c9beadf5f1b4331b30d4ba0593286
-  languageName: node
-  linkType: hard
-
 "@babel/preset-modules@npm:0.1.6-no-external-plugins":
   version: 0.1.6-no-external-plugins
   resolution: "@babel/preset-modules@npm:0.1.6-no-external-plugins"
@@ -1588,6 +1552,167 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/aix-ppc64@npm:0.20.2"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/android-arm64@npm:0.20.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/android-arm@npm:0.20.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/android-x64@npm:0.20.2"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/darwin-arm64@npm:0.20.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/darwin-x64@npm:0.20.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/freebsd-arm64@npm:0.20.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/freebsd-x64@npm:0.20.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/linux-arm64@npm:0.20.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/linux-arm@npm:0.20.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/linux-ia32@npm:0.20.2"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/linux-loong64@npm:0.20.2"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/linux-mips64el@npm:0.20.2"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/linux-ppc64@npm:0.20.2"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/linux-riscv64@npm:0.20.2"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/linux-s390x@npm:0.20.2"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/linux-x64@npm:0.20.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/netbsd-x64@npm:0.20.2"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/openbsd-x64@npm:0.20.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/sunos-x64@npm:0.20.2"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/win32-arm64@npm:0.20.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/win32-ia32@npm:0.20.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.20.2":
+  version: 0.20.2
+  resolution: "@esbuild/win32-x64@npm:0.20.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@eslint-community/eslint-utils@npm:^4.2.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
@@ -1662,7 +1787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inboxsdk/core@workspace:packages/core":
+"@inboxsdk/core@workspace:*, @inboxsdk/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@inboxsdk/core@workspace:packages/core"
   dependencies:
@@ -1678,6 +1803,15 @@ __metadata:
     sha.js: "npm:^2.4.0"
     tag-tree: "npm:^1.0.0"
     typed-emitter: "npm:^2.1.0"
+  languageName: unknown
+  linkType: soft
+
+"@inboxsdk/examples@workspace:*, @inboxsdk/examples@workspace:examples":
+  version: 0.0.0-use.local
+  resolution: "@inboxsdk/examples@workspace:examples"
+  dependencies:
+    "@inboxsdk/core": "workspace:*"
+    esbuild: "npm:^0.20.2"
   languageName: unknown
   linkType: soft
 
@@ -1959,6 +2093,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/resolve-uri@npm:^3.1.0":
+  version: 3.1.2
+  resolution: "@jridgewell/resolve-uri@npm:3.1.2"
+  checksum: 97106439d750a409c22c8bff822d648f6a71f3aa9bc8e5129efdc36343cd3096ddc4eeb1c62d2fe48e9bdd4db37b05d4646a17114ecebd3bbcacfa2de51c3c1d
+  languageName: node
+  linkType: hard
+
 "@jridgewell/set-array@npm:^1.0.0, @jridgewell/set-array@npm:^1.0.1":
   version: 1.1.2
   resolution: "@jridgewell/set-array@npm:1.1.2"
@@ -1983,6 +2124,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/sourcemap-codec@npm:^1.4.14":
+  version: 1.4.15
+  resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
+  checksum: 89960ac087781b961ad918978975bcdf2051cd1741880469783c42de64239703eab9db5230d776d8e6a09d73bb5e4cb964e07d93ee6e2e7aea5a7d726e865c09
+  languageName: node
+  linkType: hard
+
 "@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.15, @jridgewell/trace-mapping@npm:^0.3.17":
   version: 0.3.17
   resolution: "@jridgewell/trace-mapping@npm:0.3.17"
@@ -1990,6 +2138,16 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:3.1.0"
     "@jridgewell/sourcemap-codec": "npm:1.4.14"
   checksum: 790d439c9b271d9fc381dc4a837393ab942920245efedd5db20f65a665c0f778637fa623573337d3241ff784ffdb6724bbadf7fa2b61666bcd4884064b02f113
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.20":
+  version: 0.3.25
+  resolution: "@jridgewell/trace-mapping@npm:0.3.25"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.1.0"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
+  checksum: dced32160a44b49d531b80a4a2159dceab6b3ddf0c8e95a0deae4b0e894b172defa63d5ac52a19c2068e1fe7d31ea4ba931fbeec103233ecb4208953967120fc
   languageName: node
   linkType: hard
 
@@ -2237,10 +2395,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:^0.0.51":
-  version: 0.0.51
-  resolution: "@types/estree@npm:0.0.51"
-  checksum: b566c7a3fc8a81ca3d9e00a717e90b8f5d567e2476b4f6d76a20ec6da33ec28165b8f989ed8dd0c9df41405199777ec36a4f85f32a347fbc6c3f696a3128b6e7
+"@types/estree@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@types/estree@npm:1.0.5"
+  checksum: 7de6d928dd4010b0e20c6919e1a6c27b61f8d4567befa89252055fad503d587ecb9a1e3eab1b1901f923964d7019796db810b7fd6430acb26c32866d126fd408
   languageName: node
   linkType: hard
 
@@ -2692,154 +2850,154 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/ast@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/ast@npm:1.11.1"
+"@webassemblyjs/ast@npm:1.12.1, @webassemblyjs/ast@npm:^1.12.1":
+  version: 1.12.1
+  resolution: "@webassemblyjs/ast@npm:1.12.1"
   dependencies:
-    "@webassemblyjs/helper-numbers": "npm:1.11.1"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.1"
-  checksum: 28cc949e2e68eb103fc416b30880cf57bc37b452e1e6fe05c73c64bc6d90d68176013fb5101bf80a2eb4961299dd4d7cffeecd32d189a17951da7ead90c2f35f
+    "@webassemblyjs/helper-numbers": "npm:1.11.6"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.6"
+  checksum: a775b0559437ae122d14fec0cfe59fdcaf5ca2d8ff48254014fd05d6797e20401e0f1518e628f9b06819aa085834a2534234977f9608b3f2e51f94b6e8b0bc43
   languageName: node
   linkType: hard
 
-"@webassemblyjs/floating-point-hex-parser@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.11.1"
-  checksum: b8efc6fa08e4787b7f8e682182d84dfdf8da9d9c77cae5d293818bc4a55c1f419a87fa265ab85252b3e6c1fd323d799efea68d825d341a7c365c64bc14750e97
+"@webassemblyjs/floating-point-hex-parser@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.11.6"
+  checksum: 29b08758841fd8b299c7152eda36b9eb4921e9c584eb4594437b5cd90ed6b920523606eae7316175f89c20628da14326801090167cc7fbffc77af448ac84b7e2
   languageName: node
   linkType: hard
 
-"@webassemblyjs/helper-api-error@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/helper-api-error@npm:1.11.1"
-  checksum: 0792813f0ed4a0e5ee0750e8b5d0c631f08e927f4bdfdd9fe9105dc410c786850b8c61bff7f9f515fdfb149903bec3c976a1310573a4c6866a94d49bc7271959
+"@webassemblyjs/helper-api-error@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/helper-api-error@npm:1.11.6"
+  checksum: e8563df85161096343008f9161adb138a6e8f3c2cc338d6a36011aa55eabb32f2fd138ffe63bc278d009ada001cc41d263dadd1c0be01be6c2ed99076103689f
   languageName: node
   linkType: hard
 
-"@webassemblyjs/helper-buffer@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/helper-buffer@npm:1.11.1"
-  checksum: a337ee44b45590c3a30db5a8b7b68a717526cf967ada9f10253995294dbd70a58b2da2165222e0b9830cd4fc6e4c833bf441a721128d1fe2e9a7ab26b36003ce
+"@webassemblyjs/helper-buffer@npm:1.12.1":
+  version: 1.12.1
+  resolution: "@webassemblyjs/helper-buffer@npm:1.12.1"
+  checksum: 1d8705daa41f4d22ef7c6d422af4c530b84d69d0c253c6db5adec44d511d7caa66837803db5b1addcea611a1498fd5a67d2cf318b057a916283ae41ffb85ba8a
   languageName: node
   linkType: hard
 
-"@webassemblyjs/helper-numbers@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/helper-numbers@npm:1.11.1"
+"@webassemblyjs/helper-numbers@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/helper-numbers@npm:1.11.6"
   dependencies:
-    "@webassemblyjs/floating-point-hex-parser": "npm:1.11.1"
-    "@webassemblyjs/helper-api-error": "npm:1.11.1"
+    "@webassemblyjs/floating-point-hex-parser": "npm:1.11.6"
+    "@webassemblyjs/helper-api-error": "npm:1.11.6"
     "@xtuc/long": "npm:4.2.2"
-  checksum: cbe5b456fa074d11a5acf80860df2899a160011943d7e26e60b6eda1c1dbe594e717e0c9f2b50ba2323f75f333bc5ec949acd992a63f2207df754a474167e424
+  checksum: 9ffd258ad809402688a490fdef1fd02222f20cdfe191c895ac215a331343292164e5033dbc0347f0f76f2447865c0b5c2d2e3304ee948d44f7aa27857028fd08
   languageName: node
   linkType: hard
 
-"@webassemblyjs/helper-wasm-bytecode@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.11.1"
-  checksum: 009b494010907a52c1c6c6fcb42db8606cf2443e2e767c7ff3029acf31f9a206108285609d735ee77bcbcbd3f1a1f8920b365e7a9466ef35a7932b74c743c816
+"@webassemblyjs/helper-wasm-bytecode@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.11.6"
+  checksum: 4ebf03e9c1941288c10e94e0f813f413f972bfaa1f09be2cc2e5577f300430906b61aa24d52f5ef2f894e8e24e61c6f7c39871d7e3d98bc69460e1b8e00bb20b
   languageName: node
   linkType: hard
 
-"@webassemblyjs/helper-wasm-section@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/helper-wasm-section@npm:1.11.1"
+"@webassemblyjs/helper-wasm-section@npm:1.12.1":
+  version: 1.12.1
+  resolution: "@webassemblyjs/helper-wasm-section@npm:1.12.1"
   dependencies:
-    "@webassemblyjs/ast": "npm:1.11.1"
-    "@webassemblyjs/helper-buffer": "npm:1.11.1"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.1"
-    "@webassemblyjs/wasm-gen": "npm:1.11.1"
-  checksum: dd6eee9f73346b14d31e95074a8dced21d59269e86e47ad01b6578d86ae6008b411fb989bbd400102c355ea0ba3d070eb9949a64f822abc8f65cf0162704834a
+    "@webassemblyjs/ast": "npm:1.12.1"
+    "@webassemblyjs/helper-buffer": "npm:1.12.1"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.6"
+    "@webassemblyjs/wasm-gen": "npm:1.12.1"
+  checksum: e91e6b28114e35321934070a2db8973a08a5cd9c30500b817214c683bbf5269ed4324366dd93ad83bf2fba0d671ac8f39df1c142bf58f70c57a827eeba4a3d2f
   languageName: node
   linkType: hard
 
-"@webassemblyjs/ieee754@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/ieee754@npm:1.11.1"
+"@webassemblyjs/ieee754@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/ieee754@npm:1.11.6"
   dependencies:
     "@xtuc/ieee754": "npm:^1.2.0"
-  checksum: 23a0ac02a50f244471631802798a816524df17e56b1ef929f0c73e3cde70eaf105a24130105c60aff9d64a24ce3b640dad443d6f86e5967f922943a7115022ec
+  checksum: 13574b8e41f6ca39b700e292d7edf102577db5650fe8add7066a320aa4b7a7c09a5056feccac7a74eb68c10dea9546d4461412af351f13f6b24b5f32379b49de
   languageName: node
   linkType: hard
 
-"@webassemblyjs/leb128@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/leb128@npm:1.11.1"
+"@webassemblyjs/leb128@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/leb128@npm:1.11.6"
   dependencies:
     "@xtuc/long": "npm:4.2.2"
-  checksum: 85beb7156f131c29e9a7f1a05e7fc131849152dd7b0c198d4f21b8e965d96dbfeaca3ac53e4bfbedfeef88b0ada0ff0bd0b7ad5c7dfb8c3d3fed0f922084a557
+  checksum: ec3b72db0e7ce7908fe08ec24395bfc97db486063824c0edc580f0973a4cfbadf30529569d9c7db663a56513e45b94299cca03be9e1992ea3308bb0744164f3d
   languageName: node
   linkType: hard
 
-"@webassemblyjs/utf8@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/utf8@npm:1.11.1"
-  checksum: b93e57912dfb91df4a76162abd6fb5e491110e113101ec136cea0ea8b8bd43708e94f919ea0e8762657994da6a5fcb63d34b6da392e5dd4e189169da4c75c149
+"@webassemblyjs/utf8@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/utf8@npm:1.11.6"
+  checksum: 361a537bd604101b320a5604c3c96d1038d83166f1b9fb86cedadc7e81bae54c3785ae5d90bf5b1842f7da08194ccaf0f44a64fcca0cbbd6afe1a166196986d6
   languageName: node
   linkType: hard
 
-"@webassemblyjs/wasm-edit@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/wasm-edit@npm:1.11.1"
+"@webassemblyjs/wasm-edit@npm:^1.12.1":
+  version: 1.12.1
+  resolution: "@webassemblyjs/wasm-edit@npm:1.12.1"
   dependencies:
-    "@webassemblyjs/ast": "npm:1.11.1"
-    "@webassemblyjs/helper-buffer": "npm:1.11.1"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.1"
-    "@webassemblyjs/helper-wasm-section": "npm:1.11.1"
-    "@webassemblyjs/wasm-gen": "npm:1.11.1"
-    "@webassemblyjs/wasm-opt": "npm:1.11.1"
-    "@webassemblyjs/wasm-parser": "npm:1.11.1"
-    "@webassemblyjs/wast-printer": "npm:1.11.1"
-  checksum: 6a029ae21c3c0890a55e3d6fb20071434ed5ef024d7d9ca79a754555ccbbc595052e936f6e547b6823922e3f41d3350027a21e65a04032c5fce29d0e4301513d
+    "@webassemblyjs/ast": "npm:1.12.1"
+    "@webassemblyjs/helper-buffer": "npm:1.12.1"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.6"
+    "@webassemblyjs/helper-wasm-section": "npm:1.12.1"
+    "@webassemblyjs/wasm-gen": "npm:1.12.1"
+    "@webassemblyjs/wasm-opt": "npm:1.12.1"
+    "@webassemblyjs/wasm-parser": "npm:1.12.1"
+    "@webassemblyjs/wast-printer": "npm:1.12.1"
+  checksum: 5678ae02dbebba2f3a344e25928ea5a26a0df777166c9be77a467bfde7aca7f4b57ef95587e4bd768a402cdf2fddc4c56f0a599d164cdd9fe313520e39e18137
   languageName: node
   linkType: hard
 
-"@webassemblyjs/wasm-gen@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/wasm-gen@npm:1.11.1"
+"@webassemblyjs/wasm-gen@npm:1.12.1":
+  version: 1.12.1
+  resolution: "@webassemblyjs/wasm-gen@npm:1.12.1"
   dependencies:
-    "@webassemblyjs/ast": "npm:1.11.1"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.1"
-    "@webassemblyjs/ieee754": "npm:1.11.1"
-    "@webassemblyjs/leb128": "npm:1.11.1"
-    "@webassemblyjs/utf8": "npm:1.11.1"
-  checksum: 5da040e78045f5499a99435ce0b1878d77f4fbfecb854841367cfc8ac16cc169a7f04187aac5da794b8d08a84ba25324f276f9128c5597ee6666cabd6b954ec1
+    "@webassemblyjs/ast": "npm:1.12.1"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.6"
+    "@webassemblyjs/ieee754": "npm:1.11.6"
+    "@webassemblyjs/leb128": "npm:1.11.6"
+    "@webassemblyjs/utf8": "npm:1.11.6"
+  checksum: ec45bd50e86bc9856f80fe9af4bc1ae5c98fb85f57023d11dff2b670da240c47a7b1b9b6c89755890314212bd167cf3adae7f1157216ddffb739a4ce589fc338
   languageName: node
   linkType: hard
 
-"@webassemblyjs/wasm-opt@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/wasm-opt@npm:1.11.1"
+"@webassemblyjs/wasm-opt@npm:1.12.1":
+  version: 1.12.1
+  resolution: "@webassemblyjs/wasm-opt@npm:1.12.1"
   dependencies:
-    "@webassemblyjs/ast": "npm:1.11.1"
-    "@webassemblyjs/helper-buffer": "npm:1.11.1"
-    "@webassemblyjs/wasm-gen": "npm:1.11.1"
-    "@webassemblyjs/wasm-parser": "npm:1.11.1"
-  checksum: 00f85d1f762ca2574ea6b5e85b3e9c50720886cca86ef192c80a1af484d98353500667af91416c407cdaeac3176bcd2b0f0641f4299a915b21b03a7f2ff84f3a
+    "@webassemblyjs/ast": "npm:1.12.1"
+    "@webassemblyjs/helper-buffer": "npm:1.12.1"
+    "@webassemblyjs/wasm-gen": "npm:1.12.1"
+    "@webassemblyjs/wasm-parser": "npm:1.12.1"
+  checksum: 21f25ae109012c49bb084e09f3b67679510429adc3e2408ad3621b2b505379d9cce337799a7919ef44db64e0d136833216914aea16b0d4856f353b9778e0cdb7
   languageName: node
   linkType: hard
 
-"@webassemblyjs/wasm-parser@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/wasm-parser@npm:1.11.1"
+"@webassemblyjs/wasm-parser@npm:1.12.1, @webassemblyjs/wasm-parser@npm:^1.12.1":
+  version: 1.12.1
+  resolution: "@webassemblyjs/wasm-parser@npm:1.12.1"
   dependencies:
-    "@webassemblyjs/ast": "npm:1.11.1"
-    "@webassemblyjs/helper-api-error": "npm:1.11.1"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.1"
-    "@webassemblyjs/ieee754": "npm:1.11.1"
-    "@webassemblyjs/leb128": "npm:1.11.1"
-    "@webassemblyjs/utf8": "npm:1.11.1"
-  checksum: cc6de8f4d9c56b370c2151dd9daacbdabe4aa20ba55b278e322de949dcbdc33b615773ce1756b69580cd2d68273d72ddf8ba68c3bb8715a462e64cf02de9a7c3
+    "@webassemblyjs/ast": "npm:1.12.1"
+    "@webassemblyjs/helper-api-error": "npm:1.11.6"
+    "@webassemblyjs/helper-wasm-bytecode": "npm:1.11.6"
+    "@webassemblyjs/ieee754": "npm:1.11.6"
+    "@webassemblyjs/leb128": "npm:1.11.6"
+    "@webassemblyjs/utf8": "npm:1.11.6"
+  checksum: f7311685b76c3e1def2abea3488be1e77f06ecd8633143a6c5c943ca289660952b73785231bb76a010055ca64645227a4bc79705c26ab7536216891b6bb36320
   languageName: node
   linkType: hard
 
-"@webassemblyjs/wast-printer@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@webassemblyjs/wast-printer@npm:1.11.1"
+"@webassemblyjs/wast-printer@npm:1.12.1":
+  version: 1.12.1
+  resolution: "@webassemblyjs/wast-printer@npm:1.12.1"
   dependencies:
-    "@webassemblyjs/ast": "npm:1.11.1"
+    "@webassemblyjs/ast": "npm:1.12.1"
     "@xtuc/long": "npm:4.2.2"
-  checksum: bd1cf7a0630bf2d003d9df004fca97f53026b39560d0629dc8019aed7e7cc38000d1cb78f7e70ea52fc0561a822bcc7683d48f839363a9d0cf16574f9cbd8c32
+  checksum: 1a6a4b6bc4234f2b5adbab0cb11a24911b03380eb1cab6fb27a2250174a279fdc6aa2f5a9cf62dd1f6d4eb39f778f488e8ff15b9deb0670dee5c5077d46cf572
   languageName: node
   linkType: hard
 
@@ -2881,12 +3039,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-import-assertions@npm:^1.7.6":
-  version: 1.8.0
-  resolution: "acorn-import-assertions@npm:1.8.0"
+"acorn-import-assertions@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "acorn-import-assertions@npm:1.9.0"
   peerDependencies:
     acorn: ^8
-  checksum: d61a8a1c1eaf1ba205fb2011c664533813bb517d8b5cec4adecd44efc1dbccc76eced7d68b2a283b7704634718660ef5ccce2da6a0fbc2da2d5039abdb12d049
+  checksum: af8dd58f6b0c6a43e85849744534b99f2133835c6fcdabda9eea27d0a0da625a0d323c4793ba7cb25cf4507609d0f747c210ccc2fc9b5866de04b0e59c9c5617
   languageName: node
   linkType: hard
 
@@ -3712,17 +3870,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.14.5":
-  version: 4.21.5
-  resolution: "browserslist@npm:4.21.5"
+"browserslist@npm:^4.21.10":
+  version: 4.23.0
+  resolution: "browserslist@npm:4.23.0"
   dependencies:
-    caniuse-lite: "npm:^1.0.30001449"
-    electron-to-chromium: "npm:^1.4.284"
-    node-releases: "npm:^2.0.8"
-    update-browserslist-db: "npm:^1.0.10"
+    caniuse-lite: "npm:^1.0.30001587"
+    electron-to-chromium: "npm:^1.4.668"
+    node-releases: "npm:^2.0.14"
+    update-browserslist-db: "npm:^1.0.13"
   bin:
     browserslist: cli.js
-  checksum: 560ec095ab4fa878f611ddf29038193d3a40ce69282dd15e633bcb9523fa25122e566d34192ab45e261a637d768884e7318cb3545533720469ee8f10d10c3298
+  checksum: 496c3862df74565dd942b4ae65f502c575cbeba1fa4a3894dad7aa3b16130dc3033bc502d8848147f7b625154a284708253d9598bcdbef5a1e34cf11dc7bad8e
   languageName: node
   linkType: hard
 
@@ -3865,10 +4023,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001449, caniuse-lite@npm:^1.0.30001541":
+"caniuse-lite@npm:^1.0.30001541":
   version: 1.0.30001589
   resolution: "caniuse-lite@npm:1.0.30001589"
   checksum: 5e1d2eb7c32d48c52204227bc1377f0f4c758ef889c53b9b479e28470e7f82eb1db5853e7754be9600ee662ae32a1d58e8bef0fde6edab06322ddbabfd9d212f
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001587":
+  version: 1.0.30001607
+  resolution: "caniuse-lite@npm:1.0.30001607"
+  checksum: caab9ae1aa343e72da935c071041344c80338d8a12bd12a90b7d46eb8a97c7620dac72e95c994b94ce82d63f2f27151dab49206864620d8bfd7aa99f7fc75c83
   languageName: node
   linkType: hard
 
@@ -4849,17 +5014,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.4.284":
-  version: 1.4.340
-  resolution: "electron-to-chromium@npm:1.4.340"
-  checksum: 5493af55f2dab413ca82255b0074d1cc2785862aef7d808a38feeabe69d68c3a84d6ea961977a797f92d7580bc7d40b0802abc6a87a9ddaae9bcec001dfa04c0
-  languageName: node
-  linkType: hard
-
 "electron-to-chromium@npm:^1.4.535":
   version: 1.4.542
   resolution: "electron-to-chromium@npm:1.4.542"
   checksum: b47a22495a6a2173efb69c23cd053879c06b6a16f1bfca030ad0622e7c9622ab46356ca96c2c74dbac2908deb114daa9101870fab83bcf8ef5e31bfbfa0cf387
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.4.668":
+  version: 1.4.729
+  resolution: "electron-to-chromium@npm:1.4.729"
+  checksum: dae5bb21f9f85d9f51b7724f71c8825f746ad918f2dfb9d75400142b91c373422bdeaa92c9b6a191696a07cf11e122480094ad2d3460ed31f6e003013fd5bdc7
   languageName: node
   linkType: hard
 
@@ -4902,13 +5067,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.10.0":
-  version: 5.12.0
-  resolution: "enhanced-resolve@npm:5.12.0"
+"enhanced-resolve@npm:^5.16.0":
+  version: 5.16.0
+  resolution: "enhanced-resolve@npm:5.16.0"
   dependencies:
     graceful-fs: "npm:^4.2.4"
     tapable: "npm:^2.2.0"
-  checksum: ea5b49a0641827c6a083eaa3a625f953f4bd4e8f015bf70b9fb8cf60a35aaeb44e567df2da91ed28efaea3882845016e1d22a3152c2fdf773ea14f39cbe3d8a9
+  checksum: 47f123676b9b179b35195769b9d9523f314f6fc3a13d4461a4d95d5beaec9adc26aaa3b60b61f93e21ed1290dff0e9d9e67df343ec47f4480669a8e26ffe52a3
   languageName: node
   linkType: hard
 
@@ -5019,10 +5184,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^0.9.0":
-  version: 0.9.3
-  resolution: "es-module-lexer@npm:0.9.3"
-  checksum: c3e39465d06a6ecd103ccdb746508c88ee4bdd56c15238b0013de38b949a4eca91d5e44d2a9b88d772fe7821547c5fe9200ba0f3353116e208d44bb50c7bc1ea
+"es-module-lexer@npm:^1.2.1":
+  version: 1.5.0
+  resolution: "es-module-lexer@npm:1.5.0"
+  checksum: d0e198d8642cb42aa82d86f2c6830cb6786916171a3e693046c11500c0cb62e77703940e58757db8aafa8a86fa2a9cc1c493dcd22c0b03c4a72dede3ce5c7dd1
   languageName: node
   linkType: hard
 
@@ -5098,6 +5263,86 @@ __metadata:
     es6-iterator: "npm:^2.0.3"
     es6-symbol: "npm:^3.1.1"
   checksum: 5958a321cf8dfadc82b79eeaa57dc855893a4afd062b4ef5c9ded0010d3932099311272965c3d3fdd3c85df1d7236013a570e704fa6c1f159bbf979c203dd3a3
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.20.2":
+  version: 0.20.2
+  resolution: "esbuild@npm:0.20.2"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.20.2"
+    "@esbuild/android-arm": "npm:0.20.2"
+    "@esbuild/android-arm64": "npm:0.20.2"
+    "@esbuild/android-x64": "npm:0.20.2"
+    "@esbuild/darwin-arm64": "npm:0.20.2"
+    "@esbuild/darwin-x64": "npm:0.20.2"
+    "@esbuild/freebsd-arm64": "npm:0.20.2"
+    "@esbuild/freebsd-x64": "npm:0.20.2"
+    "@esbuild/linux-arm": "npm:0.20.2"
+    "@esbuild/linux-arm64": "npm:0.20.2"
+    "@esbuild/linux-ia32": "npm:0.20.2"
+    "@esbuild/linux-loong64": "npm:0.20.2"
+    "@esbuild/linux-mips64el": "npm:0.20.2"
+    "@esbuild/linux-ppc64": "npm:0.20.2"
+    "@esbuild/linux-riscv64": "npm:0.20.2"
+    "@esbuild/linux-s390x": "npm:0.20.2"
+    "@esbuild/linux-x64": "npm:0.20.2"
+    "@esbuild/netbsd-x64": "npm:0.20.2"
+    "@esbuild/openbsd-x64": "npm:0.20.2"
+    "@esbuild/sunos-x64": "npm:0.20.2"
+    "@esbuild/win32-arm64": "npm:0.20.2"
+    "@esbuild/win32-ia32": "npm:0.20.2"
+    "@esbuild/win32-x64": "npm:0.20.2"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 663215ab7e599651e00d61b528a63136e1f1d397db8b9c3712540af928c9476d61da95aefa81b7a8dfc7a9fdd7616fcf08395c27be68be8c99953fb461863ce4
   languageName: node
   linkType: hard
 
@@ -6222,17 +6467,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.9":
+  version: 4.2.11
+  resolution: "graceful-fs@npm:4.2.11"
+  checksum: bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.2.6":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
   checksum: 0c83c52b62c68a944dcfb9d66b0f9f10f7d6e3d081e8067b9bfdc9e5f3a8896584d576036f82915773189eec1eba599397fc620e75c03c0610fb3d67c6713c1a
-  languageName: node
-  linkType: hard
-
-"graceful-fs@npm:^4.2.9":
-  version: 4.2.11
-  resolution: "graceful-fs@npm:4.2.11"
-  checksum: bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
   languageName: node
   linkType: hard
 
@@ -6702,10 +6947,10 @@ __metadata:
     "@babel/node": "npm:^7.22.19"
     "@babel/plugin-transform-runtime": "npm:^7.22.15"
     "@babel/preset-env": "npm:^7.22.20"
-    "@babel/preset-flow": "npm:^7.22.15"
     "@babel/preset-react": "npm:^7.22.15"
     "@babel/preset-typescript": "npm:^7.23.0"
     "@babel/register": "npm:^7.22.15"
+    "@inboxsdk/examples": "workspace:*"
     "@macil/simple-base-converter": "npm:^1.0.0"
     "@types/asap": "npm:^2.0.0"
     "@types/classnames": "npm:^2.2.8"
@@ -9062,10 +9307,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.8":
-  version: 2.0.10
-  resolution: "node-releases@npm:2.0.10"
-  checksum: d784ecde25696a15d449c4433077f5cce620ed30a1656c4abf31282bfc691a70d9618bae6868d247a67914d1be5cc4fde22f65a05f4398cdfb92e0fc83cadfbc
+"node-releases@npm:^2.0.14":
+  version: 2.0.14
+  resolution: "node-releases@npm:2.0.14"
+  checksum: 0f7607ec7db5ef1dc616899a5f24ae90c869b6a54c2d4f36ff6d84a282ab9343c7ff3ca3670fe4669171bb1e8a9b3e286e1ef1c131f09a83d70554f855d54f24
   languageName: node
   linkType: hard
 
@@ -10770,7 +11015,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^3.1.0, schema-utils@npm:^3.1.1":
+"schema-utils@npm:^3.1.1":
   version: 3.1.1
   resolution: "schema-utils@npm:3.1.1"
   dependencies:
@@ -10778,6 +11023,17 @@ __metadata:
     ajv: "npm:^6.12.5"
     ajv-keywords: "npm:^3.5.2"
   checksum: cfcf991f108797719d8054281272cf508543d6e092e273129fca84d569baafa5344bc23ec98cf2274943f6ed69851ced4fd0ae24471601f3f4d69c00fac47be6
+  languageName: node
+  linkType: hard
+
+"schema-utils@npm:^3.2.0":
+  version: 3.3.0
+  resolution: "schema-utils@npm:3.3.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.8"
+    ajv: "npm:^6.12.5"
+    ajv-keywords: "npm:^3.5.2"
+  checksum: 2c7bbb1da967fdfd320e6cea538949006ec6e8c13ea560a4f94ff2c56809a8486fa5ec419e023452501a6befe1ca381e409c2798c24f4993c7c4094d97fdb258
   languageName: node
   linkType: hard
 
@@ -11800,15 +12056,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.1.3":
-  version: 5.3.9
-  resolution: "terser-webpack-plugin@npm:5.3.9"
+"terser-webpack-plugin@npm:^5.3.10":
+  version: 5.3.10
+  resolution: "terser-webpack-plugin@npm:5.3.10"
   dependencies:
-    "@jridgewell/trace-mapping": "npm:^0.3.17"
+    "@jridgewell/trace-mapping": "npm:^0.3.20"
     jest-worker: "npm:^27.4.5"
     schema-utils: "npm:^3.1.1"
     serialize-javascript: "npm:^6.0.1"
-    terser: "npm:^5.16.8"
+    terser: "npm:^5.26.0"
   peerDependencies:
     webpack: ^5.1.0
   peerDependenciesMeta:
@@ -11818,13 +12074,13 @@ __metadata:
       optional: true
     uglify-js:
       optional: true
-  checksum: 339737a407e034b7a9d4a66e31d84d81c10433e41b8eae2ca776f0e47c2048879be482a9aa08e8c27565a2a949bc68f6e07f451bf4d9aa347dd61b3d000f5353
+  checksum: fb1c2436ae1b4e983be043fa0a3d355c047b16b68f102437d08c736d7960c001e7420e2f722b9d99ce0dc70ca26a68cc63c0b82bc45f5b48671142b352a9d938
   languageName: node
   linkType: hard
 
-"terser@npm:^5.16.8":
-  version: 5.21.0
-  resolution: "terser@npm:5.21.0"
+"terser@npm:^5.26.0":
+  version: 5.30.3
+  resolution: "terser@npm:5.30.3"
   dependencies:
     "@jridgewell/source-map": "npm:^0.3.3"
     acorn: "npm:^8.8.2"
@@ -11832,7 +12088,7 @@ __metadata:
     source-map-support: "npm:~0.5.20"
   bin:
     terser: bin/terser
-  checksum: 4660eae8ecef177bfc66f64f3bab008f1604973a76ea68aaf5d64217e2b928f8f53e4097a21cbe90447d911438c9d9c954ac450fa932ef5451dd8db27df9e9aa
+  checksum: f4ee378065a327c85472f351ac232fa47ec84d4f15df7ec58c044b41e3c063cf11aaedd90dcfe9c7f2a6ef01d4aab23deb61622301170dc77d0a8b6a6a83cf5e
   languageName: node
   linkType: hard
 
@@ -12351,20 +12607,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.0.10":
-  version: 1.0.10
-  resolution: "update-browserslist-db@npm:1.0.10"
-  dependencies:
-    escalade: "npm:^3.1.1"
-    picocolors: "npm:^1.0.0"
-  peerDependencies:
-    browserslist: ">= 4.21.0"
-  bin:
-    browserslist-lint: cli.js
-  checksum: 2c88096ca99918efc77a514458c4241b3f2a8e7882aa91b97251231240c30c71e82cb2043aaf12e40eba6bebda3369010e180a58bc11bbd0bca29094945c31cb
-  languageName: node
-  linkType: hard
-
 "update-browserslist-db@npm:^1.0.13":
   version: 1.0.13
   resolution: "update-browserslist-db@npm:1.0.13"
@@ -12542,13 +12784,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"watchpack@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "watchpack@npm:2.4.0"
+"watchpack@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "watchpack@npm:2.4.1"
   dependencies:
     glob-to-regexp: "npm:^0.4.1"
     graceful-fs: "npm:^4.1.2"
-  checksum: 4280b45bc4b5d45d5579113f2a4af93b67ae1b9607cc3d86ae41cdd53ead10db5d9dc3237f24256d05ef88b28c69a02712f78e434cb7ecc8edaca134a56e8cab
+  checksum: 0736ebd20b75d3931f9b6175c819a66dee29297c1b389b2e178bc53396a6f867ecc2fd5d87a713ae92dcb73e487daec4905beee20ca00a9e27f1184a7c2bca5e
   languageName: node
   linkType: hard
 
@@ -12567,39 +12809,39 @@ __metadata:
   linkType: hard
 
 "webpack@npm:^5.76.3":
-  version: 5.76.3
-  resolution: "webpack@npm:5.76.3"
+  version: 5.91.0
+  resolution: "webpack@npm:5.91.0"
   dependencies:
     "@types/eslint-scope": "npm:^3.7.3"
-    "@types/estree": "npm:^0.0.51"
-    "@webassemblyjs/ast": "npm:1.11.1"
-    "@webassemblyjs/wasm-edit": "npm:1.11.1"
-    "@webassemblyjs/wasm-parser": "npm:1.11.1"
+    "@types/estree": "npm:^1.0.5"
+    "@webassemblyjs/ast": "npm:^1.12.1"
+    "@webassemblyjs/wasm-edit": "npm:^1.12.1"
+    "@webassemblyjs/wasm-parser": "npm:^1.12.1"
     acorn: "npm:^8.7.1"
-    acorn-import-assertions: "npm:^1.7.6"
-    browserslist: "npm:^4.14.5"
+    acorn-import-assertions: "npm:^1.9.0"
+    browserslist: "npm:^4.21.10"
     chrome-trace-event: "npm:^1.0.2"
-    enhanced-resolve: "npm:^5.10.0"
-    es-module-lexer: "npm:^0.9.0"
+    enhanced-resolve: "npm:^5.16.0"
+    es-module-lexer: "npm:^1.2.1"
     eslint-scope: "npm:5.1.1"
     events: "npm:^3.2.0"
     glob-to-regexp: "npm:^0.4.1"
-    graceful-fs: "npm:^4.2.9"
+    graceful-fs: "npm:^4.2.11"
     json-parse-even-better-errors: "npm:^2.3.1"
     loader-runner: "npm:^4.2.0"
     mime-types: "npm:^2.1.27"
     neo-async: "npm:^2.6.2"
-    schema-utils: "npm:^3.1.0"
+    schema-utils: "npm:^3.2.0"
     tapable: "npm:^2.1.1"
-    terser-webpack-plugin: "npm:^5.1.3"
-    watchpack: "npm:^2.4.0"
+    terser-webpack-plugin: "npm:^5.3.10"
+    watchpack: "npm:^2.4.1"
     webpack-sources: "npm:^3.2.3"
   peerDependenciesMeta:
     webpack-cli:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 776e2ff95002596d0d2aad73df47b44b460624133b4741a8218aabb3fd3ee20d79826f5e47e002f50f6fb3356a671265db6928d5f477b6d70500fa8894116b25
+  checksum: 647ca53c15fe0fa1af4396a7257d7a93cbea648d2685e565a11cc822a9e3ea9316345250987d75f02c0b45dae118814f094ec81908d1032e77a33cd6470b289e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Build this repo's bundled examples more similarly to InboxSDK/hello-world, but using esbuild. This allows us to:

- Test our source map setup, minify, and production builds in MV3
- `import * as InboxSDK from '@inboxsdk/core` in our example content scripts (bonus: type hints in JS, and we avoid using the UMD `InboxSDK` global
- write example extensions in TypeScript

Acts as a stepping stone for #1170
