### PR TITLE
Tweak positioning to work with both old and new popover style

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -2800,7 +2800,6 @@ table[role='presentation'].inboxsdk__thread_view_with_custom_view > tr {
 .inboxsdk__linkPopOver_section_container {
   position: absolute;
   width: 100%;
-  top: 35px;
   left: 0;
 }
 

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -2801,6 +2801,7 @@ table[role='presentation'].inboxsdk__thread_view_with_custom_view > tr {
   position: absolute;
   width: 100%;
   left: 0;
+  margin-top: 10px;
 }
 
 .inboxsdk__linkPopOver_section {

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -2801,7 +2801,7 @@ table[role='presentation'].inboxsdk__thread_view_with_custom_view > tr {
   position: absolute;
   width: 100%;
   left: 0;
-  margin-top: 10px;
+  margin-top: 8px;
 }
 
 .inboxsdk__linkPopOver_section {


### PR DESCRIPTION
Gmail has new popover styles for editing links. Fix the positioning of the SDK popovers.

A tad suspicious why I had the top position defined in the first place but maybe there was something going on with that container that they changed to support the new content state (there are still states that use the old style popover)

Before:
![image](https://github.com/user-attachments/assets/3bab143d-70e5-4955-9e51-8998cc8c9402)

After:
![image](https://github.com/user-attachments/assets/f3eb2a49-3aaa-4d9b-94b1-54bcc01408d2)
