### PR TITLE
Fix reading extension id for error logging in MV3

### DIFF
--- a/src/common/get-extension-id.ts
+++ b/src/common/get-extension-id.ts
@@ -1,6 +1,9 @@
 export default function getExtensionId(): string | null {
   const chrome: any = (global as any).chrome;
-  if (chrome && chrome.extension && chrome.extension.getURL) {
+  if (chrome?.runtime?.getURL) {
+    return chrome.runtime.getURL('');
+  }
+  if (chrome?.extension?.getURL) {
     return chrome.extension.getURL('');
   }
   return null;


### PR DESCRIPTION
In Chrome MV3 extensions, `chrome.extension.getURL()` has been changed to `chrome.runtime.getURL()`. This PR updates our code so we can use the correct function when present in order to get the extension id in error logs.