### PR TITLE
Prevent pageWorld.js from possibly running in the wrong page

### DIFF
--- a/packages/core/background.js
+++ b/packages/core/background.js
@@ -3,8 +3,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'inboxsdk__injectPageWorld' && sender.tab) {
     if (chrome.scripting) {
       // MV3
+      let documentIds;
+      let frameIds;
+      if (sender.documentId) {
+        // Protect against https://github.com/w3c/webextensions/issues/8 in
+        // browsers (Chrome 106+) that support the documentId property.
+        // Protections for other browsers happen inside the injected script.
+        documentIds = [sender.documentId];
+      } else {
+        frameIds = [sender.frameId];
+      }
       chrome.scripting.executeScript({
-        target: { tabId: sender.tab.id, frameIds: [sender.frameId] },
+        target: { tabId: sender.tab.id, documentIds, frameIds },
         world: 'MAIN',
         files: ['pageWorld.js'],
       });


### PR DESCRIPTION
This PR prevents the issue described in https://github.com/w3c/webextensions/issues/8 from affecting the execution of pageWorld.js. I've never observed the issue happening, though I expect that if it did then it would cause some confusing console errors. I avoid the issue by using the [`documentIds` option to scripting.executeScript()](https://developer.chrome.com/docs/extensions/reference/api/scripting#type-InjectionTarget) when available (Chrome 106+) and otherwise by checking within the injected script that it's running in the document that requested it.