### PR TITLE
Better simpler console error logging

### DIFF
--- a/src/common/log-error.ts
+++ b/src/common/log-error.ts
@@ -71,20 +71,17 @@ export default function logError(
     // our own current stack just in case.
     const nowStack = getStackTrace();
 
-    const stuffToLog: any[] = ['Error logged:', err];
-    if (err && (err as any).stack) {
-      stuffToLog.push('\n\nOriginal error stack:\n' + (err as any).stack);
-    }
-    stuffToLog.push('\n\nError logged from:\n' + nowStack);
+    const stuffToLog: unknown[] = ['Error logged:', err];
     if (details) {
       stuffToLog.push('\n\nError details:', details);
     }
-    stuffToLog.push('\n\nExtension App Ids:', JSON.stringify(appIds, null, 2));
-    stuffToLog.push('\nSent by App:', sentByApp);
-    stuffToLog.push('\nSession Id:', sessionId);
-    stuffToLog.push('\nExtension Id:', getExtensionId());
-    stuffToLog.push('\nInboxSDK Loader Version:', loaderVersion);
-    stuffToLog.push('\nInboxSDK Implementation Version:', implVersion);
+    stuffToLog.push(`\
+\n\nExtension App Ids: ${JSON.stringify(appIds, null, 2)}
+Sent by App: ${sentByApp}
+Session Id: ${sessionId}
+Extension Id: ${getExtensionId()}
+InboxSDK Loader Version: ${loaderVersion}
+InboxSDK Implementation Version: ${implVersion}`);
 
     console.error(...stuffToLog);
 


### PR DESCRIPTION
The console logging we do when we catch an uncaught error is a bit redundant, and on Safari the redundant parts are useless because the stack property of errors in content scripts don't have file and line number information. Also the formatting of parts of the logged text is bad on Safari specifically. This PR removes the redundant parts of what we log to the console and also improves the formatting of the rest to look better in Safari.

1. When we log an error to the console, we logged the error, the error's stacktrace, and the stacktrace of the current logging call. It's redundant to log the error's stacktrace because it can be viewed by expanding the error in the console. It's redundant to log the stacktrace of the current logging call because the browser already shows the stacktrace on `console.error()` calls. (I believe both of these things weren't true when I originally wrote this error logging code.)

2. In Safari specifically, all arguments to `console.error()` are rendered separately. This made our output really ugly. Now we combine as much as possible into a single string argument so the output isn't split up a bunch of times.

Safari screenshots, before:

![Screenshot 2024-07-15 at 5 06 29 PM](https://github.com/user-attachments/assets/9f664bfc-602b-46f2-b857-e0b80fbf9029)

After:

<img width="661" alt="Screenshot 2024-07-15 at 10 46 24 AM" src="https://github.com/user-attachments/assets/590c763b-4f09-4292-89ec-dfea49cd006b">