### PR TITLE
fix: DropdownButtonAccessoryDescriptor.onClick type

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,7 @@ feature themselves.
 
 Run `yarn` to install the necessary dependencies, and run `yarn start` to start
 the automatic builder. Then load `examples/app-menu/` as an unpacked extension
-into Google Chrome. You may need to manually copy `background.js` from
-`packages/core/` to the `examples/app-menu/` directory.
+into Google Chrome.
 
 The
 [Chrome Extensions Reloader](https://chrome.google.com/webstore/detail/extensions-reloader/fimgfedafeadlieiabdeeaodndnlbhid)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ InboxSDK.load(2, 'YOUR_APP_ID_HERE').then((sdk) => {
 });
 ```
 
-See https://github.com/InboxSDK/hello-world for an example extension using the
+See <https://github.com/InboxSDK/hello-world> for an example extension using the
 InboxSDK.
 
 # Licensing
@@ -82,7 +82,8 @@ feature themselves.
 
 Run `yarn` to install the necessary dependencies, and run `yarn start` to start
 the automatic builder. Then load `examples/app-menu/` as an unpacked extension
-into Google Chrome.
+into Google Chrome. You may need to manually copy `background.js` from
+`packages/core/` to the `examples/app-menu/` directory.
 
 The
 [Chrome Extensions Reloader](https://chrome.google.com/webstore/detail/extensions-reloader/fimgfedafeadlieiabdeeaodndnlbhid)
@@ -100,6 +101,10 @@ isolation in an example extension, and must not depend on Streak (including
 Streak's CSS). Any new features that add elements controlled by the extension
 ought to be styled (positioned) reasonably by the InboxSDK without requiring the
 extension to include its own non-trivial CSS.
+
+If you are using the default `example/app-menu` extension, make sure that your
+app menu is enabled by going to Gmail's `Settings > Chat and Meet` and enabling
+at least either Chat or Meet.
 
 ## Technology Choices
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
@@ -24,6 +24,7 @@ import renderCustomIcon from '../../../driver-common/render-custom-icon';
 import NAV_ITEM_TYPES from '../../../constants/nav-item-types';
 
 import GmailDriver from '../gmail-driver';
+import DropdownView from '../../../widgets/buttons/dropdown-view';
 
 let NUMBER_OF_GMAIL_NAV_ITEM_VIEWS_CREATED = 0;
 
@@ -43,7 +44,7 @@ type IconButtonAccessoryDescriptor = {
 
 type DropdownButtonAccessoryDescriptor = {
   type: 'DROPDOWN_BUTTON';
-  onClick: (e: MouseEvent) => void;
+  onClick: (e: { dropdown: DropdownView }) => void;
 };
 
 export type NavItemTypes = typeof NAV_ITEM_TYPES;


### PR DESCRIPTION
closes https://github.com/InboxSDK/InboxSDK/issues/1168; have updated the docs accordingly in https://github.com/InboxSDK/inboxsdk-docs/pull/29

also added clarifications to the README to make it easier for newcomers to set things up

have also opened [a further PR](https://github.com/zxt-tzx/InboxSDK/pull/1) based on top of this to refactor the `/example/app-menu`, happy to include that within this PR instead