### PR TITLE
fix compose buttons

### DIFF
--- a/examples/compose-dropdown-button/content.js
+++ b/examples/compose-dropdown-button/content.js
@@ -123,6 +123,15 @@ InboxSDK.load(1, 'simple-example', {
       },
     });
 
+    composeView.addButton({
+      title: 'Close',
+      iconUrl: chrome.runtime.getURL('monkey.png'),
+      onClick: function () {
+        console.log('close');
+        composeView.close();
+      },
+    });
+
     composeView.on('presending', function (event) {
       console.log('presending', event);
       event.cancel();

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
@@ -1309,11 +1309,19 @@ class GmailComposeView {
   }
 
   getCloseButton(): HTMLElement {
-    return this.#element.querySelectorAll<HTMLElement>('.Hm > img')[2];
+    // Prefer legacy <img> titlebar controls; fall back to newer <button class="Ha">.
+    return (
+      this.#element.querySelectorAll<HTMLElement>('.Hm > img')[2] ||
+      querySelector(this.#element, '.Hm .Ha')
+    );
   }
 
   getMoleSwitchButton(): HTMLElement {
-    return this.#element.querySelectorAll<HTMLElement>('.Hm > img')[1];
+    // Prefer legacy <img> titlebar controls; fall back to newer <button class="Hq">.
+    return (
+      this.#element.querySelectorAll<HTMLElement>('.Hm > img')[1] ||
+      querySelector(this.#element, '.Hm .Hq')
+    );
   }
 
   getBottomBarTable(): HTMLElement {
@@ -1497,7 +1505,10 @@ class GmailComposeView {
     if (minimized !== this.isMinimized()) {
       if (this.#isInlineReplyForm)
         throw new Error('Not implemented for inline compose views');
-      const minimizeButton = querySelector(this.#element, '.Hm > img');
+      // Prefer legacy <img>; fall back to newer <button class="Hl">.
+      const minimizeButton =
+        this.#element.querySelector<HTMLElement>('.Hm > img') ||
+        querySelector(this.#element, '.Hm .Hl');
       simulateClick(minimizeButton);
     }
   }
@@ -1506,10 +1517,10 @@ class GmailComposeView {
     if (fullscreen !== this.isFullscreen()) {
       if (this.#isInlineReplyForm)
         throw new Error('Not implemented for inline compose views');
-      const fullscreenButton = querySelector(
-        this.#element,
-        '.Hm > img:nth-of-type(2)',
-      );
+      // Prefer legacy <img>; fall back to newer <button class="Hq">.
+      const fullscreenButton =
+        this.#element.querySelector<HTMLElement>('.Hm > img:nth-of-type(2)') ||
+        querySelector(this.#element, '.Hm .Hq');
       simulateClick(fullscreenButton);
     }
   }


### PR DESCRIPTION
Compose view buttons are updated, see the new version from gmail:

<img width="542" height="167" alt="image" src="https://github.com/user-attachments/assets/2717e3fc-3e68-4526-b72f-82242315d1cb" />

We can reproduce this by calling `comopseView.close()`. So adding it to our example extension compose-dropdown-button. 

Before: Clicking on the customized close button in compose view doesn't close compose view

https://github.com/user-attachments/assets/4d9f376f-2bba-4702-8605-112e8650e367

After: Clicking on the customized close button in compose view close compose view properly

https://github.com/user-attachments/assets/2db9e2b2-20e3-480f-83e3-bb15a75c5af3

