### PR TITLE
fix(xsrf): isRelevantTo should be true if xsrf has changed

### DIFF
--- a/src/injected-js/gmail/setup-gmail-interceptor.ts
+++ b/src/injected-js/gmail/setup-gmail-interceptor.ts
@@ -1149,7 +1149,10 @@ export function setupGmailInterceptorOnFrames(
       isRelevantTo(connection) {
         return (
           /sync(?:\/u\/\d+)?\//.test(connection.url) &&
-          !(document.head as any).hasAttribute('data-inboxsdk-xsrf-token')
+          (!(document.head as any).hasAttribute('data-inboxsdk-xsrf-token') ||
+            (!!connection.headers['X-Framework-Xsrf-Token'] &&
+              connection.headers['X-Framework-Xsrf-Token'] ===
+                (document.head as any)['data-inboxsdk-xsrf-token']))
         );
       },
 


### PR DESCRIPTION
Hello again, we had a bug today due to the xsrf token being invalid.

In case the page is not refreshed for a long period of time, the xsrf token can be invalid and it should be updated.
Currently, has the token is already set, `isRelevantTo` return false.

This fix return true in case the tokens are not equal.

Not sure about the token lifespan but it seems to be multiple days, the issues happened on a 16 days old token, so it is quite difficult to reproduce unfortunately.