### PR TITLE
fix gmail mole

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -262,6 +262,10 @@ class GmailMoleViewDriver {
 
     if (insertBefore instanceof HTMLElement) {
       moleParent.insertBefore(this.#element, insertBefore);
+    } else if (!insertBefore) {
+      // when google chat and meet are disabled, the moleParent element has no children initially,
+      // unlike when enabled and there is a hidden mole like stub created by gmail
+      moleParent.appendChild(this.#element);
     } else {
       this.#driver.logger.error(
         new Error(


### PR DESCRIPTION
when google chat and meet are disabled, the moleParent element has no children initially, unlike when enabled and there is a hidden mole like stub created by gmail
