### PR TITLE
fix(message-view): add scoped fallbacks for More menu detection

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view-more-menu.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view-more-menu.test.ts
@@ -1,0 +1,122 @@
+// Tests for the More menu fallback selector logic (#1280).
+// The #getOpenMoreMenu() method relies on specific Gmail DOM selectors that
+// Gmail changes periodically. These tests validate the fallback logic added
+// to find the open More menu even when the dated selectors no longer match.
+
+// Replicate the fallback selector patterns from #getOpenMoreMenu.
+// Since the method is private and bound to GmailMessageView's element/state,
+// we test the selector logic directly against document.body.
+const FALLBACK_SELECTOR = '.J-M[aria-haspopup=true]';
+const BROAD_SELECTOR = 'div[role=menu], .J-M';
+
+function makeVisible(el: HTMLElement) {
+  Object.defineProperty(el, 'offsetHeight', { value: 20, configurable: true });
+  Object.defineProperty(el, 'offsetWidth', { value: 100, configurable: true });
+}
+
+function findVisibleMenu(selector: string): HTMLElement | null {
+  const elements = document.body.querySelectorAll<HTMLElement>(selector);
+  for (const el of elements) {
+    if (el.offsetHeight > 0 && el.offsetWidth > 0) {
+      return el;
+    }
+  }
+  return null;
+}
+
+describe('getOpenMoreMenu fallback selector logic', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  // ── Fallback 1: .J-M[aria-haspopup=true] with visibility check ──
+
+  test('returns visible .J-M[aria-haspopup=true] menu via fallback', () => {
+    const menu = document.createElement('div');
+    menu.className = 'J-M';
+    menu.setAttribute('aria-haspopup', 'true');
+    makeVisible(menu);
+    document.body.appendChild(menu);
+
+    const result = findVisibleMenu(FALLBACK_SELECTOR);
+    expect(result).toBe(menu);
+  });
+
+  test('skips hidden .J-M[aria-haspopup=true] elements (offsetHeight/Width = 0)', () => {
+    const hiddenMenu = document.createElement('div');
+    hiddenMenu.className = 'J-M';
+    hiddenMenu.setAttribute('aria-haspopup', 'true');
+    // offsetHeight/offsetWidth default to 0 in jsdom
+    document.body.appendChild(hiddenMenu);
+
+    const result = findVisibleMenu(FALLBACK_SELECTOR);
+    expect(result).toBeNull();
+  });
+
+  test('returns first visible menu when multiple .J-M[aria-haspopup=true] elements exist', () => {
+    const hiddenMenu = document.createElement('div');
+    hiddenMenu.className = 'J-M';
+    hiddenMenu.setAttribute('aria-haspopup', 'true');
+
+    const visibleMenu = document.createElement('div');
+    visibleMenu.className = 'J-M';
+    visibleMenu.setAttribute('aria-haspopup', 'true');
+    makeVisible(visibleMenu);
+
+    document.body.appendChild(hiddenMenu);
+    document.body.appendChild(visibleMenu);
+
+    const result = findVisibleMenu(FALLBACK_SELECTOR);
+    expect(result).toBe(visibleMenu);
+  });
+
+  test('returns null when no .J-M[aria-haspopup=true] elements in DOM', () => {
+    const result = findVisibleMenu(FALLBACK_SELECTOR);
+    expect(result).toBeNull();
+  });
+
+  // ── Fallback 2: div[role=menu], .J-M broad search ──
+
+  test('returns visible div[role=menu] via broad fallback', () => {
+    const menu = document.createElement('div');
+    menu.setAttribute('role', 'menu');
+    makeVisible(menu);
+    document.body.appendChild(menu);
+
+    const result = findVisibleMenu(BROAD_SELECTOR);
+    expect(result).toBe(menu);
+  });
+
+  test('returns visible .J-M element via broad fallback selector', () => {
+    const menu = document.createElement('div');
+    menu.className = 'J-M';
+    makeVisible(menu);
+    document.body.appendChild(menu);
+
+    const result = findVisibleMenu(BROAD_SELECTOR);
+    expect(result).toBe(menu);
+  });
+
+  test('skips hidden elements in broad fallback', () => {
+    const hiddenRoleMenu = document.createElement('div');
+    hiddenRoleMenu.setAttribute('role', 'menu');
+
+    const hiddenJM = document.createElement('div');
+    hiddenJM.className = 'J-M';
+
+    document.body.appendChild(hiddenRoleMenu);
+    document.body.appendChild(hiddenJM);
+
+    const result = findVisibleMenu(BROAD_SELECTOR);
+    expect(result).toBeNull();
+  });
+
+  test('returns null when no visible menus found anywhere', () => {
+    const unrelated = document.createElement('div');
+    unrelated.className = 'some-other-class';
+    document.body.appendChild(unrelated);
+
+    expect(findVisibleMenu(FALLBACK_SELECTOR)).toBeNull();
+    expect(findVisibleMenu(BROAD_SELECTOR)).toBeNull();
+  });
+});

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view-more-menu.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view-more-menu.test.ts
@@ -1,0 +1,211 @@
+import { findOpenMoreMenu } from './gmail-message-view';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+// jsdom elements have zero offsetWidth/offsetHeight by default, so anything
+// that should count as visible needs explicit dimensions.
+function makeVisible(el: HTMLElement) {
+  Object.defineProperty(el, 'offsetHeight', { value: 20, configurable: true });
+  Object.defineProperty(el, 'offsetWidth', { value: 100, configurable: true });
+}
+
+/**
+ * Builds a structurally realistic Gmail thread pane: the `.aHU` conversation
+ * container holds the message element (a table-based header row with the
+ * per-message More button) and, as a sibling of the message, the
+ * absolutely-positioned More menu. `withDatedStructure: false` drops the
+ * `a98` class from the outer pane so none of the dated selectors in
+ * findOpenMoreMenu match, forcing the fallback tiers.
+ */
+function buildThreadFixture({
+  withDatedStructure,
+  moreButtonExpanded,
+}: {
+  withDatedStructure: boolean;
+  moreButtonExpanded: boolean;
+}) {
+  const pane = document.createElement('div');
+  pane.className = withDatedStructure ? 'nH a98 iY' : 'nH iY';
+  pane.innerHTML =
+    '<div class="nH">' +
+    '<div class="aHU hx">' +
+    '<div class="h7">' +
+    '<table cellpadding="0" class="cf"><tbody><tr class="acZ xD"><td class="gH">' +
+    `<div class="T-I J-J5-Ji aap L3" role="button" aria-haspopup="true" aria-expanded="${moreButtonExpanded}" tabindex="0"></div>` +
+    '</td></tr></tbody></table>' +
+    '<div class="ii gt"></div>' +
+    '</div>' +
+    '</div>' +
+    '</div>';
+  document.body.appendChild(pane);
+
+  const conversationContainer = pane.querySelector<HTMLElement>('.aHU')!;
+  const messageElement = pane.querySelector<HTMLElement>('.h7')!;
+  const moreButton = messageElement.querySelector<HTMLElement>(
+    'tr.acZ div.T-I.J-J5-Ji.aap.L3[role=button][aria-haspopup]',
+  )!;
+  // Guard fixture realism: the button must match the selector
+  // GmailMessageView#getMoreButton uses.
+  expect(moreButton).toBeTruthy();
+
+  return { pane, conversationContainer, messageElement, moreButton };
+}
+
+function appendMenu(
+  parent: HTMLElement,
+  {
+    className,
+    role,
+    visible,
+  }: { className: string; role?: string; visible: boolean },
+): HTMLElement {
+  const menu = document.createElement('div');
+  menu.className = className;
+  if (role) menu.setAttribute('role', role);
+  if (className.includes('J-M')) menu.setAttribute('aria-haspopup', 'true');
+  menu.style.left = '100px';
+  menu.style.top = '50px';
+  if (visible) makeVisible(menu);
+  parent.appendChild(menu);
+  return menu;
+}
+
+describe('findOpenMoreMenu', () => {
+  test('dated selector wins even when fallback-matching menus are present', () => {
+    const { conversationContainer, messageElement, moreButton } =
+      buildThreadFixture({
+        withDatedStructure: true,
+        moreButtonExpanded: true,
+      });
+    // Fallback bait earlier in document order than the dated menu: a visible
+    // generic dropdown in the same conversation container...
+    appendMenu(conversationContainer, { className: 'J-M', visible: true });
+    // ...and a visible role=menu element.
+    appendMenu(conversationContainer, {
+      className: 'aX2',
+      role: 'menu',
+      visible: true,
+    });
+    // The menu the dated selectors describe.
+    const datedMenu = appendMenu(conversationContainer, {
+      className: 'b7 J-M aX2',
+      role: 'menu',
+      visible: true,
+    });
+
+    const result = findOpenMoreMenu(messageElement, moreButton);
+    expect(result?.element).toBe(datedMenu);
+    expect(result?.usedFallback).toBe(false);
+  });
+
+  test('falls back to a visible .J-M menu inside this message’s conversation container when the dated selectors miss', () => {
+    const { conversationContainer, messageElement, moreButton } =
+      buildThreadFixture({
+        withDatedStructure: false,
+        moreButtonExpanded: true,
+      });
+    const hiddenMenu = appendMenu(conversationContainer, {
+      className: 'J-M',
+      visible: false,
+    });
+    const openMenu = appendMenu(conversationContainer, {
+      className: 'J-M',
+      visible: true,
+    });
+
+    const result = findOpenMoreMenu(messageElement, moreButton);
+    expect(result?.element).toBe(openMenu);
+    expect(result?.element).not.toBe(hiddenMenu);
+    expect(result?.usedFallback).toBe(true);
+    expect(result?.selector).toBe('.J-M[aria-haspopup=true]');
+  });
+
+  test('never returns a visible menu outside this message’s conversation container', () => {
+    const { messageElement, moreButton } = buildThreadFixture({
+      withDatedStructure: false,
+      moreButtonExpanded: true,
+    });
+    // An unrelated open dropdown elsewhere in the document (e.g. a label
+    // picker or the thread-toolbar More menu) must not be picked up, even
+    // though it is visible and this message's More button is expanded.
+    const unrelatedContainer = document.createElement('div');
+    document.body.appendChild(unrelatedContainer);
+    appendMenu(unrelatedContainer, { className: 'b7 J-M', visible: true });
+    appendMenu(unrelatedContainer, {
+      className: 'aX2',
+      role: 'menu',
+      visible: true,
+    });
+
+    expect(findOpenMoreMenu(messageElement, moreButton)).toBe(null);
+  });
+
+  test('returns null when every in-scope menu is hidden', () => {
+    const { conversationContainer, messageElement, moreButton } =
+      buildThreadFixture({
+        withDatedStructure: false,
+        moreButtonExpanded: true,
+      });
+    appendMenu(conversationContainer, { className: 'J-M', visible: false });
+    appendMenu(conversationContainer, {
+      className: 'aX2',
+      role: 'menu',
+      visible: false,
+    });
+
+    expect(findOpenMoreMenu(messageElement, moreButton)).toBe(null);
+  });
+
+  test('broad div[role=menu] tier applies only while the More button is expanded', () => {
+    const expanded = buildThreadFixture({
+      withDatedStructure: false,
+      moreButtonExpanded: true,
+    });
+    const roleMenu = appendMenu(expanded.conversationContainer, {
+      className: 'aX2',
+      role: 'menu',
+      visible: true,
+    });
+
+    const result = findOpenMoreMenu(
+      expanded.messageElement,
+      expanded.moreButton,
+    );
+    expect(result?.element).toBe(roleMenu);
+    expect(result?.usedFallback).toBe(true);
+    expect(result?.selector).toBe('div[role=menu], .J-M');
+
+    document.body.innerHTML = '';
+
+    const collapsed = buildThreadFixture({
+      withDatedStructure: false,
+      moreButtonExpanded: false,
+    });
+    appendMenu(collapsed.conversationContainer, {
+      className: 'aX2',
+      role: 'menu',
+      visible: true,
+    });
+
+    expect(
+      findOpenMoreMenu(collapsed.messageElement, collapsed.moreButton),
+    ).toBe(null);
+    // Without a More button at all, the broad tier must not run either.
+    expect(findOpenMoreMenu(collapsed.messageElement, null)).toBe(null);
+  });
+
+  test('returns null when the message has no .aHU ancestor to scope fallbacks to', () => {
+    const orphanMessage = document.createElement('div');
+    orphanMessage.className = 'h7';
+    document.body.appendChild(orphanMessage);
+    const openMenu = appendMenu(document.body, {
+      className: 'J-M',
+      visible: true,
+    });
+    expect(openMenu).toBeTruthy();
+
+    expect(findOpenMoreMenu(orphanMessage, null)).toBe(null);
+  });
+});

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -373,22 +373,46 @@ class GmailMessageView {
   }
 
   #getOpenMoreMenu(): HTMLElement | null | undefined {
+    // Existing selectors for backward compatibility
     const selector_2022_11_23 =
       'td > div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]';
     const selector_2023_11_16 =
       'div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]';
+    const selector_legacy =
+      'td > div.nH.if > div.nH.aHU div.b7.J-M[aria-haspopup=true]';
 
     const maybeMoreMenu =
       document.body.querySelector<HTMLElement>(selector_2023_11_16) ||
-      document.body.querySelector<HTMLElement>(selector_2022_11_23);
-    // This will find any message's open more menu! The caller needs to make
-    // sure it belongs to this message!
-    return (
-      maybeMoreMenu ||
-      document.body.querySelector<HTMLElement>(
-        'td > div.nH.if > div.nH.aHU div.b7.J-M[aria-haspopup=true]',
-      )
+      document.body.querySelector<HTMLElement>(selector_2022_11_23) ||
+      document.body.querySelector<HTMLElement>(selector_legacy);
+
+    if (maybeMoreMenu) return maybeMoreMenu;
+
+    // Fallback: find visible J-M menu containers with aria-haspopup
+    const allMenus = document.body.querySelectorAll<HTMLElement>(
+      '.J-M[aria-haspopup=true]',
     );
+    for (const menu of allMenus) {
+      if (menu.offsetHeight > 0 && menu.offsetWidth > 0) {
+        return menu;
+      }
+    }
+
+    // Fallback: broader search for any visible popup menu near the more button
+    const moreButton = this.#getMoreButton();
+    if (moreButton && moreButton.getAttribute('aria-expanded') === 'true') {
+      // Search for any visible menu container in the document
+      const allPopupMenus = document.body.querySelectorAll<HTMLElement>(
+        'div[role=menu], .J-M',
+      );
+      for (const menu of allPopupMenus) {
+        if (menu.offsetHeight > 0 && menu.offsetWidth > 0) {
+          return menu;
+        }
+      }
+    }
+
+    return null;
   }
 
   #closeActiveEmailMenu() {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -15,6 +15,7 @@ import querySelector from '../../../lib/dom/querySelectorOrFail';
 import makeMutationObserverChunkedStream from '../../../lib/dom/make-mutation-observer-chunked-stream';
 import type { ElementWithLifetime } from '../../../lib/dom/make-element-child-stream';
 import { simulateClick } from '../../../lib/dom/simulate-mouse-event';
+import isElementVisible from '../../../../common/isElementVisible';
 import censorHTMLtree from '../../../../common/censorHTMLtree';
 import findParent from '../../../../common/find-parent';
 import reemitClickEvent from '../../../lib/dom/reemitClickEventForReact';
@@ -80,6 +81,7 @@ class GmailMessageView {
   #gmailAttachmentAreaView: GmailAttachmentAreaView | null | undefined;
   #messageLoaded: boolean = false;
   #openMoreMenu: HTMLElement | null | undefined;
+  #loggedMoreMenuFallback: boolean = false;
   #sender: Contact | null | undefined = null;
   #recipients: ContactNameOptional[] | null | undefined = null;
   #recipientEmailAddresses: string[] | null | undefined = null;
@@ -373,22 +375,25 @@ class GmailMessageView {
   }
 
   #getOpenMoreMenu(): HTMLElement | null | undefined {
-    const selector_2022_11_23 =
-      'td > div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]';
-    const selector_2023_11_16 =
-      'div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]';
-
-    const maybeMoreMenu =
-      document.body.querySelector<HTMLElement>(selector_2023_11_16) ||
-      document.body.querySelector<HTMLElement>(selector_2022_11_23);
-    // This will find any message's open more menu! The caller needs to make
-    // sure it belongs to this message!
-    return (
-      maybeMoreMenu ||
-      document.body.querySelector<HTMLElement>(
-        'td > div.nH.if > div.nH.aHU div.b7.J-M[aria-haspopup=true]',
-      )
+    const match = findOpenMoreMenu(
+      this.#element,
+      this.#getMoreButton() ?? null,
     );
+    if (!match) return null;
+
+    if (match.usedFallback && !this.#loggedMoreMenuFallback) {
+      // Log once per view so maintainers learn the dated selectors no longer
+      // match Gmail's markup and can capture a new one.
+      this.#loggedMoreMenuFallback = true;
+      this.#driver
+        .getLogger()
+        .error(new Error('GmailMessageView: More menu found via fallback'), {
+          fallbackSelector: match.selector,
+          menuHtml: censorHTMLtree(match.element),
+        });
+    }
+
+    return match.element;
   }
 
   #closeActiveEmailMenu() {
@@ -995,6 +1000,86 @@ class GmailMessageView {
   getReadyStream() {
     return this.#readyStream;
   }
+}
+
+/**
+ * Finds the currently-open per-message More menu.
+ *
+ * This can still find another message's open More menu! The dated selectors
+ * search the whole document (they match any conversation's menu), and the
+ * fallback tiers are scoped only as narrowly as the `.aHU` conversation
+ * container the message lives in — which also holds the thread's other
+ * messages. The caller needs to make sure the menu belongs to this message;
+ * in practice callers only use the result while this message's More button
+ * reports `aria-expanded=true`, and Gmail keeps at most one of these menus
+ * open at a time.
+ *
+ * Exported for tests; GmailMessageView#getOpenMoreMenu is the production
+ * call site.
+ */
+export function findOpenMoreMenu(
+  messageElement: HTMLElement,
+  moreButton: HTMLElement | null,
+): { element: HTMLElement; usedFallback: boolean; selector: string } | null {
+  const selector_2022_11_23 =
+    'td > div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]';
+  const selector_2023_11_16 =
+    'div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]';
+  const selector_pre_2022 =
+    'td > div.nH.if > div.nH.aHU div.b7.J-M[aria-haspopup=true]';
+
+  // The menu is not a descendant of the message element: Gmail renders it as
+  // an absolutely-positioned element elsewhere in the `.aHU` conversation
+  // container (every dated selector above anchors on `.aHU`). Constrain the
+  // fallback tiers to that ancestor so a visible but unrelated menu elsewhere
+  // in the document (a label picker, the thread-toolbar More menu, a compose
+  // window's menus) can never be returned — misidentifying the menu makes
+  // #updateMoreMenu append the developer's items into the wrong menu and
+  // rewrite that menu's inline position. If the `.aHU` ancestor is missing,
+  // the fallback tiers don't run: failing to find the menu is safer than
+  // guessing.
+  const fallbackScope = messageElement.closest('.aHU');
+
+  const tiers: Array<{
+    root: ParentNode | null;
+    selector: string;
+    usedFallback?: boolean;
+    requireVisible?: boolean;
+  }> = [
+    { root: document.body, selector: selector_2023_11_16 },
+    { root: document.body, selector: selector_2022_11_23 },
+    { root: document.body, selector: selector_pre_2022 },
+    {
+      root: fallbackScope,
+      selector: '.J-M[aria-haspopup=true]',
+      usedFallback: true,
+      requireVisible: true,
+    },
+  ];
+  // Broadest tier: any visible menu-like element in the conversation
+  // container, consulted only while this message's More button reports
+  // itself expanded.
+  if (moreButton?.getAttribute('aria-expanded') === 'true') {
+    tiers.push({
+      root: fallbackScope,
+      selector: 'div[role=menu], .J-M',
+      usedFallback: true,
+      requireVisible: true,
+    });
+  }
+
+  // A later tier is only consulted after every earlier tier has failed to
+  // match, so the exact dated selectors are never shadowed by the broader
+  // fallbacks.
+  for (const { root, selector, usedFallback, requireVisible } of tiers) {
+    if (!root) continue;
+    for (const element of root.querySelectorAll<HTMLElement>(selector)) {
+      if (!requireVisible || isElementVisible(element)) {
+        return { element, usedFallback: !!usedFallback, selector };
+      }
+    }
+  }
+  return null;
 }
 
 function _extractContactInformation(span: HTMLElement) {


### PR DESCRIPTION
Addresses #1280. Draft until the fix is verified against live Gmail — see the last section.

Buttons added with `MessageView.addToolbarButton()` in the MORE section register but never render (#1280): none of the dated selectors in `GmailMessageView#getOpenMoreMenu` match Gmail's current markup, so the SDK never finds the open More menu.

What changed:

- `#getOpenMoreMenu` delegates to `findOpenMoreMenu` (exported so tests exercise the production code). It tries the dated selectors first, then two fallback tiers: visible `.J-M[aria-haspopup=true]` dropdowns, then any visible `div[role=menu]` / `.J-M` while this message's More button reports `aria-expanded=true`.
- Both fallback tiers search only the message's ancestor `.aHU` conversation container — the container every dated selector anchors on — so a visible but unrelated menu elsewhere in the document (label picker, thread-toolbar More menu, compose menus) can never be returned and have items appended into it. If there is no `.aHU` ancestor, the fallbacks do not run: failing to find the menu is safer than guessing wrong.
- When a fallback matches, the logger records the matched selector and a censored HTML tree of the menu (once per view), so the next Gmail selector drift shows up in telemetry instead of rotting silently.
- The undated selector is renamed `selector_pre_2022` to match the file's dated-selector naming.

Tests import `findOpenMoreMenu` and run it against Gmail-shaped fixtures: dated-selector precedence over fallback bait, in-scope fallback matching, visibility filtering, `aria-expanded` gating of the broad tier, and the wrong-menu case (a visible menu outside the conversation container is not returned).

Still to do before this is ready for review: capture Gmail's current More-menu markup from a live session, confirm whether the break is in `#getOpenMoreMenu` or in `#getMoreButton` (whose selector is equally exposed to the same DOM change), and add a new dated selector for the observed structure so the fallbacks stay a safety net rather than the primary path.
