### PR TITLE
Ignore artificial thread row elements added by Simplify Gmail

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-row-list-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-row-list-view.ts
@@ -255,7 +255,8 @@ class GmailRowListView {
         (rowEvent) =>
           Boolean(rowEvent.el.id) &&
           // let other extensions opt their rows out of our processing
-          !rowEvent.el.classList.contains('inboxsdk__ignore_row'),
+          !rowEvent.el.classList.contains('inboxsdk__ignore_row') &&
+          !rowEvent.el.classList.contains('bundle'),
       );
     const laterStream = Kefir.later(2, undefined);
     this._rowViewDriverStream = elementStream


### PR DESCRIPTION
This PR makes the InboxSDK ignore thread row elements containing the `bundle` classname (used by Simplify Gmail) or the `inboxsdk__ignore_row` classname.
Re: https://github.com/InboxSDK/InboxSDK/issues/1224
