### PR TITLE
Potentially resolve #1151: add parseOnActivateResult tests

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.test.ts
@@ -404,8 +404,10 @@ test('missing threads in response', async () => {
 
 describe('parseOnActivateResult', () => {
   const fakeLogger = {
+    /* eslint-disable  @typescript-eslint/no-empty-function */
     deprecationWarning: (..._) => {},
     error: (..._) => {},
+    /* eslint-enable @typescript-eslint/no-empty-function */
   } as Logger;
   test("should default to one page since arrays can't be paginated when provided with a results array", () => {
     const result = [
@@ -436,7 +438,7 @@ describe('parseOnActivateResult', () => {
     );
   });
   test('should throw if BOTH `hasMore` and `total` have values', () => {
-    let result: HandlerResult = { total: 10, hasMore: true, threads: [] };
+    const result: HandlerResult = { total: 10, hasMore: true, threads: [] };
     const expectedError =
       'handleCustomListRoute result must only contain either a "total" or a "hasMore" property, but not both. (https://www.inboxsdk.com/docs/#Router).';
 
@@ -460,7 +462,7 @@ describe('parseOnActivateResult', () => {
 
   test('should correctly parse onActivate result when only total exists', () => {
     const resultTotal = 10;
-    let result: HandlerResult = {
+    const result: HandlerResult = {
       total: resultTotal,
       threads: [
         'id1',
@@ -482,7 +484,7 @@ describe('parseOnActivateResult', () => {
   });
   test('should correctly parse and limit onActivate result when only total exists and result threads are over 50', () => {
     const resultTotal = 150;
-    let result: HandlerResult = {
+    const result: HandlerResult = {
       total: resultTotal,
       threads: [],
     };
@@ -508,7 +510,7 @@ describe('parseOnActivateResult', () => {
     expect(fnResult).toStrictEqual(expected);
   });
   test('should correctly parse onActivate result when only hasMore is true', () => {
-    let result: HandlerResult = {
+    const result: HandlerResult = {
       hasMore: true,
       threads: [],
     };
@@ -531,7 +533,7 @@ describe('parseOnActivateResult', () => {
     expect(fnResult).toStrictEqual(expected);
   });
   test('should correctly parse onActivate result when only hasMore is true and threads are > than MAX', () => {
-    let result: HandlerResult = {
+    const result: HandlerResult = {
       hasMore: true,
       threads: [],
     };
@@ -557,7 +559,7 @@ describe('parseOnActivateResult', () => {
     expect(fnResult).toStrictEqual(expected);
   });
   test('should correctly parse onActivate result when only hasMore is false', () => {
-    let result: HandlerResult = {
+    const result: HandlerResult = {
       hasMore: false,
       threads: [],
     };
@@ -580,7 +582,7 @@ describe('parseOnActivateResult', () => {
     expect(fnResult).toStrictEqual(expected);
   });
   test('should correctly parse onActivate result when only hasMore is false and threads are > than MAX', () => {
-    let result: HandlerResult = {
+    const result: HandlerResult = {
       hasMore: false,
       threads: [],
     };

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.ts
@@ -22,7 +22,7 @@ type InitialIDPair =
 type IDPairWithRFC = { rfcId: string; gtid?: string };
 type CompletedIDPair = { rfcId: string; gtid: string };
 
-type HandlerResult = {
+export type HandlerResult = {
   total?: number;
   hasMore?: boolean;
   threads: Array<ThreadDescriptor>;
@@ -100,7 +100,7 @@ function _findIdFailure(id: string, err: Error) {
   return null;
 }
 
-function parseOnActivateResult(
+export function parseOnActivateResult(
   logger: Logger,
   start: number,
   result: HandlerResult | Array<ThreadDescriptor>,
@@ -126,7 +126,7 @@ function parseOnActivateResult(
       );
     }
 
-    if (total != null && hasMore != null) {
+    if (typeof total === 'number' && typeof hasMore === 'boolean') {
       throw new Error(
         'handleCustomListRoute result must only contain either ' +
           'a "total" or a "hasMore" property, but not both. ' +
@@ -142,7 +142,7 @@ function parseOnActivateResult(
     } else if (typeof hasMore === 'boolean') {
       const threadsWithoutExcess = copyAndOmitExcessThreads(threads, logger);
       return {
-        total: hasMore ? 'MANY' : start + threads.length,
+        total: hasMore ? 'MANY' : start + threadsWithoutExcess.length,
         threads: threadsWithoutExcess,
       };
     } else {


### PR DESCRIPTION
I'm not a user of InboxSDK, but I was perusing the open issues and saw #1151 and it smelled to me like a simple business logic issue. So I added some tests where I was suspicious and I _think_ I found and fixed a couple of little bugs including one that seems like it could be responsible for #1151. Specifically, it looks like it could be a language-translation issue because the logic was doing `null`-checks on variables who's type did not include `null`, but _did_ include `undefined`, which seemed suspicious.

However, someone should probably properly reproduce the issue and see if this resolves it who is an actual user of the software 😅  