### PR TITLE
Fix build InboxSDK examples with --watch flag

### DIFF
--- a/examples/build.ts
+++ b/examples/build.ts
@@ -3,9 +3,7 @@ import path from 'node:path';
 import esbuild from 'esbuild';
 
 type BuildConfig = Parameters<typeof esbuild.build>[0];
-type Watcher = ReturnType<typeof esbuild.context>;
 
-let esbuildWatch: undefined | Watcher;
 const TIMING_LABEL = 'building ./examples took';
 
 const buildSdkFiles = ['@inboxsdk/core/pageWorld', '@inboxsdk/core/background'];
@@ -65,10 +63,9 @@ export async function buildExamples({
     entryNames: '[dir]/[name]',
   };
 
-  if (watch && esbuildWatch == null) {
-    esbuildWatch = esbuild.context(config);
-
-    (await esbuildWatch).watch();
+  if (watch) {
+    const esbuildWatch = await esbuild.context(config);
+    await esbuildWatch.watch();
   } else {
     await esbuild.build(config);
   }

--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -30,8 +30,8 @@ const args = stdio.getopt({
     key: 'c',
     description: 'Copy dev build to Streak dev build folder',
   },
-  examples: {
-    description: 'Copy inboxsdk.js to all subdirs under examples/',
+  noExamples: {
+    description: `Don't build examples/ extensions`,
   },
 })!;
 
@@ -59,6 +59,9 @@ process.env.IMPLEMENTATION_URL = args.production
  * @deprecated when MV2 support is removed, delete this function.
  */
 async function setupExamples() {
+  if (args.noExamples) {
+    return;
+  }
   const dirs: string[] = [];
   if (args.copyToStreak) {
     dirs.push('../MailFoo/extensions/devBuilds/chrome/');
@@ -416,7 +419,7 @@ if (args.remote) {
     },
     disableMinification: true,
     afterBuild: async () => {
-      if (args.examples && !startedBuildingExamples) {
+      if (!args.noExamples && !startedBuildingExamples) {
         startedBuildingExamples = true;
 
         const contentScriptFps = await fg(

--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -400,6 +400,8 @@ if (args.remote) {
   };
 } else {
   // standard npm non-remote bundle
+  let startedBuildingExamples = false;
+
   config = {
     entry: {
       ...pageWorld,
@@ -414,7 +416,9 @@ if (args.remote) {
     },
     disableMinification: true,
     afterBuild: async () => {
-      if (args.examples) {
+      if (args.examples && !startedBuildingExamples) {
+        startedBuildingExamples = true;
+
         const contentScriptFps = await fg(
           ['.ts', '.js'].map((ext) => './examples/*/content' + ext),
         );

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "typecheck": "tsc",
     "typedefs": "tsc -p tsconfig.declarations.json",
     "prepare": "husky install",
-    "publish-npm": "gulp clean && gulp --production && yarn workspace @inboxsdk/core npm publish && git push --follow-tags",
+    "publish-npm": "gulp clean && gulp --production --noExamples && yarn workspace @inboxsdk/core npm publish && git push --follow-tags",
     "lint": "yarn run lint:eslint && yarn run prettier:check",
     "lint:fix": "yarn run lint:eslint --fix && yarn run prettier:fix",
     "lint:eslint": "eslint . --report-unused-disable-directives --max-warnings 0",
@@ -111,7 +111,7 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "puppeteer": "jest -c test/chrome/jest.config.js --runInBand",
-    "start": "gulp default -w --reloader --examples",
+    "start": "gulp default -w --reloader",
     "test": "jest"
   },
   "lint-staged": {


### PR DESCRIPTION
- Building InboxSDK examples with the --watch flag would start esbuild again every time any input file was changed.
- Re-enable building the examples by default with the InboxSDK.