### PR TITLE
Add more specific class to avoid race condition when loading the inbox sdk

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -42,7 +42,7 @@ const GmailElementGetter = {
   },
 
   getCompanionSidebarContentContainerElement(): HTMLElement | null {
-    return document.querySelector('.brC-brG');
+    return document.querySelector('.brC-brG.brC-aMv-auO');
   },
 
   // <div class="brC-aT5-aOt-Jw" role="complementary" aria-label="Side panel">


### PR DESCRIPTION
# Change log

This is a fix for the bug reported on issue [#809](https://github.com/InboxSDK/InboxSDK/issues/809)

The issue appears to be a race condition. The [gmail-element-getter](https://github.com/InboxSDK/InboxSDK/blob/0de424786e0c05834f753fedaa89e852ce5df139/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts#L45) is querySelecting the sidebar container using the class `.brC-brG` (sidebar selector) . 

However, if the InboxSDK loads before the gmail calendar, the sidebar selector will select an element with the full class list of `.brC-brG .brC-aW-aV` (first element), which will be removed and replaced by a very similar element with a full class list of `.brC-brG .brC-aMv-auO` (second element).

So, the InboxSDK attaches to the first element which, the calendar loads, and the first element is removed from the DOM and the side panel is forever doomed. 

This does not appear to be happening on the main Streak product because it just loads slower then the calendar.

___Before fix class list change___
![before-wrong-class-calload](https://github.com/user-attachments/assets/a64017b2-1338-4856-b10f-d715c30c054b)


___After fix class list change___

![afterfix-right-class-calload](https://github.com/user-attachments/assets/be3f6891-d0fc-40a5-aae5-8b86347cc612)





