### PR TITLE
Fix compose not detected in new Gmail Update

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -877,8 +877,9 @@ class GmailMessageView {
       .onValue((mutation) => {
         if (mutation !== 'END' && replyContainer.classList.contains('adB')) {
           if (!currentReplyElementRemovalStream) {
-            const replyElement =
-              (replyContainer.getElementsByClassName('M9')?.[0] || replyContainer.firstElementChild) as HTMLElement | null;
+            const replyElement = (replyContainer.getElementsByClassName(
+              'M9',
+            )?.[0] || replyContainer.firstElementChild) as HTMLElement | null;
             self.#replyElement = replyElement;
 
             if (replyElement) {


### PR DESCRIPTION
fix #1275 

Gmail did an update to their HTML with a new div.
We should get the `M9` div to be sure to have the correct one.

Current
<img width="363" height="239" alt="image" src="https://github.com/user-attachments/assets/d3867853-d5bc-4b91-87a3-29ce10b7d6d6" />

New
<img width="274" height="355" alt="image" src="https://github.com/user-attachments/assets/8e66c9e3-2d37-4e54-b2c3-c14f1401ec71" />
