### PR TITLE
Cache extension ID, avoid "Extension context invalidated" errors in logs

### DIFF
--- a/src/common/get-extension-id.ts
+++ b/src/common/get-extension-id.ts
@@ -1,10 +1,19 @@
 export default function getExtensionId(): string | null {
-  const chrome: any = (global as any).chrome;
-  if (chrome?.runtime?.getURL) {
-    return chrome.runtime.getURL('');
-  }
-  if (chrome?.extension?.getURL) {
-    return chrome.extension.getURL('');
+  try {
+    const chrome: any = (global as any).chrome;
+    if (chrome?.runtime?.getURL) {
+      return chrome.runtime.getURL('');
+    }
+    // MV2
+    if (chrome?.extension?.getURL) {
+      return chrome.extension.getURL('');
+    }
+  } catch (e) {
+    // When an extension is reloaded or removed, then Chrome APIs in any of its
+    // pre-existing content scripts start throwing "Extension context
+    // invalidated" errors. We only use extension IDs for logging, so we
+    // shouldn't treat this as fatal.
+    console.error('Failed to get extension ID:', e);
   }
   return null;
 }

--- a/src/common/get-extension-id.ts
+++ b/src/common/get-extension-id.ts
@@ -1,6 +1,8 @@
-export default function getExtensionId(): string | null {
+import once from 'lodash/once';
+
+const getExtensionId = once((): string | null => {
   try {
-    const chrome: any = (global as any).chrome;
+    const chrome: any = (globalThis as any).chrome;
     if (chrome?.runtime?.getURL) {
       return chrome.runtime.getURL('');
     }
@@ -16,4 +18,6 @@ export default function getExtensionId(): string | null {
     console.error('Failed to get extension ID:', e);
   }
   return null;
-}
+});
+
+export default getExtensionId;

--- a/src/common/get-extension-id.ts
+++ b/src/common/get-extension-id.ts
@@ -15,9 +15,13 @@ const getExtensionId = once((): string | null => {
     // pre-existing content scripts start throwing "Extension context
     // invalidated" errors. We only use extension IDs for logging, so we
     // shouldn't treat this as fatal.
-    console.error('Failed to get extension ID:', e);
+    console.error('Failed to read extension ID:', e);
   }
   return null;
 });
+
+// pre-cache the extension ID so we still know it inside this content script if
+// the extension is reloaded or removed later.
+getExtensionId();
 
 export default getExtensionId;


### PR DESCRIPTION
When an extension is reloaded or removed, certain Chrome APIs in its content scripts switch to throwing "Extension context invalidated" errors when called. The InboxSDK is mostly unaffected since it mostly doesn't use these APIs, except when logging an error it tries to get the extension's ID using a Chrome API. This means that the next time the InboxSDK tries to log an error after the extension is reloaded or removed, the InboxSDK ends up interrupting itself with a new error from trying to look up the extension ID. (This doesn't cause an infinite loop because we catch any errors thrown while logging an error and log them through a simpler code path, but it does add a lot of noise in the console that distracts from any actual errors triggered by the extension itself.)

![Screenshot 2024-06-18 at 16 24 58](https://github.com/InboxSDK/InboxSDK/assets/577345/3d4f6ae5-4ab1-40e3-880c-1a4d3ee31270)

This PR fixes this by:
1. The getExtensionId() function now uses a try-catch and logs any errors itself instead of letting the error be thrown from it, since for all of the uses of the function it's better to have a `null` instead of being interrupted by an error.
2. We call getExtensionId() once on startup and cache its result, so that way if it's called again later after the extension has been reloaded or removed, it still remembers the extension's ID.