### PR TITLE
Fix modal and mole close icons

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-modal-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-modal-view-driver.ts
@@ -132,7 +132,7 @@ class GmailModalViewDriver {
     <div class="Kj-JD inboxsdk__modal_container" tabindex="0" role="alertdialog">
       <div class="Kj-JD-K7 Kj-JD-K7-GIHV4 inboxsdk__modal_toprow ${constrainTitleWidthTopRowClass}">
         <span class="Kj-JD-K7-K0" role="heading"></span>
-        <span class="Kj-JD-K7-Jq inboxsdk__modal_close" tabindex="0" role="button"></span>
+        <span class="Kj-JD-K7-Jq inboxsdk__modal_close inboxsdk__close_button" tabindex="0" role="button" aria-label="Close"></span>
       </div>
       <div class="Kj-JD-Jz inboxsdk__modal_content">
       </div>

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -435,7 +435,7 @@ function getTitleHTMLString(options: MoleOptions) {
         <div class="inboxsdk__mole_title_buttons${
           originalView ? ' inboxsdk__original_view' : ''
         }">
-          <img class="Hl" src="images/cleardot.gif" alt="Minimize" aria-label="Minimize" data-tooltip-delay="800" data-tooltip="Minimize"><img class="Hk" id=":rp" src="images/cleardot.gif" alt="Minimize" aria-label="Maximize" data-tooltip-delay="800" data-tooltip="Maximize"><!--<img class="Hq aUG" src="images/cleardot.gif" alt="Pop-out" aria-label="Full-screen (Shift for Pop-out)" data-tooltip-delay="800" data-tooltip="Full-screen (Shift for Pop-out)">--><img class="Ha inboxsdk__mole_close_button" src="images/cleardot.gif" alt="Close" aria-label="Close" data-tooltip-delay="800" data-tooltip="Close">
+          <img class="Hl" src="images/cleardot.gif" alt="Minimize" aria-label="Minimize" data-tooltip-delay="800" data-tooltip="Minimize"><img class="Hk" id=":rp" src="images/cleardot.gif" alt="Minimize" aria-label="Maximize" data-tooltip-delay="800" data-tooltip="Maximize"><!--<img class="Hq aUG" src="images/cleardot.gif" alt="Pop-out" aria-label="Full-screen (Shift for Pop-out)" data-tooltip-delay="800" data-tooltip="Full-screen (Shift for Pop-out)">--><img class="Ha inboxsdk__mole_close_button" src="https://www.gstatic.com/images/icons/material/system/1x/close_black_24dp.png" srcset="https://www.gstatic.com/images/icons/material/system/2x/close_black_24dp.png 2x" alt="Close" aria-label="Close" data-tooltip-delay="800" data-tooltip="Close">
         </div>
         <h2 class="inboxsdk__mole_default"></h2>
         <h2 class="inboxsdk__mole_minimized"></h2>

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -435,7 +435,7 @@ function getTitleHTMLString(options: MoleOptions) {
         <div class="inboxsdk__mole_title_buttons${
           originalView ? ' inboxsdk__original_view' : ''
         }">
-          <img class="Hl" src="images/cleardot.gif" alt="Minimize" aria-label="Minimize" data-tooltip-delay="800" data-tooltip="Minimize"><img class="Hk" id=":rp" src="images/cleardot.gif" alt="Minimize" aria-label="Maximize" data-tooltip-delay="800" data-tooltip="Maximize"><!--<img class="Hq aUG" src="images/cleardot.gif" alt="Pop-out" aria-label="Full-screen (Shift for Pop-out)" data-tooltip-delay="800" data-tooltip="Full-screen (Shift for Pop-out)">--><img class="Ha" src="images/cleardot.gif" alt="Close" aria-label="Close" data-tooltip-delay="800" data-tooltip="Close">
+          <img class="Hl" src="images/cleardot.gif" alt="Minimize" aria-label="Minimize" data-tooltip-delay="800" data-tooltip="Minimize"><img class="Hk" id=":rp" src="images/cleardot.gif" alt="Minimize" aria-label="Maximize" data-tooltip-delay="800" data-tooltip="Maximize"><!--<img class="Hq aUG" src="images/cleardot.gif" alt="Pop-out" aria-label="Full-screen (Shift for Pop-out)" data-tooltip-delay="800" data-tooltip="Full-screen (Shift for Pop-out)">--><img class="Ha inboxsdk__mole_close_button" src="images/cleardot.gif" alt="Close" aria-label="Close" data-tooltip-delay="800" data-tooltip="Close">
         </div>
         <h2 class="inboxsdk__mole_default"></h2>
         <h2 class="inboxsdk__mole_minimized"></h2>

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1486,16 +1486,8 @@ isn't visible behind it. */
 }
 
 .inboxsdk__mole_title_buttons > img.inboxsdk__mole_close_button {
-  background: url(https://www.gstatic.com/images/icons/material/system/1x/close_black_24dp.png)
-    center / 16px no-repeat;
   border-radius: 50%;
   opacity: 0.7;
-}
-
-@media (min-resolution: 192dpi) {
-  .inboxsdk__mole_title_buttons > img.inboxsdk__mole_close_button {
-    background-image: url(https://www.gstatic.com/images/icons/material/system/2x/close_black_24dp.png);
-  }
 }
 
 .inboxsdk__mole_title_buttons.inboxsdk__original_view

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1306,6 +1306,10 @@ isn't visible behind it. */
   cursor: pointer;
 }
 
+.inboxsdk__modal_close.inboxsdk__close_button {
+  display: inline-block;
+}
+
 .inboxsdk__modal_fullscreen .inboxsdk__modal_container {
   position: relative;
   margin-top: -60px;
@@ -1479,6 +1483,24 @@ isn't visible behind it. */
 
 .inboxsdk__mole_title_buttons:not(.inboxsdk__original_view) > img:hover {
   background-color: rgb(68 71 70 / 7.8%);
+}
+
+.inboxsdk__mole_title_buttons > img.inboxsdk__mole_close_button {
+  background: url(https://www.gstatic.com/images/icons/material/system/1x/close_black_24dp.png)
+    center / 16px no-repeat;
+  border-radius: 50%;
+  opacity: 0.7;
+}
+
+@media (min-resolution: 192dpi) {
+  .inboxsdk__mole_title_buttons > img.inboxsdk__mole_close_button {
+    background-image: url(https://www.gstatic.com/images/icons/material/system/2x/close_black_24dp.png);
+  }
+}
+
+.inboxsdk__mole_title_buttons.inboxsdk__original_view
+  > img.inboxsdk__mole_close_button {
+  filter: invert(1);
 }
 
 .inboxsdk__mole_title_buttons.inboxsdk__original_view > img:hover {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add SDK-owned close glyph rendering for mole titlebar close buttons so they no longer depend on Gmail's private `cleardot.gif`/`.Ha` sprite styling.
- Reuse the existing InboxSDK close button styling for modal close controls and add an accessible label.

## Walkthrough artifact
<a href="https://cursor.com/agents/bc-7887dd52-21ea-4c5a-a5f6-2312c825d3f6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclose_icon_fixture_verification.mp4"><img src="https://cursor.com/artifacts/c/art-9edf943e-7fde-45e4-b62f-7a6c8abc3176" alt="close_icon_fixture_verification.mp4" /></a>

## Testing
- `yarn lint` ✅
- `yarn lint:stylelint` ✅
- `yarn test` ✅ — 53 suites / 384 tests passed
- Focused browser fixture using the generated modal/mole DOM classes ✅ — modal, light mole, and original/dark mole close icons all visible after hard refresh
- `yarn typecheck` ⚠️ — fails on existing workspace setup before reaching touched files: `examples/app-menu/content.ts` cannot resolve `@inboxsdk/core`, causing implicit-any follow-on errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://streak.slack.com/archives/C0B32NWMJ9Y/p1781121293825569?thread_ts=1781121293.825569&cid=C0B32NWMJ9Y)

<div><a href="https://cursor.com/agents/bc-7887dd52-21ea-4c5a-a5f6-2312c825d3f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7887dd52-21ea-4c5a-a5f6-2312c825d3f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

