### PR TITLE
fix(thread view): tweak notice bar spacing with ai suggestions container

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
@@ -211,6 +211,10 @@ class GmailThreadView {
     '2023_11_16': '* > .nH',
   };
 
+  _subjectAISuggestionsContainerSelectors = {
+    '2024_04_26': '.nH > .einvLd',
+  };
+
   addNoticeBar(): SimpleElementView {
     const el = document.createElement('div');
     el.className = idMap('thread_noticeBar');
@@ -242,6 +246,30 @@ class GmailThreadView {
     this._driver.getLogger().eventSdkPassive('addNoticeBar subjectContainer', {
       version,
     });
+
+    // AI suggestions container could be rendered after the subject container so
+    // if present, we need to adjust spacing when inserting the notice bar in between subject and AI suggestions
+    for (const [currentVersion, selector] of Object.entries(
+      this._subjectAISuggestionsContainerSelectors,
+    )) {
+      const hasAIButtonsSubjectContainer =
+        !!this._element.querySelector(selector);
+
+      if (!hasAIButtonsSubjectContainer) {
+        continue;
+      }
+
+      this._driver
+        .getLogger()
+        .eventSdkPassive('addNoticeBar AIButtonsSubjectContainer', {
+          version: currentVersion,
+        });
+
+      // AI suggestions container is present, adjust spacing of notice bar by the same amount as the subject container bottom spacing for consistency
+      el.style.marginBottom = '8px';
+
+      break;
+    }
 
     subjectContainer.insertAdjacentElement('afterend', el);
     const view = new SimpleElementView(el);


### PR DESCRIPTION
## Description

Tweak the notice bar bottom spacing when AI suggestions ("Summarize this email" etc.) are enabled in the thread view. 

Example:
| Before the fix      | After the fix |
| ----------- | ----------- |
| ![image](https://github.com/InboxSDK/InboxSDK/assets/108280206/5c4f5e1b-e4dc-461c-9926-28eed2c5b99f)  | ![image](https://github.com/InboxSDK/InboxSDK/assets/108280206/b75072d2-f971-4f4d-9950-0b9ec42af120) |