### PR TITLE
fix mole titlebar icons

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -429,6 +429,7 @@ function getTitleHTMLString(options: MoleOptions) {
   } else {
     const originalView = !isComposeTitleBarLightColor();
     return `
+      <!-- Ht lets Gmail's compose titlebar rules provide icons for Hl/Hk/Ha. -->
       <div class="inboxsdk__mole_view_titlebar Ht${
         originalView ? ' inboxsdk__original_view' : ''
       }">

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -429,7 +429,7 @@ function getTitleHTMLString(options: MoleOptions) {
   } else {
     const originalView = !isComposeTitleBarLightColor();
     return `
-      <div class="inboxsdk__mole_view_titlebar${
+      <div class="inboxsdk__mole_view_titlebar Ht${
         originalView ? ' inboxsdk__original_view' : ''
       }">
         <div class="inboxsdk__mole_title_buttons${

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1427,8 +1427,10 @@ isn't visible behind it. */
   right: 5px;
   font-size: 14px;
   font-weight: 500;
+  border-collapse: separate;
   box-sizing: border-box;
   height: 40px;
+  width: auto;
   cursor: pointer;
   padding: 10px 12px 10px 16px;
   color: #041e49;

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -1427,14 +1427,18 @@ isn't visible behind it. */
   right: 5px;
   font-size: 14px;
   font-weight: 500;
-  border-collapse: separate;
   box-sizing: border-box;
   height: 40px;
-  width: auto;
   cursor: pointer;
   padding: 10px 12px 10px 16px;
   color: #041e49;
   background: #f2f6fc;
+}
+
+/* Ht lets Gmail supply Hl/Hk/Ha icons, but its table styles should not resize the SDK titlebar. */
+.inboxsdk__mole_view_titlebar.Ht {
+  border-collapse: separate;
+  width: auto;
 }
 
 .inboxsdk__mole_view_titlebar.inboxsdk__original_view {


### PR DESCRIPTION
Gmail changed how the compose titlebar icons are scoped. Our mole titlebar was still using Gmail’s native icon classes (`Hl`, `Hk`, `Ha`) on `cleardot.gif`, but it wasn’t inside an `.Ht` titlebar anymore, so Gmail stopped applying the icon backgrounds. The buttons were there and still clickable, just visually blank.

This adds `Ht` to the SDK mole titlebar so Gmail’s existing `.Ht .Hl`, `.Ht .Hk`, and `.Ht .Ha` rules apply again. Since `.Ht` also brings a couple layout styles we don’t want, we reset `width` and `border-collapse` on our own titlebar selector.

### Testing
Reproduced and tested in live Gmail with `examples/mole-example`.

Before
<img width="281" height="120" alt="image" src="https://github.com/user-attachments/assets/8d24eba7-08f1-4697-b9b2-8f044beb57be" />


After
<img width="313" height="123" alt="image" src="https://github.com/user-attachments/assets/5e697e4d-8024-4fe5-822a-1fd792f57e76" />
