### PR TITLE
chore: Drop closest-ng library

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "bimapcache": "^2.0.0",
     "buffer": "^6.0.3",
     "classnames": "^2.2.5",
-    "closest-ng": "^1.0.0",
     "combokeys-capture": "^2.4.2",
     "concat-stream": "^2.0.0",
     "contain-by-screen": "^1.0.3",

--- a/src/injected-js/setupCustomViewEventAssassin.ts
+++ b/src/injected-js/setupCustomViewEventAssassin.ts
@@ -42,7 +42,9 @@ function shouldBlockEvent(event: KeyboardEvent): boolean {
 
   // Block all escape key presses inside a custom view, even when an input
   // is focused.
-  if (event.key === 'Escape' && target.closest('.inboxsdk__custom_view')) {
+  const target = event.target;
+  // ...
+  if (event.key === 'Escape' && target instanceof HTMLElement && target.closest('.inboxsdk__custom_view')) {
     return true;
   }
 

--- a/src/injected-js/setupCustomViewEventAssassin.ts
+++ b/src/injected-js/setupCustomViewEventAssassin.ts
@@ -71,10 +71,12 @@ function shouldBlockEvent(event: KeyboardEvent): boolean {
     if (
       // Gmail already ignores events originating in these elements even if
       // they were made by an extension.
-      target.closest('input, textarea, button, [contenteditable]') ||
+      (target instanceof HTMLElement &&
+        target.closest('input, textarea, button, [contenteditable]')) ||
       // Gmail ignores events originating in its own interactive elements
       // which tend to have certain role attributes.
-      (!target.closest('.inboxsdk__custom_view') &&
+      (target instanceof HTMLElement &&
+        !target.closest('.inboxsdk__custom_view') &&
         target.closest('[role=button], [role=link]'))
     ) {
       return false;

--- a/src/injected-js/setupCustomViewEventAssassin.ts
+++ b/src/injected-js/setupCustomViewEventAssassin.ts
@@ -42,9 +42,7 @@ function shouldBlockEvent(event: KeyboardEvent): boolean {
 
   // Block all escape key presses inside a custom view, even when an input
   // is focused.
-  const target = event.target;
-  // ...
-  if (event.key === 'Escape' && target instanceof HTMLElement && target.closest('.inboxsdk__custom_view')) {
+  if (event.key === 'Escape' && target.closest('.inboxsdk__custom_view')) {
     return true;
   }
 

--- a/src/injected-js/setupCustomViewEventAssassin.ts
+++ b/src/injected-js/setupCustomViewEventAssassin.ts
@@ -1,6 +1,5 @@
 import { defn } from 'ud';
 import includes from 'lodash/includes';
-import closest from 'closest-ng';
 import * as logger from './injected-logger';
 
 function md<T>(value: T): { value: T; configurable: boolean } {
@@ -43,7 +42,7 @@ function shouldBlockEvent(event: KeyboardEvent): boolean {
 
   // Block all escape key presses inside a custom view, even when an input
   // is focused.
-  if (event.key === 'Escape' && closest(target, '.inboxsdk__custom_view')) {
+  if (event.key === 'Escape' && target.closest('.inboxsdk__custom_view')) {
     return true;
   }
 
@@ -68,11 +67,11 @@ function shouldBlockEvent(event: KeyboardEvent): boolean {
     if (
       // Gmail already ignores events originating in these elements even if
       // they were made by an extension.
-      closest(target, 'input, textarea, button, [contenteditable]') ||
+      target.closest('input, textarea, button, [contenteditable]') ||
       // Gmail ignores events originating in its own interactive elements
       // which tend to have certain role attributes.
-      (!closest(target, '.inboxsdk__custom_view') &&
-        closest(target, '[role=button], [role=link]'))
+      (!target.closest('.inboxsdk__custom_view') &&
+        target.closest('[role=button], [role=link]'))
     ) {
       return false;
     }

--- a/src/injected-js/setupCustomViewEventAssassin.ts
+++ b/src/injected-js/setupCustomViewEventAssassin.ts
@@ -35,14 +35,18 @@ function shouldBlockEvent(event: KeyboardEvent): boolean {
     return false;
   }
 
-  const target = event.target as HTMLElement;
+  const target = event.target;
 
   const key =
     event.key || /* safari*/ String.fromCharCode(event.which || event.keyCode);
 
   // Block all escape key presses inside a custom view, even when an input
   // is focused.
-  if (event.key === 'Escape' && target.closest('.inboxsdk__custom_view')) {
+  if (
+    event.key === 'Escape' &&
+    target instanceof HTMLElement &&
+    target.closest('.inboxsdk__custom_view')
+  ) {
     return true;
   }
 

--- a/src/injected-js/setupInboxCustomViewLinkFixer.ts
+++ b/src/injected-js/setupInboxCustomViewLinkFixer.ts
@@ -1,4 +1,3 @@
-import closest from 'closest-ng';
 export default function setupInboxCustomViewLinkFixer() {
   const allowedStartTerms = new Set();
   document.addEventListener(
@@ -13,7 +12,7 @@ export default function setupInboxCustomViewLinkFixer() {
     function (event: MouseEvent) {
       const target = event.target;
       if (!(target instanceof HTMLElement)) return;
-      const anchor = closest(target, 'a[href^="#"]');
+      const anchor = target.closest('a[href^="#"]');
       if (!anchor || !(anchor instanceof HTMLAnchorElement)) return;
       const m = /^#([^/]+)/.exec(anchor.getAttribute('href') || '');
       if (!m) return;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
@@ -9,7 +9,6 @@ import find from 'lodash/find';
 import asap from 'asap';
 import delay from 'pdelay';
 import * as Kefir from 'kefir';
-import closest from 'closest-ng';
 import kefirBus from 'kefir-bus';
 import type { Bus } from 'kefir-bus';
 import kefirStopper from 'kefir-stopper';
@@ -1165,7 +1164,7 @@ class GmailComposeView {
 
   getFormattingToolbarToggleButton(): HTMLElement {
     const innerElement = querySelector(this.#element, '[role=button] .dv');
-    const btn = closest(innerElement, '[role=button]');
+    const btn = innerElement.closest('[role=button]') as HTMLElement;
     if (!btn) throw new Error('failed to find button');
     return btn;
   }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/page-parser.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/page-parser.ts
@@ -1,4 +1,3 @@
-import closest from 'closest-ng';
 import PageParserTree from 'page-parser-tree';
 import censorHTMLtree from '../../../../../common/censorHTMLtree';
 import Logger from '../../../../lib/logger';
@@ -251,7 +250,7 @@ export function getOldRecipientRowForType(
     `.GS tr textarea.vO[name="${addressType}"], .GS tr input[name="${addressType}"]`,
   );
   if (input) {
-    return closest(input, 'tr');
+    return input.closest('tr');
   } else {
     return null;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4269,15 +4269,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"closest-ng@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "closest-ng@npm:1.1.0"
-  dependencies:
-    matches-selector-ng: "npm:^1.0.1"
-  checksum: 040dc3dcb532f98092a89794e76ff3cb5ccd47d07353c9068e7eaf729b799cd552b00c2fecdd9f0155b91e52cec542ba0310bf64a2890824a0a25c70cbcbb9ed
-  languageName: node
-  linkType: hard
-
 "co@npm:^4.6.0":
   version: 4.6.0
   resolution: "co@npm:4.6.0"
@@ -6978,7 +6969,6 @@ __metadata:
     bimapcache: "npm:^2.0.0"
     buffer: "npm:^6.0.3"
     classnames: "npm:^2.2.5"
-    closest-ng: "npm:^1.0.0"
     combokeys-capture: "npm:^2.4.2"
     concat-stream: "npm:^2.0.0"
     contain-by-screen: "npm:^1.0.3"
@@ -8836,7 +8826,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"matches-selector-ng@npm:^1.0.0, matches-selector-ng@npm:^1.0.1":
+"matches-selector-ng@npm:^1.0.0":
   version: 1.1.0
   resolution: "matches-selector-ng@npm:1.1.0"
   checksum: 6abc7e95fc903dac58baa7f4b0d8dc823cb854979d1c6839e1a847095cd87ae26752240d63a326780b8dd526cb7d277fa9905364e44573e951a50f001a0b9181


### PR DESCRIPTION
- Removed closest imports
- Removed the first param and leave the classname as the only one

Closes https://github.com/InboxSDK/InboxSDK/issues/1190