### PR TITLE
Fix nav item name and plus ("create") button not showing up always

### DIFF
--- a/examples/nav-menu/content.js
+++ b/examples/nav-menu/content.js
@@ -1,4 +1,5 @@
 import * as InboxSDK from '@inboxsdk/core';
+import * as Kefir from 'kefir';
 
 function log() {
   console.log.apply(
@@ -93,15 +94,33 @@ InboxSDK.load(1, 'nav-menu').then(function (sdk) {
   };
 
   const initNavItemCollapse = () => {
-    const parent = sdk.NavMenu.addNavItem({
-      accessory: {
-        onClick: () => {
-          parent.setCollapsed(!parent.isCollapsed());
-        },
-        type: 'CREATE',
-      },
-      name: 'P - Toggle Collapse',
-    });
+    const parent = sdk.NavMenu.addNavItem(
+      Kefir.later(500, {
+        name: 'P - Toggle Collapse 1',
+      })
+        .merge(
+          Kefir.later(1000, {
+            accessory: {
+              onClick: () => {
+                parent.setCollapsed(!parent.isCollapsed());
+              },
+              type: 'CREATE',
+            },
+            name: 'P - Toggle Collapse 2',
+          }),
+        )
+        .merge(
+          Kefir.later(2000, {
+            accessory: {
+              onClick: () => {
+                parent.setCollapsed(!parent.isCollapsed());
+              },
+              type: 'CREATE',
+            },
+            name: 'P - Toggle Collapse 3',
+          }),
+        ),
+    );
 
     const child = parent.addNavItem({
       accessory: {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
@@ -1099,7 +1099,14 @@ export default class GmailNavItemView {
       return;
     }
 
-    const nameElement = this._element.querySelector('.inboxsdk__navItem_name');
+    let nameElement = this._element.querySelector('.inboxsdk__navItem_name');
+    if (
+      nameElement &&
+      nameElement.closest('.inboxsdk__navItem') !== this._element
+    ) {
+      // ignore the name element if it belongs to a child nav item
+      nameElement = null;
+    }
 
     switch (type) {
       case NAV_ITEM_TYPES.GROUPER:

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
@@ -403,18 +403,20 @@ export default class GmailNavItemView {
       );
       this._accessoryViewController = accessoryViewController;
 
-      const accessoryEl = querySelector(this._element, '.Yh');
-      const parentNode = accessoryEl.parentNode;
-      if (parentNode) {
-        buttonOptions.buttonView
-          .getElement()
-          .classList.add(...accessoryEl.classList);
-        parentNode.replaceChild(
-          buttonOptions.buttonView.getElement(),
-          accessoryEl,
-        );
-        this._iconSettings.iconElement = null;
-      }
+      const accessoryEl = querySelector(
+        this._element,
+        '.Yh:not(.inboxsdk__navItem_parent_accessory_button)',
+      );
+
+      buttonOptions.buttonView
+        .getElement()
+        .classList.add(...accessoryEl.classList);
+
+      accessoryEl.style.display = 'none';
+      accessoryEl.parentNode!.appendChild(
+        buttonOptions.buttonView.getElement(),
+      );
+      this._iconSettings.iconElement = null;
 
       return;
     }
@@ -611,18 +613,20 @@ export default class GmailNavItemView {
         buttonOptions,
       );
 
-      const accessoryEl = querySelector(this._element, '.Yh');
-      const parentNode = accessoryEl.parentNode;
-      if (parentNode) {
-        buttonOptions.buttonView
-          .getElement()
-          .classList.add(...accessoryEl.classList);
-        parentNode.replaceChild(
-          buttonOptions.buttonView.getElement(),
-          accessoryEl,
-        );
-        this._iconSettings.iconElement = null;
-      }
+      const accessoryEl = querySelector(
+        this._element,
+        '.Yh:not(.inboxsdk__navItem_parent_accessory_button)',
+      );
+
+      buttonOptions.buttonView
+        .getElement()
+        .classList.add(...accessoryEl.classList);
+
+      accessoryEl.style.display = 'none';
+      accessoryEl.parentNode!.appendChild(
+        buttonOptions.buttonView.getElement(),
+      );
+      this._iconSettings.iconElement = null;
 
       return;
     }


### PR DESCRIPTION
This PR fixes two issues:

- If Gmail is set so both Chat and Meet are disabled, and a stream passed to `NavMenu.addNavItem()` emits a value with a accessory button multiple times, then the accessory button would disappear from the page.
- If Gmail is set so Chat is on, and a stream passed to `NavMenu.addNavItem()` emits its first value after child nav items have been added, then the value's name property would be set on a child of the nav item instead of directly on the nav item.