### PR TITLE
Potential fix for issue #1155.

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.ts
@@ -483,27 +483,27 @@ export default function showCustomThreadList(
     .changes()
     .take(1)
     .map(() => searchInput)
-    .filter((input: HTMLElement)  => !!Boolean(input))
-    .flatMapLatest((input: HTMLElement) => 
+    .flatMapLatest((input: HTMLElement) =>
       makeMutationObserverChunkedStream(input, {
         attributes: true,
         attributeOldValue: true,
       })
-      .filter((mutationRecords: MutationRecord[]) => {
-        // These are sort of arbitrary, they just occur after input.value has been written on the inputSearbox 
-        return mutationRecords.some(mutationRecord => 
-          mutationRecord.attributeName === 'role' && mutationRecord.oldValue === 'combobox'
-        )
-      })
-      .take(1)
+        .filter((mutationRecords: MutationRecord[]) => {
+          // These are sort of arbitrary, they just occur after input.value has been written on the inputSearbox
+          return mutationRecords.some(
+            (mutationRecord) =>
+              mutationRecord.attributeName === 'role' &&
+              mutationRecord.oldValue === 'combobox',
+          );
+        })
+        .take(1),
+    );
 
-  )
-  
   inputStream.onValue(() => {
     searchInput.value = '';
     searchInput.style.visibility = 'visible';
-  })
-  
+  });
+
   searchInput.style.visibility = 'hidden';
 
   // Change the hash *without* making a new history entry.

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.ts
@@ -7,6 +7,7 @@ import type GmailDriver from '../gmail-driver';
 import isStreakAppId from '../../../lib/isStreakAppId';
 import update from 'immutability-helper';
 import isNotNil from '../../../../common/isNotNil';
+import makeMutationObserverChunkedStream from '../../../lib/dom/make-mutation-observer-chunked-stream';
 
 type ThreadDescriptor =
   | string
@@ -475,17 +476,35 @@ export default function showCustomThreadList(
   );
   const customHash = document.location.hash;
 
-  const nextMainContentElementChange =
-    GmailElementGetter.getMainContentElementChangedStream().changes().take(1);
-
   const searchInput = GmailElementGetter.getSearchInput();
   if (!searchInput) throw new Error('could not find search input');
-  searchInput.value = '';
-  searchInput.style.visibility = 'hidden';
-  nextMainContentElementChange.onValue(() => {
-    // setup-route-view-driver-stream handles clearing search again
+
+  const inputStream = GmailElementGetter.getMainContentElementChangedStream()
+    .changes()
+    .take(1)
+    .map(() => searchInput)
+    .filter((input: HTMLElement)  => !!Boolean(input))
+    .flatMapLatest((input: HTMLElement) => 
+      makeMutationObserverChunkedStream(input, {
+        attributes: true,
+        attributeOldValue: true,
+      })
+      .filter((mutationRecords: MutationRecord[]) => {
+        // These are sort of arbitrary, they just occur after input.value has been written on the inputSearbox 
+        return mutationRecords.some(mutationRecord => 
+          mutationRecord.attributeName === 'role' && mutationRecord.oldValue === 'combobox'
+        )
+      })
+      .take(1)
+
+  )
+  
+  inputStream.onValue(() => {
+    searchInput.value = '';
     searchInput.style.visibility = 'visible';
-  });
+  })
+  
+  searchInput.style.visibility = 'hidden';
 
   // Change the hash *without* making a new history entry.
   const searchHash =


### PR DESCRIPTION
# Change log

This is a potential fix for issue [#1155](https://github.com/InboxSDK/InboxSDK/issues/1155#top). 

My findings are in the comments of the above issue. 
Tests were unaffected by the change 🤔.

## Changes
- Create a mutationObserver stream on the input box that listens for changes in "role" before setting the visibility of the input box to `visible` (a little brittle I know). This attribute change happens right after the `input.value` is set.
- Remove `nextMainContentElementChange.onValue` to set the the visibility of the input box to `visible`

### Before update

![before-tab-switch](https://github.com/user-attachments/assets/a0df4cc6-a639-4efb-9689-b06daee6bec4)


### After update

![after-tab-switch](https://github.com/user-attachments/assets/35c483af-a61d-4dd1-a5b5-5a36148d56d6)

