### PR TITLE
feat: add iconLiga option for right sidebar

### DIFF
--- a/examples/sidebar-example/content.js
+++ b/examples/sidebar-example/content.js
@@ -1,5 +1,18 @@
 import * as InboxSDK from '@inboxsdk/core';
 
+function addStyle(href) {
+  const linkEl = document.createElement('link');
+  linkEl.rel = 'stylesheet';
+  linkEl.href = href;
+
+  if (!document.head) throw new Error('missing head');
+  document.head.appendChild(linkEl);
+}
+
+addStyle(
+  'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..24,400..500,0,0',
+);
+
 InboxSDK.load(2, 'sidebar-example', {
   appName: 'Twitter',
   appIconUrl:
@@ -100,5 +113,25 @@ InboxSDK.load(2, 'sidebar-example', {
     iconUrl: chrome.runtime.getURL('monkey-face.jpg'),
     el: globalPanelEl2,
     orderHint: 2,
+  });
+
+  try {
+    document.styleSheets[0].insertRule(
+      `.test-ligature:first-child {
+      font-family: 'Material Symbols Outlined';
+      line-height: 1;
+    }`,
+    );
+  } catch (e) {
+    console.error(e);
+  }
+
+  inboxSDK.Global.addSidebarContentPanel({
+    title: 'Panel 3.0',
+    appName: 'Not Twitter 3.0',
+    iconClass: 'test-ligature',
+    iconLiga: 'task_alt',
+    el: globalPanelEl2.cloneNode(true),
+    orderHint: 3,
   });
 });

--- a/examples/sidebar-example/content.js
+++ b/examples/sidebar-example/content.js
@@ -1,18 +1,5 @@
 import * as InboxSDK from '@inboxsdk/core';
 
-function addStyle(href) {
-  const linkEl = document.createElement('link');
-  linkEl.rel = 'stylesheet';
-  linkEl.href = href;
-
-  if (!document.head) throw new Error('missing head');
-  document.head.appendChild(linkEl);
-}
-
-addStyle(
-  'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..24,400..500,0,0',
-);
-
 InboxSDK.load(2, 'sidebar-example', {
   appName: 'Twitter',
   appIconUrl:
@@ -113,25 +100,5 @@ InboxSDK.load(2, 'sidebar-example', {
     iconUrl: chrome.runtime.getURL('monkey-face.jpg'),
     el: globalPanelEl2,
     orderHint: 2,
-  });
-
-  try {
-    document.styleSheets[0].insertRule(
-      `.test-ligature:first-child {
-      font-family: 'Material Symbols Outlined';
-      line-height: 1;
-    }`,
-    );
-  } catch (e) {
-    console.error(e);
-  }
-
-  inboxSDK.Global.addSidebarContentPanel({
-    title: 'Panel 3.0',
-    appName: 'Not Twitter 3.0',
-    iconClass: 'test-ligature',
-    iconLiga: 'task_alt',
-    el: globalPanelEl2.cloneNode(true),
-    orderHint: 3,
   });
 });

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.module.css
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.module.css
@@ -1,0 +1,6 @@
+.iconLiga {
+  font-size: 20px;
+  line-height: 1;
+  position: relative;
+  z-index: 1 !important;
+}

--- a/src/platform-implementation-js/driver-common/sidebar/AppSidebar.tsx
+++ b/src/platform-implementation-js/driver-common/sidebar/AppSidebar.tsx
@@ -31,8 +31,9 @@ export type PanelDescriptor = {
   instanceId: string;
   appId: string;
   id: string;
-  title: string;
+  title?: string;
   iconClass: string | null | undefined;
+  iconLiga?: string;
   iconUrl: string | null | undefined;
   hideTitleBar: boolean;
   el: HTMLElement;
@@ -369,7 +370,7 @@ class Panel extends React.Component<PanelProps> {
       dragHandleProps,
       itemSelected,
       item: {
-        panelDescriptor: { title, appName, iconClass, iconUrl, el },
+        panelDescriptor: { title, appName, iconClass, iconUrl, iconLiga, el },
         showControls,
         expanded,
         onExpandedToggle,
@@ -415,6 +416,7 @@ class Panel extends React.Component<PanelProps> {
                   iconClass,
                 )}
               >
+                {!!iconLiga && iconLiga}
                 {iconUrl && <img src={iconUrl} />}
               </span>
             </span>

--- a/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.ts
+++ b/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.ts
@@ -12,10 +12,29 @@ export interface ContentPanelDescriptor {
   id?: string;
   hideTitleBar?: boolean;
   iconClass?: string;
+  iconLiga?: string;
   iconUrl?: string;
   orderHint?: number;
   primaryColor?: string;
   secondaryColor?: string;
+  title?: string;
+}
+
+export interface SidebarPanelEvent {
+  appIconUrl?: string;
+  appId: string;
+  appName: string;
+  hideTitleBar: boolean;
+  iconLiga?: string;
+  iconClass?: string;
+  iconUrl?: string;
+  id: string;
+  instanceId: string;
+  isGlobal?: boolean;
+  orderHint: number;
+  primaryColor?: string;
+  secondaryColor?: string;
+  sidebarId: string;
   title?: string;
 }
 
@@ -88,6 +107,7 @@ class ContentPanelViewDriver {
         const {
           el,
           iconUrl,
+          iconLiga,
           iconClass,
           title,
           orderHint,
@@ -109,7 +129,7 @@ class ContentPanelViewDriver {
           : 'inboxsdkNewSidebarPanel';
         hasPlacedAlready = true;
         el.dispatchEvent(
-          new CustomEvent(eventName, {
+          new CustomEvent<SidebarPanelEvent>(eventName, {
             bubbles: true,
             cancelable: false,
             detail: {
@@ -119,6 +139,7 @@ class ContentPanelViewDriver {
               appName,
               hideTitleBar: Boolean(hideTitleBar),
               iconClass,
+              iconLiga,
               iconUrl,
               id: String(id || title),
               instanceId: this.#instanceId,


### PR DESCRIPTION
In `AppSidebar`, allow the same sort of `iconLiga` setup that was added in #1174.

The third icon down in both screenshots uses the new option. The extension I tested with was `sidebar-example`.

<img width="53" alt="Screenshot 2024-04-26 at 14 17 08" src="https://github.com/InboxSDK/InboxSDK/assets/5156873/7e4f57e8-54e7-437e-accc-8322d46de5ec">
<img width="57" alt="Screenshot 2024-04-26 at 14 14 31" src="https://github.com/InboxSDK/InboxSDK/assets/5156873/b976dfc0-f258-4c9e-9f5e-96ffd3d34d3c">
