### PR TITLE
Fix AttachmentCardView.getDownloadURL() on html attachments

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-attachment-card-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-attachment-card-view.ts
@@ -148,7 +148,7 @@ class GmailAttachmentCardView {
       const download_url = this._element.getAttribute('download_url');
 
       if (download_url) {
-        const m = /:(https:\/\/[^:]+)/.exec(download_url);
+        const m = /:(https:\/\/.+)/.exec(download_url);
         return m ? m[1] : null;
       }
     } else {


### PR DESCRIPTION
Fixes https://github.com/InboxSDK/InboxSDK/issues/1204.

The AttachmentCardView.getDownloadURL() method started failing recently on html attachments, possibly because of a recent Gmail change. The "download_url" attribute set by Gmail that the InboxSDK reads has a string separated with colons and a URL. The URL now contains colons sometimes, and the regex we would use to get the URL out of the "download_url" attribute would not handle that correctly.