### PR TITLE
Sidebar removal fix

### DIFF
--- a/examples/sidebar-example/content.js
+++ b/examples/sidebar-example/content.js
@@ -1,11 +1,11 @@
 import * as InboxSDK from '@inboxsdk/core';
 
 InboxSDK.load(2, 'sidebar-example', {
-  appName: 'Twitter',
+  appName: 'Sidebar Example',
   appIconUrl:
     'http://materialdesignblog.com/wp-content/uploads/2015/04/387b93c8b66379c32e1cc2b98dcf5197.png',
   suppressAddonTitle: 'Streak',
-}).then((inboxSDK) => {
+}).then(async (inboxSDK) => {
   window._sdk = inboxSDK;
 
   inboxSDK.Conversations.registerThreadViewHandler(function (threadView) {
@@ -94,11 +94,40 @@ InboxSDK.load(2, 'sidebar-example', {
   const globalPanelEl2 = document.createElement('div');
   globalPanelEl2.innerHTML = `Panel 2.0 content here`;
 
-  inboxSDK.Global.addSidebarContentPanel({
+  let contentPanel = await inboxSDK.Global.addSidebarContentPanel({
     title: 'Panel 2.0',
     appName: 'Not Twitter 2.0',
     iconUrl: chrome.runtime.getURL('monkey-face.jpg'),
     el: globalPanelEl2,
     orderHint: 2,
+  });
+
+  inboxSDK.Compose.registerComposeViewHandler((composeView) => {
+    composeView.addButton({
+      title: 'OPEN SIDEBAR',
+      iconUrl: chrome.runtime.getURL('monkey-face.jpg'),
+      onClick(event) {
+        contentPanel.open();
+      },
+    });
+
+    composeView.addButton({
+      title: 'CLOSE SIDEBAR',
+      iconUrl: chrome.runtime.getURL('monkey-face.jpg'),
+      onClick(event) {
+        contentPanel.close();
+      },
+    });
+
+    composeView.addButton({
+      title: 'REMOVE SIDEBAR',
+      iconUrl: chrome.runtime.getURL('monkey-face.jpg'),
+      onClick(event) {
+        if (contentPanel) {
+          contentPanel.remove();
+          contentPanel = null;
+        }
+      },
+    });
   });
 });

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-app-id-warning.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-app-id-warning.ts
@@ -11,7 +11,7 @@ export default function showAppIdWarning(driver: GmailDriver) {
   <div class="topline">InboxSDK Developer Warning: Invalid AppId</div>
   <div>You've loaded the InboxSDK with an unregistered appId. Registration is free but necessary to load the SDK.</div>
 </div>
-<a class="inboxsdk__appid_register" target="_blank" href="https://www.inboxsdk.com/register">Register Your App</a>
+<a class="inboxsdk__appid_register" target="_blank" href="https://register.inboxsdk.com/">Register Your App</a>
 <input type="button" value="" title="Close" class="inboxsdk__x_close_button" />
 `;
 

--- a/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.ts
+++ b/src/platform-implementation-js/driver-common/sidebar/ContentPanelViewDriver.ts
@@ -165,6 +165,7 @@ class ContentPanelViewDriver {
             appName,
             sidebarId: this.#sidebarId,
             instanceId: this.#instanceId,
+            isGlobal,
           },
         }),
       );


### PR DESCRIPTION
### The original issue:
When I tried call `remove` on a `ContentPanelView`, the method would error out with a message reading `should not happen: failed to find orderItem`. The given content panel would also not be removed and the interior contents were left in an unusable state.

### The fix:
* The underlying issue proved to be that the `inboxsdkRemoveSidebarPanel` was missing the `isGlobal` property from its event `detail` property.
* In GmailAppSidebarView, the `isGlobal` property is used to determine whether a given event is coming from a "thread sidebar" or a "global sidebar" (see `GmailAppSidebarPrimary::844` and `GmailAppSidebarPrimary::1006`).
* Because the `inboxsdkRemoveSidebarPanel` event was missing the `isGlobal` property, the `isGlobal` check would resolve as `false` and the event was ingested by the "thread sidebar" handler. This handler then threw the `"should not happen: failed to find orderItem"` error because it (correctly) could not find the given sidebarId in its list of registered thread sidebars.
* Adding `isGlobal` to the construction site of the `inboxsdkRemoveSidebarPanel` events handily fixes the issue.

### Other changes in this PR:
* I expanded the Sidebar Example extension to also add three compose buttons that call the three main manipulation methods on a `ContentPanelView`: `open`, `close`, and `remove`.
* I updated the link in the "Unregistered App" warning banner to point to the new registration site (the previous link has been dead for a while).
