### PR TITLE
add MessageView.getElement

### DIFF
--- a/src/platform-implementation-js/views/conversations/message-view.ts
+++ b/src/platform-implementation-js/views/conversations/message-view.ts
@@ -139,6 +139,10 @@ export default class MessageView extends (EventEmitter as new () => TypedEventEm
     this.#messageViewImplementation.addMoreMenuItem(buttonOptions);
   }
 
+  getElement(): HTMLElement {
+    return this.#messageViewImplementation.getElement();
+  }
+
   getBodyElement(): HTMLElement {
     return this.#messageViewImplementation.getContentsElement();
   }


### PR DESCRIPTION
@Macil same motivation and reasoning as https://github.com/InboxSDK/InboxSDK/pull/1165:

Gmail has been relatively stable, Google Inbox was discontinued, it's extremely useful to prototype features using direct access to elements outside of the InboxSDK, and some extensions want to do things that the InboxSDK doesn't want to commit to maintaining, so we're much more willing to expose Gmail elements now where it's useful to.