### PR TITLE
Add ListRouteView.hideSearchPageFilterToolbar() method

### DIFF
--- a/examples/add-route-view-sections/content.js
+++ b/examples/add-route-view-sections/content.js
@@ -68,12 +68,17 @@ InboxSDK.load(1.0, 'route-view-sections-example').then(function (inboxSDK) {
       var el = document.createElement('div');
       el.innerHTML = 'Hello World';
 
-      var view3 = listRouteView.addSection({
-        title: 'No Collapse!',
-        contentElement: el,
-        footerLinkText: 'Smell my feet',
-        onFooterLinkClick: console.log.bind(console, 'they stink!'),
-      });
+      if (
+        listRouteView.getRouteID() === inboxSDK.Router.NativeRouteIDs.SEARCH
+      ) {
+        const view3 = listRouteView.addSection({
+          contentElement: el,
+          footerLinkText: 'Hide filter toolbars (present on search pages)',
+          onFooterLinkClick() {
+            listRouteView.hideSearchPageFilterToolbar();
+          },
+        });
+      }
 
       var bus = new Bacon.Bus();
       listRouteView.addCollapsibleSection(bus);

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -91,6 +91,7 @@ class GmailRouteView implements RouteViewDriver {
         .takeUntilBy(this._stopper)
         .onValue(async () => {
           await this.#waitForMainElementSafe();
+          if (this._stopper.stopped) return;
 
           var last = driver.getLastCustomThreadListActivity();
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -268,6 +268,19 @@ class GmailRouteView implements RouteViewDriver {
     return gmailResultsSectionView;
   }
 
+  hideSearchPageFilterToolbar() {
+    toItemWithLifetimeStream(
+      this.#page.tree.getAllByTag('rowListElementContainer'),
+    )
+      .takeUntilBy(this._stopper)
+      .onValue(({ el, removalStream }) => {
+        el.getValue().classList.add('inboxsdk__hide_filter_toolbar');
+        removalStream.onValue(() => {
+          el.getValue().classList.remove('inboxsdk__hide_filter_toolbar');
+        });
+      });
+  }
+
   _setupCustomViewElement() {
     this._customViewElement = document.createElement('div');
 

--- a/src/platform-implementation-js/driver-interfaces/route-view-driver.ts
+++ b/src/platform-implementation-js/driver-interfaces/route-view-driver.ts
@@ -30,6 +30,7 @@ export type RouteViewDriver = MinRouteViewDriver & {
     >,
     groupOrderHint: any,
   ): GmailCollapsibleSectionView;
+  hideSearchPageFilterToolbar(): void;
   getCustomViewElement(): HTMLElement | null | undefined;
   setFullWidth(fullWidth: boolean): void;
 };

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -2813,3 +2813,14 @@ table[role='presentation'].inboxsdk__thread_view_with_custom_view > tr {
 .T-I.J-J5-Ji.T-I-ax7.inboxsdk__button .asa::after {
   width: auto;
 }
+
+/* ListRouteView hideFilterToolbar() support */
+.inboxsdk__hide_filter_toolbar .G6[role="toolbar"] /* chat+meet off */,
+.inboxsdk__hide_filter_toolbar .biW[data-srm="email"] /* chat+meet on */ {
+  display: none;
+}
+
+.inboxsdk__hide_filter_toolbar .G-atb.PY /* chat+meet off */ {
+  min-height: 32px !important;
+  height: 32px !important;
+}

--- a/src/platform-implementation-js/views/route-view/list-route-view.ts
+++ b/src/platform-implementation-js/views/route-view/list-route-view.ts
@@ -69,6 +69,16 @@ class ListRouteView extends RouteView {
     return sectionView;
   }
 
+  /**
+   * Hides the search filter toolbar that appears on search pages.
+   *
+   * This method may not support other pages such as the Sent page, even though
+   * it has a very similar filter toolbar.
+   */
+  hideSearchPageFilterToolbar() {
+    this.#routeViewDriver.hideSearchPageFilterToolbar();
+  }
+
   /** Simulates a click on the Gmail thread list refresh button. */
   refresh() {
     this.#routeViewDriver.refresh();


### PR DESCRIPTION
Adds ListRouteView hideSearchPageFilterToolbar() method that hides this top toolbar on search pages:
<img width="1039" alt="Screenshot 2024-08-01 at 4 56 40 PM" src="https://github.com/user-attachments/assets/34317590-7eef-4fdb-b6ef-563324e3c605">

Currently does nothing on non-search pages (such as Sent) even though some other pages have a visually similar filter toolbar, as those toolbars are structured differently in the document.