### PR TITLE
additional getters in linkPopOver

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/setupLinkPopovers.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view/setupLinkPopovers.ts
@@ -19,6 +19,17 @@ class LinkPopOver extends SafeEventEmitter {
     return this._linkEl;
   }
 
+  getPopOverContainerElement() {
+    return this._popOverEl;
+  }
+
+  getUrlInputElement() {
+    // this is for the new gmail UI
+    return this._popOverEl.querySelector<HTMLInputElement>(
+      '.qdOxv-K0-wGMbrd[aria-label="Link"]',
+    );
+  }
+
   addSection() {
     let containerEl = this._popOverEl.querySelector<HTMLElement>(
       '.inboxsdk__linkPopOver_section_container',

--- a/src/platform-implementation-js/views/compose-view.ts
+++ b/src/platform-implementation-js/views/compose-view.ts
@@ -34,6 +34,8 @@ const memberMap = ud.defonce(module, () => new WeakMap<ComposeView, Members>());
 export type LinkPopOver = {
   getLinkElement(): HTMLAnchorElement;
   addSection(): LinkPopOverSection;
+  getPopOverContainerElement(): HTMLElement;
+  getUrlInputElement(): HTMLInputElement | null;
 } & TypedEventEmitter<{ close(): void }>;
 
 export interface LinkPopOverSection {


### PR DESCRIPTION
Two functions to help users access contents of gmail's link popover easier. This is helpful with gmail's new UI where the link editing happens in the popover rather than a separate modal, so there are more states and more activity in the popover now.