### PR TITLE
fix(compose): harden inline reply element detection against delayed rendering

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view-reply-element.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view-reply-element.test.ts
@@ -1,0 +1,100 @@
+import waitFor from '../../../lib/wait-for';
+
+// Tests for the inline reply element detection fix (#1281).
+// Validates the findReplyElement selector priority and the waitFor-based
+// retry used when the compose element is not yet in the DOM when the
+// adB class is first added to the reply container.
+
+// Replicate the findReplyElement logic from #setupReplyStream.
+function findReplyElement(container: HTMLElement): HTMLElement | null {
+  return (container.getElementsByClassName('M9')?.[0] ||
+    container.querySelector<HTMLElement>('[role="dialog"]') ||
+    container.querySelector<HTMLElement>('form') ||
+    container.firstElementChild) as HTMLElement | null;
+}
+
+describe('findReplyElement selector priority', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+  });
+
+  test('returns .M9 element when present', () => {
+    const m9 = document.createElement('div');
+    m9.className = 'M9';
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    container.appendChild(m9);
+    container.appendChild(dialog);
+
+    expect(findReplyElement(container)).toBe(m9);
+  });
+
+  test('falls back to [role=dialog] when no .M9', () => {
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    const form = document.createElement('form');
+    container.appendChild(dialog);
+    container.appendChild(form);
+
+    expect(findReplyElement(container)).toBe(dialog);
+  });
+
+  test('falls back to form when no .M9 or [role=dialog]', () => {
+    const form = document.createElement('form');
+    const other = document.createElement('div');
+    container.appendChild(form);
+    container.appendChild(other);
+
+    expect(findReplyElement(container)).toBe(form);
+  });
+
+  test('falls back to firstElementChild as last resort', () => {
+    const child = document.createElement('div');
+    child.className = 'some-other-class';
+    container.appendChild(child);
+
+    expect(findReplyElement(container)).toBe(child);
+  });
+
+  test('returns null when container is empty', () => {
+    expect(findReplyElement(container)).toBeNull();
+  });
+});
+
+describe('inline reply waitFor retry behavior', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+  });
+
+  test('waitFor resolves when compose element appears after delay', async () => {
+    // Simulate the element appearing 50ms after adB class is set
+    setTimeout(() => {
+      const m9 = document.createElement('div');
+      m9.className = 'M9';
+      container.appendChild(m9);
+    }, 50);
+
+    const result = await waitFor(() => findReplyElement(container), 1000, 25);
+    expect(result).toBeInstanceOf(HTMLElement);
+    expect((result as HTMLElement).className).toBe('M9');
+  });
+
+  test('waitFor rejects when compose element never appears within timeout', async () => {
+    await expect(
+      waitFor(() => findReplyElement(container), 100, 25),
+    ).rejects.toThrowError('waitFor timeout');
+  });
+
+  test('waitFor resolves immediately when element already present', async () => {
+    const m9 = document.createElement('div');
+    m9.className = 'M9';
+    container.appendChild(m9);
+
+    const result = await waitFor(() => findReplyElement(container), 1000, 25);
+    expect(result).toBe(m9);
+  });
+});

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view-reply-element.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view-reply-element.test.ts
@@ -1,0 +1,159 @@
+import { findReplyElement, waitForReplyElement } from './gmail-message-view';
+
+describe('findReplyElement', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+  });
+
+  test('returns .M9 element when present', () => {
+    const m9 = document.createElement('div');
+    m9.className = 'M9';
+    const form = document.createElement('form');
+    container.appendChild(m9);
+    container.appendChild(form);
+
+    expect(findReplyElement(container)).toBe(m9);
+  });
+
+  test('falls back to form when no .M9', () => {
+    const form = document.createElement('form');
+    const other = document.createElement('div');
+    container.appendChild(form);
+    container.appendChild(other);
+
+    expect(findReplyElement(container)).toBe(form);
+  });
+
+  test('falls back to firstElementChild as last resort', () => {
+    const child = document.createElement('div');
+    child.className = 'some-other-class';
+    container.appendChild(child);
+
+    expect(findReplyElement(container)).toBe(child);
+  });
+
+  test('returns null when container is empty', () => {
+    expect(findReplyElement(container)).toBeNull();
+  });
+});
+
+describe('waitForReplyElement', () => {
+  let replyContainer: HTMLElement;
+  let onFound: jest.Mock;
+  let onTimeout: jest.Mock;
+
+  beforeEach(() => {
+    replyContainer = document.createElement('div');
+    replyContainer.classList.add('adB');
+    onFound = jest.fn();
+    onTimeout = jest.fn();
+  });
+
+  function appendReplyElementLater(delay: number) {
+    setTimeout(() => {
+      const m9 = document.createElement('div');
+      m9.className = 'M9';
+      replyContainer.appendChild(m9);
+    }, delay);
+  }
+
+  test('calls onFound when the element appears after a delay', async () => {
+    appendReplyElementLater(30);
+
+    await waitForReplyElement({
+      replyContainer,
+      isStopped: () => false,
+      isAlreadyFound: () => false,
+      onFound,
+      onTimeout,
+      timeout: 1000,
+      steptime: 10,
+    });
+
+    expect(onFound).toHaveBeenCalledTimes(1);
+    expect(onFound.mock.calls[0][0].className).toBe('M9');
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  test('stops polling immediately when the view is stopped mid-wait', async () => {
+    const isStopped = jest
+      .fn<boolean, []>()
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true);
+
+    // The generous timeout would hang this test past its own timeout if
+    // stopping did not abort the poll early.
+    await waitForReplyElement({
+      replyContainer,
+      isStopped,
+      isAlreadyFound: () => false,
+      onFound,
+      onTimeout,
+      timeout: 60 * 1000,
+      steptime: 10,
+    });
+
+    expect(isStopped).toHaveBeenCalledTimes(2);
+    expect(onFound).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  test('does not call onFound when the adB class was removed mid-wait', async () => {
+    setTimeout(() => {
+      replyContainer.classList.remove('adB');
+    }, 20);
+    appendReplyElementLater(30);
+
+    await waitForReplyElement({
+      replyContainer,
+      isStopped: () => false,
+      isAlreadyFound: () => false,
+      onFound,
+      onTimeout,
+      timeout: 1000,
+      steptime: 10,
+    });
+
+    expect(onFound).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  test('does not call onFound when the element was already found', async () => {
+    const m9 = document.createElement('div');
+    m9.className = 'M9';
+    replyContainer.appendChild(m9);
+
+    await waitForReplyElement({
+      replyContainer,
+      isStopped: () => false,
+      isAlreadyFound: () => true,
+      onFound,
+      onTimeout,
+      timeout: 1000,
+      steptime: 10,
+    });
+
+    expect(onFound).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  test('calls onTimeout when the element never appears', async () => {
+    await waitForReplyElement({
+      replyContainer,
+      isStopped: () => false,
+      isAlreadyFound: () => false,
+      onFound,
+      onTimeout,
+      timeout: 50,
+      steptime: 10,
+    });
+
+    expect(onFound).not.toHaveBeenCalled();
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onTimeout.mock.calls[0][0]).toMatchObject({
+      message: 'waitFor timeout',
+    });
+  });
+});

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -911,6 +911,8 @@ class GmailMessageView {
               // be in the DOM yet when the adB class is first added
               setTimeout(() => {
                 if (currentReplyElementRemovalStream) return; // Already found
+                if (self.#stopper.stopped) return; // View was destroyed
+                if (!replyContainer.classList.contains('adB')) return; // Reply closed
                 const retryElement = findReplyElement();
                 if (retryElement) {
                   self.#replyElement = retryElement;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -892,7 +892,7 @@ class GmailMessageView {
                 replyContainer.firstElementChild) as HTMLElement | null;
             };
 
-            let replyElement = findReplyElement();
+            const replyElement = findReplyElement();
 
             if (replyElement) {
               self.#replyElement = replyElement;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -885,12 +885,17 @@ class GmailMessageView {
       .onValue((mutation) => {
         if (mutation !== 'END' && replyContainer.classList.contains('adB')) {
           if (!currentReplyElementRemovalStream) {
-            const replyElement = (replyContainer.getElementsByClassName(
-              'M9',
-            )?.[0] || replyContainer.firstElementChild) as HTMLElement | null;
-            self.#replyElement = replyElement;
+            const findReplyElement = (): HTMLElement | null => {
+              return (replyContainer.getElementsByClassName('M9')?.[0] ||
+                replyContainer.querySelector<HTMLElement>('[role="dialog"]') ||
+                replyContainer.querySelector<HTMLElement>('form') ||
+                replyContainer.firstElementChild) as HTMLElement | null;
+            };
+
+            let replyElement = findReplyElement();
 
             if (replyElement) {
+              self.#replyElement = replyElement;
               currentReplyElementRemovalStream = kefirBus();
 
               self.#eventStream.emit({
@@ -901,6 +906,26 @@ class GmailMessageView {
                   removalStream: currentReplyElementRemovalStream,
                 },
               });
+            } else {
+              // Retry after a short delay - the compose element may not
+              // be in the DOM yet when the adB class is first added
+              setTimeout(() => {
+                if (currentReplyElementRemovalStream) return; // Already found
+                const retryElement = findReplyElement();
+                if (retryElement) {
+                  self.#replyElement = retryElement;
+                  currentReplyElementRemovalStream = kefirBus();
+
+                  self.#eventStream.emit({
+                    type: 'internal',
+                    eventName: 'replyElement',
+                    change: {
+                      el: retryElement,
+                      removalStream: currentReplyElementRemovalStream,
+                    },
+                  });
+                }
+              }, 100);
             }
           }
         } else {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -12,6 +12,7 @@ import getUpdatedContact from './gmail-message-view/get-updated-contact';
 import AttachmentIcon from './gmail-message-view/attachment-icon';
 import makeMutationObserverStream from '../../../lib/dom/make-mutation-observer-stream';
 import querySelector from '../../../lib/dom/querySelectorOrFail';
+import waitFor from '../../../lib/wait-for';
 import makeMutationObserverChunkedStream from '../../../lib/dom/make-mutation-observer-chunked-stream';
 import type { ElementWithLifetime } from '../../../lib/dom/make-element-child-stream';
 import { simulateClick } from '../../../lib/dom/simulate-mouse-event';
@@ -907,14 +908,13 @@ class GmailMessageView {
                 },
               });
             } else {
-              // Retry after a short delay - the compose element may not
-              // be in the DOM yet when the adB class is first added
-              setTimeout(() => {
-                if (currentReplyElementRemovalStream) return; // Already found
-                if (self.#stopper.stopped) return; // View was destroyed
-                if (!replyContainer.classList.contains('adB')) return; // Reply closed
-                const retryElement = findReplyElement();
-                if (retryElement) {
+              // The compose element may not be in the DOM yet when the adB
+              // class is first added. Poll until it appears (up to 1s).
+              waitFor(findReplyElement, 1000, 50)
+                .then((retryElement) => {
+                  if (currentReplyElementRemovalStream) return; // Already found
+                  if (self.#stopper.stopped) return; // View was destroyed
+                  if (!replyContainer.classList.contains('adB')) return; // Reply closed
                   self.#replyElement = retryElement;
                   currentReplyElementRemovalStream = kefirBus();
 
@@ -926,8 +926,10 @@ class GmailMessageView {
                       removalStream: currentReplyElementRemovalStream,
                     },
                   });
-                }
-              }, 100);
+                })
+                .catch(() => {
+                  // Element never appeared within 1s; give up silently.
+                });
             }
           }
         } else {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -12,6 +12,7 @@ import getUpdatedContact from './gmail-message-view/get-updated-contact';
 import AttachmentIcon from './gmail-message-view/attachment-icon';
 import makeMutationObserverStream from '../../../lib/dom/make-mutation-observer-stream';
 import querySelector from '../../../lib/dom/querySelectorOrFail';
+import waitFor from '../../../lib/wait-for';
 import makeMutationObserverChunkedStream from '../../../lib/dom/make-mutation-observer-chunked-stream';
 import type { ElementWithLifetime } from '../../../lib/dom/make-element-child-stream';
 import { simulateClick } from '../../../lib/dom/simulate-mouse-event';
@@ -870,6 +871,7 @@ class GmailMessageView {
 
     var self = this;
     var currentReplyElementRemovalStream: any = null;
+    let pendingReplyElementSearch = false;
     // hold off on emitting the mutation for a millisecond so
     // that compose-view-driver-stream is listening to reply stream
     Kefir.combine([
@@ -885,12 +887,10 @@ class GmailMessageView {
       .onValue((mutation) => {
         if (mutation !== 'END' && replyContainer.classList.contains('adB')) {
           if (!currentReplyElementRemovalStream) {
-            const replyElement = (replyContainer.getElementsByClassName(
-              'M9',
-            )?.[0] || replyContainer.firstElementChild) as HTMLElement | null;
-            self.#replyElement = replyElement;
+            const replyElement = findReplyElement(replyContainer);
 
             if (replyElement) {
+              self.#replyElement = replyElement;
               currentReplyElementRemovalStream = kefirBus();
 
               self.#eventStream.emit({
@@ -900,6 +900,34 @@ class GmailMessageView {
                   el: replyElement,
                   removalStream: currentReplyElementRemovalStream,
                 },
+              });
+            } else if (!pendingReplyElementSearch) {
+              pendingReplyElementSearch = true;
+              waitForReplyElement({
+                replyContainer,
+                isStopped: () => self.#stopper.stopped,
+                isAlreadyFound: () => currentReplyElementRemovalStream != null,
+                onFound: (retryElement) => {
+                  self.#replyElement = retryElement;
+                  currentReplyElementRemovalStream = kefirBus();
+
+                  self.#eventStream.emit({
+                    type: 'internal',
+                    eventName: 'replyElement',
+                    change: {
+                      el: retryElement,
+                      removalStream: currentReplyElementRemovalStream,
+                    },
+                  });
+                },
+                onTimeout: (err) => {
+                  self.#driver.getLogger().error(err, {
+                    reason: 'Reply element not found in reply container',
+                    replyContainerHtml: censorHTMLtree(replyContainer),
+                  });
+                },
+              }).finally(() => {
+                pendingReplyElementSearch = false;
               });
             }
           }
@@ -1002,6 +1030,56 @@ function _extractContactInformation(span: HTMLElement) {
     name: span.getAttribute('name')!,
     emailAddress: span.getAttribute('email')!,
   };
+}
+
+export function findReplyElement(container: HTMLElement): HTMLElement | null {
+  return (container.getElementsByClassName('M9')[0] ||
+    container.querySelector<HTMLElement>('form') ||
+    container.firstElementChild) as HTMLElement | null;
+}
+
+/**
+ * Gmail may add the adB class to the reply container before inserting the
+ * reply compose element, and #setupReplyStream's mutation observer only
+ * watches class attributes, so it never re-fires on the later child
+ * insertion. This polls for the element to cover that gap.
+ */
+export async function waitForReplyElement({
+  replyContainer,
+  isStopped,
+  isAlreadyFound,
+  onFound,
+  onTimeout,
+  timeout = 10 * 1000,
+  steptime,
+}: {
+  replyContainer: HTMLElement;
+  isStopped: () => boolean;
+  isAlreadyFound: () => boolean;
+  onFound: (el: HTMLElement) => void;
+  onTimeout: (err: unknown) => void;
+  timeout?: number;
+  steptime?: number;
+}): Promise<void> {
+  let replyElement;
+  try {
+    replyElement = await waitFor(
+      () => {
+        if (isStopped()) throw 'skip';
+        return findReplyElement(replyContainer);
+      },
+      timeout,
+      steptime,
+    );
+  } catch (err) {
+    if (err !== 'skip') {
+      onTimeout(err);
+    }
+    return;
+  }
+  if (isAlreadyFound()) return;
+  if (!replyContainer.classList.contains('adB')) return;
+  onFound(replyElement);
 }
 
 export default GmailMessageView;


### PR DESCRIPTION
Related to #1281.

`#setupReplyStream`'s mutation observer watches only the reply container's class attribute. If Gmail adds the `adB` class before inserting the reply compose element, detection runs against an empty container and never re-fires on the later child insertion — the reply element is silently missed and no ComposeView is emitted for it. This hardens that path. #1281 itself is unconfirmed (and possibly resolved by 2.2.11), so this PR does not claim to close it.

What changed:

- `findReplyElement` is extracted as an exported helper: `.M9`, then `form`, then `firstElementChild`.
- When the class flips but no element is present yet, `waitForReplyElement` polls for it (10s timeout) and emits through the normal reply stream when it appears. Polling aborts as soon as the view is stopped (checked inside the wait condition), a result is dropped if the reply was closed mid-wait or an element was already emitted, and only one poll runs at a time per view.
- A timeout is no longer swallowed: it logs through the driver logger with a censored HTML tree of the container, so a future selector drift is visible in telemetry.

Tests import the real `findReplyElement` / `waitForReplyElement`: selector priority, found-after-delay emit, stopped-mid-wait aborting the poll without emitting, class-removed-mid-wait, already-found dedup, and timeout logging. All fail against the previous code.
