### PR TITLE
fix: prevent race condition in `yarn start` around `background.js`

### DIFF
--- a/examples/build.ts
+++ b/examples/build.ts
@@ -5,8 +5,7 @@ import esbuild from 'esbuild';
 type BuildConfig = Parameters<typeof esbuild.build>[0];
 type Watcher = ReturnType<typeof esbuild.context>;
 
-let watchingContentScripts: undefined | Watcher;
-let watchingSdkOutput: undefined | Watcher;
+let esbuildWatch: undefined | Watcher;
 const TIMING_LABEL = 'building ./examples took';
 
 const buildSdkFiles = ['@inboxsdk/core/pageWorld', '@inboxsdk/core/background'];
@@ -23,94 +22,56 @@ export async function buildExamples({
 }) {
   console.time(TIMING_LABEL);
 
-  const sharedConfig: BuildConfig = {
+  const sdkEntryPoints = buildSdkFiles
+    .flatMap((sdkFile) =>
+      contentScriptFps.flatMap((c) => [
+        {
+          out: path.join(path.dirname(c), path.basename(sdkFile)),
+          in: sdkFile,
+        },
+      ]),
+    )
+    .concat(
+      contentScriptFps.map((c) => ({
+        out: path.join(
+          path.dirname(c),
+          'dist',
+          path.basename(c).replace(/\.[jt]s$/, ''),
+        ),
+        in: c,
+      })),
+    );
+
+  const config: BuildConfig = {
     define: {
       // closest-ng depends on node `global`.
       global: 'globalThis',
     },
-    entryNames: '[name]',
     bundle: true,
     loader: {
       '.tsx': 'tsx',
       '.ts': 'ts',
       '.js': 'js',
     },
+    logLevel: 'info',
     tsconfig: './tsconfig.json',
     platform: 'browser',
     sourcemap: 'linked',
     target: 'es2022',
     minify,
-  };
-
-  const sdkEntryPoints = buildSdkFiles.flatMap((sdkFile) =>
-    contentScriptFps.flatMap((c) => [
-      {
-        out: path.join(path.dirname(c), path.basename(sdkFile)),
-        in: sdkFile,
-      },
-    ]),
-  );
-
-  const sdkBuildConfig: BuildConfig = {
-    ...sharedConfig,
     entryPoints: sdkEntryPoints,
     outbase: '.',
     outdir: '.',
     entryNames: '[dir]/[name]',
   };
 
-  const sdkFileBuild = watchOrBuild({
-    awaitRebuild: true,
-    config: sdkBuildConfig,
-    state: watchingSdkOutput,
-    watch,
-  });
+  if (watch && esbuildWatch == null) {
+    esbuildWatch = esbuild.context(config);
 
-  const contentScriptOpts = {
-    ...sharedConfig,
-    entryPoints: contentScriptFps,
-    entryNames: '[dir]/dist/[name]',
-    outdir: 'examples',
-  } as const;
-
-  const contentScriptBuild = watchOrBuild({
-    config: contentScriptOpts,
-    awaitRebuild: false,
-    state: watchingContentScripts,
-    watch,
-  });
-
-  await Promise.all([sdkFileBuild, contentScriptBuild]);
-  console.timeEnd(TIMING_LABEL);
-}
-
-async function watchOrBuild({
-  awaitRebuild,
-  config,
-  state,
-  watch,
-}: {
-  awaitRebuild: boolean;
-  config: BuildConfig;
-  state: Promise<esbuild.BuildContext<esbuild.BuildOptions>> | undefined;
-  watch: boolean;
-}) {
-  if (watch) {
-    const watcher = await state;
-    if (watcher == null) {
-      state = esbuild.context({
-        logLevel: 'info',
-        ...config,
-      });
-
-      (await state).watch();
-    } else {
-      if (awaitRebuild) {
-        await watcher.cancel();
-        await watcher.rebuild();
-      }
-    }
+    (await esbuildWatch).watch();
   } else {
     await esbuild.build(config);
   }
+
+  console.timeEnd(TIMING_LABEL);
 }

--- a/examples/build.ts
+++ b/examples/build.ts
@@ -61,7 +61,12 @@ export async function buildExamples({
 
   const copyingFiles = contentScriptFps.map((examplePath) => {
     (async () => {
-      await sdkFileBuild;
+      if (watchingSdkOutput == null) {
+        await sdkFileBuild;
+      } else {
+        // We need these files built before we copy the first time
+        (await watchingSdkOutput).rebuild();
+      }
       const dirname = path.dirname(examplePath);
       return fs.cp('examples/dist', dirname, {
         force: true,
@@ -110,10 +115,7 @@ async function watchOrBuild({
         ...config,
       });
 
-      // For @inboxsdk/core files, we need to build prior to copying the files into each example folder
-      (await state).rebuild();
-
-      state.then((noBlock) => noBlock.watch());
+      (await state).watch();
     } else {
       if (awaitRebuild) {
         await watcher.cancel();


### PR DESCRIPTION
When building with `yarn start`, we had an issue after #1188 where in `yarn start` builds: 

1. `esbuild.rebuild` was signaling completion
2. We started copying `examples/dist` into each example extension
3. A `rebuild.watch` started up and cleared `examples/dist`.
4. `background.js` wasn't ending up in `examples/compose-stream/` on the first build.

This issue didn't seem to occur on subsequent rebuilds.

This PR removes the build and then copy that was causing issues. One ESBuild context is used instead of separate configs for service worker output and content scripts. 

