### PR TITLE
fix loading/empty result in collapsible body to cause whole section s…

### DIFF
--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -2283,6 +2283,12 @@ shows up on our elements preventing them from collapsing.
 
 .inboxsdk__resultsSection .TB.TC {
   text-align: center;
+
+  /* 2025-07-10: Remove padding from the left and right of the message element.
+    prevents .TM .TC from being applied which has a padding 8px on the left and right.
+   */
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .inboxsdk__resultsSection .inboxsdk__resultsSection_loading {


### PR DESCRIPTION
…croll horizontally

issue can be reproduced in example ext Collapsible Sections Inbox SDK example 2.0: when there isn't any results in the collapsible section, the section cause the whole pane horizontally scroll. 