### PR TITLE
fix(nav): wait for DOM readiness in addNavItem

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.test.ts
@@ -1,0 +1,65 @@
+import waitFor from '../../../lib/wait-for';
+
+// We test the core behavior that _createNavItemsHolder depends on:
+// waitFor retries until the element is available. This validates
+// the fix for #1156 where the nav injection container is not
+// immediately available on slow connections.
+
+describe('addNavItem DOM readiness', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('waitFor resolves once the nav injection container appears', async () => {
+    // Simulate the container not existing initially
+    let callCount = 0;
+    const getContainer = () => {
+      callCount++;
+      return document.querySelector<HTMLElement>('.aeN .n3');
+    };
+
+    // Add the element after a delay (simulating slow Gmail load)
+    setTimeout(() => {
+      const aeN = document.createElement('div');
+      aeN.className = 'aeN';
+      const n3 = document.createElement('div');
+      n3.className = 'n3';
+      aeN.appendChild(n3);
+      document.body.appendChild(aeN);
+    }, 50);
+
+    const result = await waitFor(getContainer, 5000, 10);
+    expect(result).toBeInstanceOf(HTMLElement);
+    expect(result.className).toBe('n3');
+    expect(callCount).toBeGreaterThan(1);
+  });
+
+  test('waitFor rejects if container never appears', async () => {
+    const getContainer = () =>
+      document.querySelector<HTMLElement>('.aeN .n3');
+
+    await expect(waitFor(getContainer, 100, 10)).rejects.toThrowError(
+      'waitFor timeout',
+    );
+  });
+
+  test('waitFor resolves immediately if container already exists', async () => {
+    // Container is already in the DOM
+    const aeN = document.createElement('div');
+    aeN.className = 'aeN';
+    const n3 = document.createElement('div');
+    n3.className = 'n3';
+    aeN.appendChild(n3);
+    document.body.appendChild(aeN);
+
+    let callCount = 0;
+    const getContainer = () => {
+      callCount++;
+      return document.querySelector<HTMLElement>('.aeN .n3');
+    };
+
+    const result = await waitFor(getContainer, 5000, 10);
+    expect(result).toBe(n3);
+    expect(callCount).toBe(1);
+  });
+});

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.test.ts
@@ -35,8 +35,7 @@ describe('addNavItem DOM readiness', () => {
   });
 
   test('waitFor rejects if container never appears', async () => {
-    const getContainer = () =>
-      document.querySelector<HTMLElement>('.aeN .n3');
+    const getContainer = () => document.querySelector<HTMLElement>('.aeN .n3');
 
     await expect(waitFor(getContainer, 100, 10)).rejects.toThrowError(
       'waitFor timeout',

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.test.ts
@@ -1,64 +1,115 @@
+import GmailElementGetter from '../gmail-element-getter';
 import waitFor from '../../../lib/wait-for';
+import querySelector from '../../../lib/dom/querySelectorOrFail';
 
-// We test the core behavior that _createNavItemsHolder depends on:
-// waitFor retries until the element is available. This validates
-// the fix for #1156 where the nav injection container is not
-// immediately available on slow connections.
+// Tests for the #1156 fix: _createNavItemsHolder now uses waitFor()
+// instead of throwing "should not happen" when the injection container
+// (.aeN .n3) isn't in the DOM yet.
 
-describe('addNavItem DOM readiness', () => {
+describe('addNavItem DOM readiness (#1156)', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
   });
 
-  test('waitFor resolves once the nav injection container appears', async () => {
-    // Simulate the container not existing initially
-    let callCount = 0;
-    const getContainer = () => {
-      callCount++;
-      return document.querySelector<HTMLElement>('.aeN .n3');
-    };
-
-    // Add the element after a delay (simulating slow Gmail load)
-    setTimeout(() => {
-      const aeN = document.createElement('div');
-      aeN.className = 'aeN';
-      const n3 = document.createElement('div');
-      n3.className = 'n3';
-      aeN.appendChild(n3);
-      document.body.appendChild(aeN);
-    }, 50);
-
-    const result = await waitFor(getContainer, 5000, 10);
-    expect(result).toBeInstanceOf(HTMLElement);
-    expect(result.className).toBe('n3');
-    expect(callCount).toBeGreaterThan(1);
-  });
-
-  test('waitFor rejects if container never appears', async () => {
-    const getContainer = () => document.querySelector<HTMLElement>('.aeN .n3');
-
-    await expect(waitFor(getContainer, 100, 10)).rejects.toThrowError(
-      'waitFor timeout',
-    );
-  });
-
-  test('waitFor resolves immediately if container already exists', async () => {
-    // Container is already in the DOM
+  function addNavInjectionContainer(): HTMLElement {
     const aeN = document.createElement('div');
     aeN.className = 'aeN';
     const n3 = document.createElement('div');
     n3.className = 'n3';
     aeN.appendChild(n3);
     document.body.appendChild(aeN);
+    return n3;
+  }
 
-    let callCount = 0;
-    const getContainer = () => {
-      callCount++;
-      return document.querySelector<HTMLElement>('.aeN .n3');
-    };
+  describe('injection container availability', () => {
+    test('getSameSectionNavItemMenuInjectionContainer returns null when .aeN .n3 is missing', () => {
+      expect(
+        GmailElementGetter.getSameSectionNavItemMenuInjectionContainer(),
+      ).toBeNull();
+    });
 
-    const result = await waitFor(getContainer, 5000, 10);
-    expect(result).toBe(n3);
-    expect(callCount).toBe(1);
+    test('getSameSectionNavItemMenuInjectionContainer returns element when present', () => {
+      const n3 = addNavInjectionContainer();
+      expect(
+        GmailElementGetter.getSameSectionNavItemMenuInjectionContainer(),
+      ).toBe(n3);
+    });
+  });
+
+  describe('waitFor integration (replaces synchronous throw)', () => {
+    test('resolves when injection container appears after a delay', async () => {
+      // This is the exact waitFor call used in _createNavItemsHolder
+      const containerPromise = waitFor(
+        () => GmailElementGetter.getSameSectionNavItemMenuInjectionContainer(),
+        5000,
+        10,
+      );
+
+      // Simulate Gmail rendering the nav container asynchronously
+      setTimeout(() => addNavInjectionContainer(), 50);
+
+      const result = await containerPromise;
+      expect(result).toBeInstanceOf(HTMLElement);
+      expect(result.className).toBe('n3');
+    });
+
+    test('resolves immediately when injection container already exists', async () => {
+      addNavInjectionContainer();
+
+      let callCount = 0;
+      const result = await waitFor(() => {
+        callCount++;
+        return GmailElementGetter.getSameSectionNavItemMenuInjectionContainer();
+      }, 5000);
+
+      expect(result).toBeInstanceOf(HTMLElement);
+      expect(callCount).toBe(1);
+    });
+
+    test('rejects after timeout when container never appears', async () => {
+      await expect(
+        waitFor(
+          () =>
+            GmailElementGetter.getSameSectionNavItemMenuInjectionContainer(),
+          100,
+          10,
+        ),
+      ).rejects.toThrowError('waitFor timeout');
+    });
+  });
+
+  describe('nav items holder creation', () => {
+    test('holder has correct structure after insertion', () => {
+      const n3 = addNavInjectionContainer();
+
+      // Replicate _createNavItemsHolder insertion logic
+      const holder = document.createElement('div');
+      holder.setAttribute('class', 'LrBjie inboxsdk__navMenu');
+      holder.innerHTML = '<div class="TK"></div>';
+      n3.insertBefore(holder, n3.children[2]);
+
+      // Verify the holder was inserted into the container
+      expect(n3.querySelector('.inboxsdk__navMenu')).toBe(holder);
+      // Verify the TK child exists (used by _getNavItemsHolder)
+      expect(querySelector(holder, '.TK')).toBeInstanceOf(HTMLElement);
+    });
+
+    test('existing holder is reused instead of creating a duplicate', () => {
+      addNavInjectionContainer();
+
+      // Simulate an existing holder already in the DOM
+      // (the _getNavItemsHolder check)
+      const existingHolder = document.createElement('div');
+      existingHolder.className = 'inboxsdk__navMenu';
+      existingHolder.innerHTML = '<div class="TK"></div>';
+      document.body.appendChild(existingHolder);
+
+      // _getNavItemsHolder checks for existing holder first
+      const found = document.querySelector('.inboxsdk__navMenu');
+      expect(found).toBe(existingHolder);
+      expect(querySelector(found as HTMLElement, '.TK')).toBeInstanceOf(
+        HTMLElement,
+      );
+    });
   });
 });

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.test.ts
@@ -1,0 +1,146 @@
+import * as Kefir from 'kefir';
+import addNavItem from './add-nav-item';
+import GmailElementGetter from '../gmail-element-getter';
+import waitFor from '../../../lib/wait-for';
+import type GmailDriver from '../gmail-driver';
+
+const driver = {} as GmailDriver;
+
+// Minimal DOM for the classic-hangouts (inline) leftnav path of addNavItem:
+// - a non-empty body class so waitForGmailModeToSettle() sees a settled mode
+//   (and one that doesn't match GmailElementGetter.isStandalone())
+// - .aeN.WR.nH.oy8Mbf[role=navigation] with .aZ6 so waitForNavMenuReady()
+//   resolves and shouldAddNavItemsInline() picks the inline path
+// - .Ls77Lb.aZ6 > .pp so waitForNavMenuReady()'s second waitFor resolves
+function setupGmailLeftNav(): HTMLElement {
+  document.body.className = 'inboxsdk-test';
+  const aeN = document.createElement('div');
+  aeN.className = 'aeN WR nH oy8Mbf aZ6';
+  aeN.setAttribute('role', 'navigation');
+  document.body.appendChild(aeN);
+  const navContents = document.createElement('div');
+  navContents.className = 'Ls77Lb aZ6';
+  navContents.innerHTML = '<div class="pp"></div>';
+  document.body.appendChild(navContents);
+  return aeN;
+}
+
+// The injection container (.aeN .n3) that _createNavItemsHolder waits for.
+function addInjectionContainer(aeN: HTMLElement): HTMLElement {
+  const n3 = document.createElement('div');
+  n3.className = 'n3';
+  aeN.appendChild(n3);
+  return n3;
+}
+
+function navItemDescriptorStream() {
+  return Kefir.never();
+}
+
+describe('addNavItem DOM readiness (#1156)', () => {
+  let aeN: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    aeN = setupGmailLeftNav();
+  });
+
+  test('waits for the injection container and inserts the nav item once it appears', async () => {
+    expect(
+      GmailElementGetter.getSameSectionNavItemMenuInjectionContainer(),
+    ).toBeNull();
+
+    const view = await addNavItem(driver, 'app1', navItemDescriptorStream());
+
+    // Simulate Gmail rendering the injection container after addNavItem was
+    // called. Pre-#1156-fix code threw 'should not happen' here instead of
+    // waiting, so the nav item never appeared.
+    setTimeout(() => addInjectionContainer(aeN), 50);
+
+    await waitFor(
+      () => document.querySelector('.inboxsdk__navMenu .TK .inboxsdk__navItem'),
+      4000,
+      25,
+    );
+
+    expect(document.querySelectorAll('.inboxsdk__navMenu').length).toBe(1);
+    expect(view.getElement().parentElement).toBe(
+      document.querySelector('.inboxsdk__navMenu .TK'),
+    );
+  });
+
+  test('concurrent addNavItem calls create exactly one holder', async () => {
+    const viewPromises = Promise.all([
+      addNavItem(driver, 'app1', navItemDescriptorStream()),
+      addNavItem(driver, 'app1', navItemDescriptorStream()),
+    ]);
+
+    setTimeout(() => addInjectionContainer(aeN), 50);
+
+    await viewPromises;
+    await waitFor(
+      () =>
+        document.querySelectorAll('.inboxsdk__navMenu .TK .inboxsdk__navItem')
+          .length === 2 || null,
+      4000,
+      25,
+    );
+
+    expect(document.querySelectorAll('.inboxsdk__navMenu').length).toBe(1);
+  });
+
+  test('does not insert the element of a view destroyed during the wait', async () => {
+    const view = await addNavItem(driver, 'app1', navItemDescriptorStream());
+
+    view.remove();
+    addInjectionContainer(aeN);
+
+    await waitFor(() => document.querySelector('.inboxsdk__navMenu'), 4000, 25);
+    // The insertion (if it were wrongly to happen) follows holder creation by
+    // a microtask; wait one small interval past the holder appearing to
+    // verify no insertion occurs.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(view.getElement().isConnected).toBe(false);
+    expect(document.querySelector('.inboxsdk__navItem')).toBeNull();
+  });
+
+  test('reuses the existing holder for nav items added later', async () => {
+    addInjectionContainer(aeN);
+
+    await addNavItem(driver, 'app1', navItemDescriptorStream());
+    await waitFor(
+      () =>
+        document.querySelectorAll('.inboxsdk__navMenu .TK .inboxsdk__navItem')
+          .length === 1 || null,
+      4000,
+      25,
+    );
+
+    await addNavItem(driver, 'app1', navItemDescriptorStream());
+    await waitFor(
+      () =>
+        document.querySelectorAll('.inboxsdk__navMenu .TK .inboxsdk__navItem')
+          .length === 2 || null,
+      4000,
+      25,
+    );
+
+    expect(document.querySelectorAll('.inboxsdk__navMenu').length).toBe(1);
+  });
+
+  describe('GmailElementGetter.getSameSectionNavItemMenuInjectionContainer', () => {
+    test('returns null while .aeN .n3 is missing', () => {
+      expect(
+        GmailElementGetter.getSameSectionNavItemMenuInjectionContainer(),
+      ).toBeNull();
+    });
+
+    test('returns the container once present', () => {
+      const n3 = addInjectionContainer(aeN);
+      expect(
+        GmailElementGetter.getSameSectionNavItemMenuInjectionContainer(),
+      ).toBe(n3);
+    });
+  });
+});

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.ts
@@ -16,14 +16,14 @@ import {
   getPanelSectionNavItemContainerElement,
 } from './nav-item-section';
 
-function attachGmailNavItemView(
+async function attachGmailNavItemView(
   gmailNavItemView: GmailNavItemView,
   injectionContainer?: HTMLElement,
 ) {
   try {
     const attacher = _attachNavItemView(gmailNavItemView, injectionContainer);
 
-    attacher();
+    await attacher();
 
     gmailNavItemView
       .getEventStream()
@@ -138,13 +138,14 @@ function _attachNavItemView(
   } else {
     // If we're in the old classic-hangouts-compatible leftnav, then
     // inject our added nav items among Gmail's own nav items.
-    return function () {
-      insertElementInOrder(_getNavItemsHolder(), gmailNavItemView.getElement());
+    return async function () {
+      const holder = await _getNavItemsHolder();
+      insertElementInOrder(holder, gmailNavItemView.getElement());
     };
   }
 }
 
-function _getNavItemsHolder(): HTMLElement {
+async function _getNavItemsHolder(): Promise<HTMLElement> {
   const holder = document.querySelector('.inboxsdk__navMenu');
   if (!holder) {
     return _createNavItemsHolder();
@@ -153,14 +154,15 @@ function _getNavItemsHolder(): HTMLElement {
   }
 }
 
-function _createNavItemsHolder(): HTMLElement {
+async function _createNavItemsHolder(): Promise<HTMLElement> {
   const holder = document.createElement('div');
   holder.setAttribute('class', 'LrBjie inboxsdk__navMenu');
   holder.innerHTML = '<div class="TK"></div>';
 
-  const navMenuInjectionContainer =
-    GmailElementGetter.getSameSectionNavItemMenuInjectionContainer();
-  if (!navMenuInjectionContainer) throw new Error('should not happen');
+  const navMenuInjectionContainer = await waitFor(() =>
+    GmailElementGetter.getSameSectionNavItemMenuInjectionContainer(),
+  );
+
   navMenuInjectionContainer.insertBefore(
     holder,
     navMenuInjectionContainer.children[2],

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.ts
@@ -16,22 +16,28 @@ import {
   getPanelSectionNavItemContainerElement,
 } from './nav-item-section';
 
-function attachGmailNavItemView(
+async function attachGmailNavItemView(
   gmailNavItemView: GmailNavItemView,
   injectionContainer?: HTMLElement,
 ) {
-  try {
-    const attacher = _attachNavItemView(gmailNavItemView, injectionContainer);
+  const attacher = _attachNavItemView(gmailNavItemView, injectionContainer);
 
-    attacher();
+  // The attacher may be invoked again on each orderChanged event, so every
+  // invocation needs its rejections handled, not just the first.
+  const attach = async () => {
+    try {
+      await attacher();
+    } catch (err) {
+      Logger.error(err);
+    }
+  };
 
-    gmailNavItemView
-      .getEventStream()
-      .filter((event) => event.eventName === 'orderChanged')
-      .onValue(attacher);
-  } catch (err) {
-    Logger.error(err);
-  }
+  await attach();
+
+  gmailNavItemView
+    .getEventStream()
+    .filter((event) => event.eventName === 'orderChanged')
+    .onValue(attach);
 }
 
 export default async function addNavItem(
@@ -138,29 +144,45 @@ function _attachNavItemView(
   } else {
     // If we're in the old classic-hangouts-compatible leftnav, then
     // inject our added nav items among Gmail's own nav items.
-    return function () {
-      insertElementInOrder(_getNavItemsHolder(), gmailNavItemView.getElement());
+    return async function () {
+      const holder = await _getNavItemsHolder();
+      // The wait for the holder can outlive the nav item: don't insert the
+      // element of a view that was destroyed in the meantime.
+      if (gmailNavItemView.isDestroyed()) return;
+      insertElementInOrder(holder, gmailNavItemView.getElement());
     };
   }
 }
 
-function _getNavItemsHolder(): HTMLElement {
+let navItemsHolderCreationPromise: Promise<HTMLElement> | null = null;
+
+function _getNavItemsHolder(): HTMLElement | Promise<HTMLElement> {
   const holder = document.querySelector('.inboxsdk__navMenu');
-  if (!holder) {
-    return _createNavItemsHolder();
-  } else {
+  if (holder) {
     return querySelector(holder, '.TK');
   }
+  // Share one creation between concurrent callers: waitFor always defers at
+  // least one macrotask, so two callers could otherwise both see no holder in
+  // the DOM and insert duplicate holders. The cache is cleared once creation
+  // settles: on success the holder is found in the DOM above, and on failure
+  // a later call gets to retry.
+  if (!navItemsHolderCreationPromise) {
+    navItemsHolderCreationPromise = _createNavItemsHolder().finally(() => {
+      navItemsHolderCreationPromise = null;
+    });
+  }
+  return navItemsHolderCreationPromise;
 }
 
-function _createNavItemsHolder(): HTMLElement {
+async function _createNavItemsHolder(): Promise<HTMLElement> {
   const holder = document.createElement('div');
   holder.setAttribute('class', 'LrBjie inboxsdk__navMenu');
   holder.innerHTML = '<div class="TK"></div>';
 
-  const navMenuInjectionContainer =
-    GmailElementGetter.getSameSectionNavItemMenuInjectionContainer();
-  if (!navMenuInjectionContainer) throw new Error('should not happen');
+  const navMenuInjectionContainer = await waitFor(() =>
+    GmailElementGetter.getSameSectionNavItemMenuInjectionContainer(),
+  );
+
   navMenuInjectionContainer.insertBefore(
     holder,
     navMenuInjectionContainer.children[2],

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
@@ -99,6 +99,7 @@ export default class GmailNavItemView {
   private _accessoryViewController: any = null;
   private _driver: GmailDriver;
   private _element: HTMLElement;
+  #destroyed: boolean = false;
   #eventStream: Bus<NavItemEvent, any>;
   private _expandoElement: HTMLElement | null = null;
   private _iconSettings: IconSettings = {};
@@ -183,6 +184,7 @@ export default class GmailNavItemView {
   }
 
   destroy() {
+    this.#destroyed = true;
     this._element.remove();
     if (this.#eventStream) this.#eventStream.end();
     this.#cleanupDOMElements();
@@ -214,6 +216,10 @@ export default class GmailNavItemView {
 
   isCollapsed(): boolean {
     return this._isCollapsed;
+  }
+
+  isDestroyed(): boolean {
+    return this.#destroyed;
   }
 
   isSection() {


### PR DESCRIPTION
Fixes #1156

`addNavItem()` threw `Error('should not happen')` when it ran before Gmail's left nav finished loading: `_createNavItemsHolder` required the injection container (`.aeN .n3`) to already exist. Extensions initializing during page load hit this reliably (stack trace in #1156).

What changed:

- `_createNavItemsHolder` waits for the injection container with `waitFor()` (the same pattern as `waitForMenuReady()` in the same file) instead of throwing.
- Holder creation is memoized in a module-level promise, so concurrent `addNavItem` calls share one holder instead of each inserting their own. The cache clears once creation settles, so a timed-out creation can be retried. When the holder already exists in the DOM, the lookup stays synchronous.
- The attacher checks `GmailNavItemView.isDestroyed()` (new flag) after the wait, so a nav item removed while waiting is not inserted afterwards.
- The `orderChanged` re-attach subscription routes rejections to `Logger.error` on every invocation, not just the first.

Tests drive the real `addNavItem` against a minimal Gmail leftnav fixture: the container appearing after the call, concurrent calls creating exactly one holder, a view destroyed mid-wait not being inserted, and holder reuse. The first three fail against the previous code.
