### PR TITLE
fix(sidebar): wait for tablist in addCompanionThreadIconArea

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/add-companion-thread-icon-area.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/add-companion-thread-icon-area.test.ts
@@ -1,0 +1,112 @@
+import waitFor from '../../../../../lib/wait-for';
+
+// Tests for the tablist race condition fix (#1287).
+// Validates that waitFor correctly handles the case where the
+// [role=tablist] attribute is set asynchronously by Gmail.
+
+const TAB_LIST_SELECTOR = '[role=tablist],.J-KU-Jg';
+
+describe('addCompanionThreadIconArea tablist detection', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  test('waitFor resolves when tablist role is set after a delay', async () => {
+    const tablistEl = document.createElement('div');
+    container.appendChild(tablistEl);
+
+    // Simulate Gmail setting the role attribute asynchronously
+    setTimeout(() => {
+      tablistEl.setAttribute('role', 'tablist');
+    }, 50);
+
+    const result = await waitFor(
+      () => container.querySelector(TAB_LIST_SELECTOR),
+      5000,
+      10,
+    );
+    expect(result).toBe(tablistEl);
+  });
+
+  test('waitFor resolves immediately when tablist already exists', async () => {
+    const tablistEl = document.createElement('div');
+    tablistEl.setAttribute('role', 'tablist');
+    container.appendChild(tablistEl);
+
+    const result = await waitFor(
+      () => container.querySelector(TAB_LIST_SELECTOR),
+      5000,
+      10,
+    );
+    expect(result).toBe(tablistEl);
+  });
+
+  test('waitFor resolves via fallback J-KU-Jg class selector', async () => {
+    const tablistEl = document.createElement('div');
+    tablistEl.className = 'J-KU-Jg';
+    container.appendChild(tablistEl);
+
+    const result = await waitFor(
+      () => container.querySelector(TAB_LIST_SELECTOR),
+      5000,
+      10,
+    );
+    expect(result).toBe(tablistEl);
+  });
+
+  test('waitFor rejects after timeout when tablist never appears', async () => {
+    await expect(
+      waitFor(() => container.querySelector(TAB_LIST_SELECTOR), 100, 10),
+    ).rejects.toThrowError('waitFor timeout');
+  });
+
+  test('icon area is inserted relative to separator when present', () => {
+    // Unit test for the insertion logic (synchronous, no waitFor needed)
+    const tablistEl = document.createElement('div');
+    tablistEl.setAttribute('role', 'tablist');
+    const separator = document.createElement('div');
+    separator.setAttribute('role', 'separator');
+    const existingIcon = document.createElement('div');
+    existingIcon.className = 'existing-icon';
+
+    container.appendChild(tablistEl);
+    container.appendChild(separator);
+    container.appendChild(existingIcon);
+
+    const iconArea = document.createElement('div');
+    iconArea.className = 'sidebar_iconArea';
+
+    // Replicate the insertion logic from addCompanionThreadIconArea
+    if (separator.parentElement) {
+      separator.parentElement.insertBefore(
+        iconArea,
+        separator.nextElementSibling,
+      );
+    }
+
+    // iconArea should be inserted between separator and existingIcon
+    expect(container.children[0]).toBe(tablistEl);
+    expect(container.children[1]).toBe(separator);
+    expect(container.children[2]).toBe(iconArea);
+    expect(container.children[3]).toBe(existingIcon);
+  });
+
+  test('icon area is inserted before tablist when no separator', () => {
+    const tablistEl = document.createElement('div');
+    tablistEl.setAttribute('role', 'tablist');
+    container.appendChild(tablistEl);
+
+    const iconArea = document.createElement('div');
+    iconArea.className = 'sidebar_iconArea';
+
+    // Replicate the fallback insertion logic
+    tablistEl.insertAdjacentElement('beforebegin', iconArea);
+
+    expect(container.children[0]).toBe(iconArea);
+    expect(container.children[1]).toBe(tablistEl);
+  });
+});

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/add-companion-thread-icon-area.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/add-companion-thread-icon-area.test.ts
@@ -1,0 +1,275 @@
+jest.mock('../../../../../lib/idMap', () => {
+  function idMap(key: string) {
+    return key;
+  }
+
+  return {
+    __esModule: true,
+    default: idMap,
+    legacyIdMap: idMap,
+  };
+});
+jest.mock('../../../../../lib/dom/make-element-child-stream', () => {
+  return () => require('kefir-bus')();
+});
+jest.mock(
+  '../../../../../lib/dom/make-mutation-observer-chunked-stream',
+  () => {
+    return () => require('kefir-bus')();
+  },
+);
+import _ from 'lodash';
+import * as Kefir from 'kefir';
+import kefirStopper from 'kefir-stopper';
+import delay from 'pdelay';
+import MockWebStorage from 'mock-webstorage';
+import GmailAppSidebarView from '../index';
+import GmailAppSidebarPrimary from './index';
+import GmailThreadView from '../../gmail-thread-view';
+import ContentPanelViewDriver, {
+  type ContentPanelDescriptor,
+} from '../../../../../driver-common/sidebar/ContentPanelViewDriver';
+import waitFor, { WaitForError } from '../../../../../lib/wait-for';
+
+// https://github.com/jestjs/jest/issues/2098#issuecomment-260733457
+Object.defineProperty(globalThis, 'localStorage', {
+  value: new MockWebStorage(),
+});
+(global as any)._APP_SIDEBAR_TEST = true;
+
+describe('addCompanionThreadIconArea', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('inserts the icon area after the separator when the tablist is present', async () => {
+    const { container, tabList } = makeSidebarContainerElement();
+    const separator = tabList.querySelector('[role=separator]')!;
+    const view = new GmailAppSidebarView(
+      makeDriver(),
+      makeContentContainerElement(),
+    );
+
+    addThreadPanel(view);
+    await delay(0);
+
+    const iconAreas = container.querySelectorAll('.sidebar_thread_iconArea');
+    expect(iconAreas.length).toBe(1);
+    expect(iconAreas[0].parentElement).toBe(tabList);
+    expect(separator.nextElementSibling).toBe(iconAreas[0]);
+    expect(
+      iconAreas[0].querySelectorAll('button.inboxsdk__button_icon').length,
+    ).toBe(1);
+  });
+
+  it('adds a single icon area when two panels are added back-to-back', async () => {
+    const { container } = makeSidebarContainerElement();
+    const view = new GmailAppSidebarView(
+      makeDriver(),
+      makeContentContainerElement(),
+    );
+
+    addThreadPanel(view, 'App1');
+    addThreadPanel(view, 'App2');
+    await waitFor(
+      () => container.querySelector('.sidebar_thread_iconArea'),
+      1000,
+      10,
+    );
+    // Give a duplicate insertion scheduled during the same tick time to land.
+    await delay(20);
+
+    const iconAreas = container.querySelectorAll('.sidebar_thread_iconArea');
+    expect(iconAreas.length).toBe(1);
+    expect(
+      iconAreas[0].querySelectorAll('.sidebar_button_container').length,
+    ).toBe(2);
+  });
+
+  it('waits for the tablist to appear before inserting the icon area (#1287)', async () => {
+    const { container, tabList } = makeSidebarContainerElement({
+      tablistReady: false,
+    });
+    const view = new GmailAppSidebarView(
+      makeDriver(),
+      makeContentContainerElement(),
+    );
+
+    addThreadPanel(view);
+    await delay(0);
+    expect(container.querySelectorAll('.sidebar_thread_iconArea').length).toBe(
+      0,
+    );
+
+    tabList.setAttribute('role', 'tablist');
+    await waitFor(
+      () => container.querySelector('.sidebar_thread_iconArea'),
+      2000,
+      10,
+    );
+
+    const iconAreas = container.querySelectorAll('.sidebar_thread_iconArea');
+    expect(iconAreas.length).toBe(1);
+    expect(iconAreas[0].parentElement).toBe(tabList);
+    expect(
+      iconAreas[0].querySelectorAll('button.inboxsdk__button_icon').length,
+    ).toBe(1);
+  });
+
+  it('reuses the pending icon area for panels added while waiting for the tablist', async () => {
+    const { container, tabList } = makeSidebarContainerElement({
+      tablistReady: false,
+    });
+    const view = new GmailAppSidebarView(
+      makeDriver(),
+      makeContentContainerElement(),
+    );
+
+    addThreadPanel(view, 'App1');
+    addThreadPanel(view, 'App2');
+    await delay(0);
+    expect(container.querySelectorAll('.sidebar_thread_iconArea').length).toBe(
+      0,
+    );
+
+    tabList.setAttribute('role', 'tablist');
+    await waitFor(
+      () => container.querySelector('.sidebar_thread_iconArea'),
+      2000,
+      10,
+    );
+    // Give a duplicate insertion scheduled during the same tick time to land.
+    await delay(20);
+
+    const iconAreas = container.querySelectorAll('.sidebar_thread_iconArea');
+    expect(iconAreas.length).toBe(1);
+    expect(
+      iconAreas[0].querySelectorAll('.sidebar_button_container').length,
+    ).toBe(2);
+  });
+
+  it('logs the timeout and inserts nothing when the tablist never appears', async () => {
+    jest.useFakeTimers();
+
+    try {
+      makeSidebarContainerElement({ tablistReady: false });
+      const errors: Array<{ err: unknown; details: unknown }> = [];
+      const view = new GmailAppSidebarView(
+        makeDriver((err, details) => errors.push({ err, details })),
+        makeContentContainerElement(),
+      );
+
+      addThreadPanel(view);
+      // addCompanionThreadIconArea waits up to 5 seconds for the tablist.
+      await jest.advanceTimersByTimeAsync(6000);
+
+      expect(errors.length).toBe(1);
+      expect(errors[0].err).toBeInstanceOf(WaitForError);
+      expect(errors[0].details).toBe('addCompanionThreadIconArea: no tablist');
+      expect(document.querySelectorAll('.sidebar_thread_iconArea').length).toBe(
+        0,
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not insert the icon area when the primary is destroyed while waiting', async () => {
+    const { tabList } = makeSidebarContainerElement({ tablistReady: false });
+    const errors: unknown[] = [];
+    const driver = makeDriver((err) => errors.push(err));
+    const primary = new GmailAppSidebarPrimary(
+      driver,
+      makeContentContainerElement(),
+    );
+
+    const descriptor = Kefir.constant({
+      title: 'foo',
+      iconUrl: '/bar.png',
+      el: document.createElement('div'),
+    } as unknown as ContentPanelDescriptor);
+    new ContentPanelViewDriver(driver, descriptor, primary.getInstanceId());
+    await delay(0);
+
+    primary.destroy();
+    tabList.setAttribute('role', 'tablist');
+    // addCompanionThreadIconArea polls every 250ms; wait past one full
+    // interval to verify no insertion happens after destroy.
+    await delay(300);
+
+    expect(document.querySelectorAll('.sidebar_thread_iconArea').length).toBe(
+      0,
+    );
+    expect(errors).toEqual([]);
+  });
+});
+
+function makeDriver(onError?: (err: unknown, details?: unknown) => void): any {
+  return {
+    getAppId: () => 'test',
+    getOpts: () => ({
+      appName: 'Test',
+      appIconUrl: 'testImage.png',
+    }),
+
+    getLogger() {
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        eventSdkPassive() {},
+
+        error(err: unknown, details?: unknown) {
+          if (onError) {
+            onError(err, details);
+          } else {
+            console.error('logger.error called:', err, details);
+            throw err;
+          }
+        },
+      };
+    },
+  };
+}
+
+/**
+ * Builds the same structure as Gmail's companion sidebar icon container. With
+ * `tablistReady: false`, the tablist element matches neither `[role=tablist]`
+ * nor the `.J-KU-Jg` fallback selector yet, like when the SDK loads on an
+ * already-open conversation before Gmail finishes setting up the sidebar
+ * (#1287).
+ */
+function makeSidebarContainerElement({ tablistReady = true } = {}) {
+  const container = document.createElement('div');
+  container.className = 'brC-aT5-aOt-Jw';
+  const tabList = document.createElement('div');
+
+  if (tablistReady) {
+    tabList.className = 'J-KU-Jg';
+    tabList.setAttribute('role', 'tablist');
+  }
+
+  const separator = document.createElement('div');
+  separator.setAttribute('role', 'separator');
+  tabList.appendChild(separator);
+  container.appendChild(tabList);
+  document.body.appendChild(container);
+  return { container, tabList };
+}
+
+function makeContentContainerElement() {
+  const contentContainerElement = document.createElement('div');
+  contentContainerElement.className = 'bq9';
+  return contentContainerElement;
+}
+
+function addThreadPanel(view: GmailAppSidebarView, appName?: string) {
+  const descriptor = Kefir.constant({
+    appName,
+    title: 'foo',
+    iconUrl: '/bar.png',
+    el: document.createElement('div'),
+  } as unknown as ContentPanelDescriptor);
+  const fakeThreadView = {
+    getStopper: _.constant(kefirStopper()),
+  } as GmailThreadView;
+  return view.addThreadSidebarContentPanel(descriptor, fakeThreadView);
+}

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/add-companion-thread-icon-area.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/add-companion-thread-icon-area.ts
@@ -1,5 +1,6 @@
 import { defn } from 'ud';
 import type Logger from '../../../../../lib/logger';
+import waitFor from '../../../../../lib/wait-for';
 
 /*
 As of Feb 6th, 2018.
@@ -9,15 +10,19 @@ As of Feb 6th, 2018.
 */
 const TAB_LIST_SELECTOR = '[role=tablist],.J-KU-Jg';
 
-function addCompanionThreadIconArea(
+async function addCompanionThreadIconArea(
   logger: Logger,
   iconArea: HTMLElement,
   companionSidebarIconContainerEl: HTMLElement,
 ) {
-  const tabList =
-    companionSidebarIconContainerEl.querySelector(TAB_LIST_SELECTOR);
+  let tabList: Element | null;
 
-  if (!tabList) {
+  try {
+    tabList = await waitFor(
+      () => companionSidebarIconContainerEl.querySelector(TAB_LIST_SELECTOR),
+      5000,
+    );
+  } catch (e) {
     logger.error(new Error('addCompanionThreadIconArea: no tablist'));
     return;
   }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/add-companion-thread-icon-area.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/add-companion-thread-icon-area.ts
@@ -1,5 +1,6 @@
 import { defn } from 'ud';
 import type Logger from '../../../../../lib/logger';
+import waitFor, { WaitForError } from '../../../../../lib/wait-for';
 
 /*
 As of Feb 6th, 2018.
@@ -9,33 +10,59 @@ As of Feb 6th, 2018.
 */
 const TAB_LIST_SELECTOR = '[role=tablist],.J-KU-Jg';
 
-function addCompanionThreadIconArea(
+async function addCompanionThreadIconArea(
   logger: Logger,
   iconArea: HTMLElement,
   companionSidebarIconContainerEl: HTMLElement,
+  isStopped: () => boolean,
 ) {
-  const tabList =
+  // Insert synchronously when the tablist is already present so that callers
+  // can find the icon area in the DOM immediately after calling this.
+  let tabList =
     companionSidebarIconContainerEl.querySelector(TAB_LIST_SELECTOR);
 
   if (!tabList) {
-    logger.error(new Error('addCompanionThreadIconArea: no tablist'));
-    return;
+    // Gmail may not have made the tablist match the selector yet, e.g. when
+    // the extension loads on an already-open conversation (#1287).
+    try {
+      tabList = await waitFor(
+        () => companionSidebarIconContainerEl.querySelector(TAB_LIST_SELECTOR),
+        5000,
+      );
+    } catch (e) {
+      if (e instanceof WaitForError) {
+        logger.error(e, 'addCompanionThreadIconArea: no tablist');
+      } else {
+        logger.error(e);
+      }
+      return;
+    }
+
+    if (isStopped()) {
+      return;
+    }
+
+    // Another icon area may have been inserted while we were waiting.
+    if (
+      companionSidebarIconContainerEl.querySelector('.sidebar_thread_iconArea')
+    ) {
+      return;
+    }
   }
 
   const separator =
     companionSidebarIconContainerEl.querySelector('[role=separator]');
 
-  if (!separator) {
-    logger.error(
-      new Error('addCompanionThreadIconArea: failed to find separator'),
-    );
-    tabList.insertAdjacentElement('beforebegin', iconArea);
-  } else {
-    if (!separator.parentElement) throw new Error();
+  if (separator?.parentElement) {
     separator.parentElement.insertBefore(
       iconArea,
       separator.nextElementSibling,
     );
+  } else {
+    logger.error(
+      new Error('addCompanionThreadIconArea: failed to find separator'),
+    );
+    tabList.insertAdjacentElement('beforebegin', iconArea);
   }
 }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.tsx
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.tsx
@@ -798,7 +798,9 @@ class GmailAppSidebarPrimary {
               this.#driver.getLogger(),
               threadIconArea,
               companionSidebarIconContainerEl,
-            );
+            ).catch(() => {
+              // Error already logged inside addCompanionThreadIconArea
+            });
           }
 
           this.#addButton(threadIconArea, event, false);

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.tsx
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.tsx
@@ -60,6 +60,12 @@ class GmailAppSidebarPrimary {
   #instanceIdsToDescriptors = new Map<string, SidebarPanelEvent>();
   #threadSidebarComponent: AppSidebar | null | undefined = null;
   #threadIconArea: HTMLElement | null | undefined = null;
+  /**
+   * Set while addCompanionThreadIconArea is still waiting for Gmail's tablist,
+   * during which the icon area isn't in the DOM yet. Lets later panels reuse
+   * the pending icon area instead of creating a duplicate.
+   */
+  #pendingThreadIconArea: HTMLElement | null = null;
   #globalIconArea: HTMLElement | null | undefined = null;
   #globalButtonContainers: Map<string, HTMLElement> = new Map();
   #threadButtonContainers: Map<string, HTMLElement> = new Map();
@@ -793,18 +799,30 @@ class GmailAppSidebarPrimary {
           let threadIconArea = (this.#threadIconArea =
             companionSidebarIconContainerEl.querySelector<HTMLElement>(
               '.sidebar_thread_iconArea',
-            ));
+            ) ?? this.#pendingThreadIconArea);
 
           if (!threadIconArea) {
-            threadIconArea = this.#threadIconArea =
-              document.createElement('div');
-            threadIconArea.className = idMap('sidebar_iconArea');
-            threadIconArea.classList.add('sidebar_thread_iconArea');
+            const newIconArea =
+              (threadIconArea =
+              this.#threadIconArea =
+                document.createElement('div'));
+            newIconArea.className = idMap('sidebar_iconArea');
+            newIconArea.classList.add('sidebar_thread_iconArea');
+            this.#pendingThreadIconArea = newIconArea;
             addCompanionThreadIconArea(
               this.#driver.getLogger(),
-              threadIconArea,
+              newIconArea,
               companionSidebarIconContainerEl,
-            );
+              () => this.#stopper.stopped,
+            )
+              .catch((err) => {
+                this.#driver.getLogger().error(err);
+              })
+              .finally(() => {
+                if (this.#pendingThreadIconArea === newIconArea) {
+                  this.#pendingThreadIconArea = null;
+                }
+              });
           }
 
           this.#addButton(threadIconArea, event, false);


### PR DESCRIPTION
Fixes #1287

When an extension loads on an already-open conversation, Gmail's companion sidebar tablist may not yet match `[role=tablist]` or `.J-KU-Jg`, so `addCompanionThreadIconArea` logged "no tablist" and gave up — thread sidebar icons never appeared.

What changed:

- `addCompanionThreadIconArea` inserts synchronously when the tablist is already present, and otherwise waits up to 5 seconds for it. The synchronous path keeps the caller's existing-icon-area lookup working for panels added back-to-back.
- While a wait is pending, the caller reuses the pending icon area instead of creating a duplicate, and insertion is skipped if the sidebar was destroyed or another icon area appeared during the wait.
- Error handling: a timeout logs the `WaitForError` with context, unexpected errors are logged as-is, the separator-without-parent path no longer throws unlogged, and the caller logs any rejection instead of swallowing it.

Tests exercise the real `GmailAppSidebarPrimary` flow (replacing tests that re-implemented the insertion logic locally): the #1287 repro (tablist matching the selector only after a delay), back-to-back panel dedup, pending-wait dedup, timeout logging, and destroy-during-wait.
