### PR TITLE
quick fix

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -45,7 +45,7 @@ const GmailElementGetter = {
     return document.querySelector('.brC-brG');
   },
 
-  // <div class="brC-aT5-aOt-Jw" role="navigation" aria-label="Side panel">
+  // <div class="brC-aT5-aOt-Jw" role="complementary" aria-label="Side panel">
   getCompanionSidebarIconContainerElement(): HTMLElement | null {
     return document.querySelector('.brC-aT5-aOt-Jw');
   },

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.tsx
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.tsx
@@ -704,6 +704,13 @@ class GmailAppSidebarPrimary {
       );
     }
 
+    // detect 2024-11-07 gmail update that moved sidebar icons to the right of
+    // the sidebar
+    if (this.#companionSidebarOuterWrapper.classList.contains('WN9Ejb')) {
+      document.body.classList.add('inboxsdk__sidebar_icons_right');
+      this.#driver.getLogger().eventSite('sidebar_icons_right');
+    }
+
     const contentContainer =
       this.#companionSidebarOuterWrapper.previousElementSibling;
 

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1815,7 +1815,7 @@ body :local(.sidebar_iconArea) .inboxsdk__button_icon {
 }
 
 /* old pre-2024-11-07 sidebar where buttons were on the right of the panel */
-:local(.companion_container_app_sidebar_in_use)
+body:not(.inboxsdk__sidebar_icons_right)
   :local(.sidebar_iconArea)
   .sidebar_button_container_active
   .inboxsdk__button_selectedIndicator {
@@ -1841,6 +1841,7 @@ body :local(.sidebar_iconArea) .inboxsdk__button_icon {
   display: block !important;
 }
 
+/* for 2024-11-07 gmail change moving sidebar icons to the right */
 .WN9Ejb.br3.companion_app_sidebar_wrapper_visible {
   display: block !important;
 }
@@ -1855,10 +1856,6 @@ body :local(.sidebar_iconArea) .inboxsdk__button_icon {
 }
 
 .nH.companion_container_app_sidebar_visible {
-  width: calc(100% - 300px) !important;
-}
-
-.nH > .GYfbG.j1GQLc.companion_container_app_sidebar_visible {
   width: calc(100% - 300px) !important;
 }
 

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1806,7 +1806,7 @@ body :local(.sidebar_iconArea) .inboxsdk__button_icon {
   .sidebar_button_container_active
   .inboxsdk__button_selectedIndicator {
   height: 40px;
-  width: 4px;
+  width: 3px;
   position: absolute;
   right: 0px;
   bottom: 0px;

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1831,6 +1831,10 @@ body :local(.sidebar_iconArea) .inboxsdk__button_icon {
   display: block !important;
 }
 
+.WN9Ejb.br3.companion_app_sidebar_wrapper_visible {
+  display: block !important;
+}
+
 .companion_global_app_sidebar_visible .thread_app_sidebar {
   display: none;
 }
@@ -1841,6 +1845,10 @@ body :local(.sidebar_iconArea) .inboxsdk__button_icon {
 }
 
 .nH.companion_container_app_sidebar_visible {
+  width: calc(100% - 300px) !important;
+}
+
+.nH > .GYfbG.j1GQLc.companion_container_app_sidebar_visible {
   width: calc(100% - 300px) !important;
 }
 

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1808,9 +1808,19 @@ body :local(.sidebar_iconArea) .inboxsdk__button_icon {
   height: 40px;
   width: 3px;
   position: absolute;
-  right: 0px;
+  left: 0px;
   bottom: 0px;
   background-color: rgb(66 133 244);
+  border-radius: 0 3px 3px 0;
+}
+
+/* old pre-2024-11-07 sidebar where buttons were on the right of the panel */
+:local(.companion_container_app_sidebar_in_use)
+  :local(.sidebar_iconArea)
+  .sidebar_button_container_active
+  .inboxsdk__button_selectedIndicator {
+  left: unset;
+  right: 0;
   border-radius: 3px 0 0 3px;
 }
 


### PR DESCRIPTION
tested current side panel for a lot of users who don't have the gmail side panel changes yet still works:

<img width="364" alt="image" src="https://github.com/user-attachments/assets/96093152-341d-4f67-8396-7b3e4246a5e3">


gmail is rolling out changes to show side panel like this, tested on gmail that has the change works too:
<img width="398" alt="image" src="https://github.com/user-attachments/assets/7c8f4f7e-7e45-4be3-b091-47152dea69cb">

