### PR TITLE
Update replaceDate function to operate on a single element for updates.

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-row-view.ts
@@ -1093,7 +1093,9 @@ class GmailThreadRowView {
           }
         } else {
           if (!dateMod) {
-            dateMod = this._modifications.replacedDate.unclaimed.shift();
+            dateMod = this._modifications.replacedDate.unclaimed.length 
+              ? this._modifications.replacedDate.unclaimed.shift()
+              : this._modifications.replacedDate.claimed.shift();
 
             if (!dateMod) {
               dateMod = {


### PR DESCRIPTION
# Changelog

This is a potential fix for issue [#1153](https://github.com/InboxSDK/InboxSDK/issues/1153).
My comments and reasoning are [here](https://github.com/InboxSDK/InboxSDK/issues/1153#issuecomment-2489519863)

## Changes
- update retrieving of the dateMod from `this._modifications.replacedDate.unclaimed` to also check `this._modifications.replacedDate.claimed` and use the element in `claimed` if it exists.  This ensures that replaceDate will replace the original date and any subsequent calls will  update the replacement. 

