### PR TITLE
remove mole position overrides

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -486,23 +486,6 @@ div.bHJ .inboxsdk__button {
 
 /* compose buttons */
 
-/*
-fix compose mole position when sidebar is open
-
-steps to repro:
-1. open compose mole
-2. open non-native sidebar
-3. mole overlaps sidebar
-
-The :has portion of this selector hopefully binds the sidebar and mole together for future readers. This selector should survive Gmail changing the width of the left sidebar a little more gracefully too.
-
-TODO: The second selector ending with `[style*=width: 310px;]` should be removed when we drop Safari 15.3 and Chrome 100 support.
-*/
-body:has(.companion_app_sidebar_visible) .dw .nH > .no .nH.nn:last-child,
-.dw .nH > .no .nH.nn:last-child[style*='width: 310px;'] {
-  width: 366px !important;
-}
-
 /* mimic button styling */
 .inboxsdk__composeButton,
 .inboxsdk__compose_sendButton {


### PR DESCRIPTION
looks like we no longer need the sidebar width override now.

close https://github.com/InboxSDK/InboxSDK/issues/1258

before fix:
https://www.loom.com/share/180105b1fd0846e4b2342989b7fbe6a3

after fix:
https://www.loom.com/share/80aac8d3ede949e9aae4cba66b2a6396

 