### PR TITLE
use more stable selector for button parent

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
@@ -611,7 +611,7 @@ export default class GmailNavItemView {
         buttonOptions,
       );
 
-      const accessoryEl = querySelector(this._element, '.Yh');
+      const accessoryEl = buttonOptions.buttonView.getElement(); // querySelector(this._element, '.Yh');
       const parentNode = accessoryEl.parentNode;
       if (parentNode) {
         buttonOptions.buttonView


### PR DESCRIPTION
We've just created the element in the `buttonView`, so is there a reason we can't just select it directly?