### PR TITLE
sync mole spacer with right panel area

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
@@ -36,6 +36,7 @@ import trackGmailStyles, {
   stylesStream,
 } from './gmail-driver/track-gmail-styles';
 import temporaryTrackDownloadUrlValidity from './gmail-driver/temporary-track-download-url-validity';
+import syncMoleSpacerWithRightColumn from './gmail-driver/sync-mole-spacer-with-right-column';
 import getGmailThreadIdForRfcMessageId from '../../driver-common/getGmailThreadIdForRfcMessageId';
 import getRfcMessageIdForGmailThreadId from './gmail-driver/get-rfc-message-id-for-gmail-thread-id';
 import getGmailMessageIdForSyncMessageId from '../../driver-common/getGmailMessageIdForSyncMessageId';
@@ -271,6 +272,7 @@ class GmailDriver {
         gmailLoadEvent(this);
         overrideGmailBackButton(this, this.#gmailRouteProcessor);
         trackGmailStyles();
+        syncMoleSpacerWithRightColumn(this);
         temporaryTrackDownloadUrlValidity(this);
         if (opts.suppressAddonTitle != null) {
           suppressAddon(this, opts.suppressAddonTitle);

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
@@ -964,7 +964,7 @@ class GmailDriver {
     return waitFor(condition)
       .map(() => undefined)
       .mapErrors((err) => {
-        const el = document.querySelector<HTMLElement>('div.aUx');
+        const el = GmailElementGetter.getCompanionSidebarColumnElement();
         this.#logger.error(err, {
           reason: 'waitForGlobalSidebarReady timed out',
           aUxHtml: el ? censorHTMLtree(el) : null,

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/sync-mole-spacer-with-right-column.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/sync-mole-spacer-with-right-column.ts
@@ -7,39 +7,35 @@ import type GmailDriver from '../gmail-driver';
  * spacer at `.dw > .jAmAWb`.
  *
  * Gmail drives that spacer for its OWN companion panels (Calendar, Keep, Tasks,
- * Contacts) but not for anything else that lives in the same right column
- *
- * We mirror the *occupied width* of the right column onto the spacer: whenever
- * the column is showing more than its ~56px icon rail, some panel is open (whoever owns it)
- * and the spacer is set to match; otherwise we leave the spacer alone so Gmail
- * keeps managing its own companions.
+ * Contacts) but not for InboxSDK content panels, which sit in the same column
+ * (`.WN9Ejb`). So whenever the column resizes (or the first mole appears) we
+ * match the spacer using Gmail's own formula — companion content width + rail
+ * inset
  */
 
+/** This includes the panel and the tab rail. */
 const RIGHT_COLUMN_SELECTOR = 'div.aUx';
+
+/** Google companions and SDK panels both render their body here. */
+const COMPANION_PANEL_SELECTOR = '.WN9Ejb';
+
 const MOLE_SPACER_SELECTOR = 'div.dw > .jAmAWb';
 
 /**
  * Dispatched by the mole driver whenever a mole is added. Creating a mole
- * doesn't resize the right column, so our `.aUx` observers wouldn't otherwise fire
+ * doesn't resize the right column, so our `.aUx` observer wouldn't otherwise fire.
  */
 export const MOLE_SPACER_REFRESH_EVENT = 'inboxsdk__refreshMoleSpacer';
-
-/** Marks a spacer whose width was set by us, so we only ever clear our own. */
-const MANAGED_ATTR = 'data-inboxsdk-mole-spacer-managed';
-
-/** Stores the spacer's original inline width so we can restore it exactly. */
-const ORIGINAL_WIDTH_ATTR = 'data-inboxsdk-mole-spacer-original-width';
 
 /** Prevents multiple InboxSDK instances from each installing the observer. */
 const INSTALLED_ATTR = 'data-inboxsdk-mole-spacer-sync';
 
 /**
- * The right column shows only a ~56px icon rail when no panel is open. Anything
- * wider than this means a panel is present. The headroom above 56px keeps
- * icon-rail-only states (including the rail collapsing, which Gmail also ignores)
- * from being mistaken for an open panel.
+ * The rail-inset width Gmail keeps on the spacer when only the icon rail is
+ * showing. We hardcode it because there are cases where we
+ * wouldn't be able to grab it from the DOM.
  */
-const ICON_RAIL_MAX_WIDTH = 80;
+const RAIL_INSET_WIDTH = 66;
 
 export default function syncMoleSpacerWithRightColumn(driver: GmailDriver) {
   const ResizeObserver = global.ResizeObserver;
@@ -69,13 +65,7 @@ export default function syncMoleSpacerWithRightColumn(driver: GmailDriver) {
 
       // Width changes when a panel opens/closes/resizes.
       new ResizeObserver(update).observe(rightColumn);
-      // A panel can also toggle via `display`/`class` changes on the column
-      // itself without a resize notification, so watch those too.
-      new MutationObserver(update).observe(rightColumn, {
-        attributes: true,
-        attributeFilter: ['style', 'class'],
-        childList: true,
-      });
+
       // A mole appearing (which also creates the spacer on the very first one)
       // doesn't touch the right column, so the mole driver signals us directly.
       document.addEventListener(MOLE_SPACER_REFRESH_EVENT, update);
@@ -97,42 +87,26 @@ function updateSpacer(rightColumn: HTMLElement) {
   // compose/thread view has been used. Until it exists there is nothing to size.
   if (!spacer) return;
 
-  const occupiedWidth = rightColumn.getBoundingClientRect().width;
-  const panelOpen = occupiedWidth > ICON_RAIL_MAX_WIDTH;
-  const managed = spacer.hasAttribute(MANAGED_ATTR);
+  const companion = rightColumn.querySelector<HTMLElement>(
+    COMPANION_PANEL_SELECTOR,
+  );
+  // `.WN9Ejb` stays in the DOM when collapsed (`display: none`); only count it
+  // when a companion/SDK panel is actually showing.
+  const companionWidth =
+    companion && getComputedStyle(companion).display !== 'none'
+      ? companion.getBoundingClientRect().width
+      : 0;
 
-  if (managed) {
-    if (panelOpen) {
-      // Keep our spacer matched to the occupied width (panel opened/resized).
-      const targetWidth = `${occupiedWidth}px`;
-      if (spacer.style.width !== targetWidth) {
-        spacer.style.width = targetWidth;
-        refreshComposeToolbars();
-      }
-    } else {
-      // Restore what was there before we took over
-      // and hand management back to Gmail.
-      spacer.style.width = spacer.getAttribute(ORIGINAL_WIDTH_ATTR) ?? '';
-      spacer.removeAttribute(ORIGINAL_WIDTH_ATTR);
-      spacer.removeAttribute(MANAGED_ATTR);
-      refreshComposeToolbars();
-    }
-    return;
+  // Match Gmail: content width + rail inset.
+  // When no panel is open, companionWidth is 0 and we restore the rail inset
+  const targetWidth =
+    companionWidth > 0 ? companionWidth + RAIL_INSET_WIDTH : RAIL_INSET_WIDTH;
+
+  const target = `${targetWidth}px`;
+  if (spacer.style.width !== target) {
+    spacer.style.width = target;
+    refreshComposeToolbars();
   }
-
-  // Only act when a panel is open but Gmail hasn't already widened the
-  // spacer for it. When Gmail HAS widened it (its own companion — Calendar, Keep,
-  // etc.), the spacer is already wider than the rail, so we leave it entirely
-  // alone and let Gmail run the whole open/close lifecycle.
-  if (!panelOpen) return;
-  if (spacer.getBoundingClientRect().width > ICON_RAIL_MAX_WIDTH) return;
-
-  // A panel Gmail isn't accounting for. Take the spacer over,
-  // remembering the original width so we can restore it.
-  spacer.setAttribute(ORIGINAL_WIDTH_ATTR, spacer.style.width);
-  spacer.setAttribute(MANAGED_ATTR, 'true');
-  spacer.style.width = `${occupiedWidth}px`;
-  refreshComposeToolbars();
 }
 
 /**

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/sync-mole-spacer-with-right-column.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/sync-mole-spacer-with-right-column.ts
@@ -1,0 +1,146 @@
+import waitFor from '../../../lib/wait-for';
+import fakeWindowResize from '../../../lib/fake-window-resize';
+import type GmailDriver from '../gmail-driver';
+
+/**
+ * Gmail keeps compose/SDK moles clear of the right side panel by widening a flex
+ * spacer at `.dw > .jAmAWb`.
+ *
+ * Gmail drives that spacer for its OWN companion panels (Calendar, Keep, Tasks,
+ * Contacts) but not for anything else that lives in the same right column
+ *
+ * We mirror the *occupied width* of the right column onto the spacer: whenever
+ * the column is showing more than its ~56px icon rail, some panel is open (whoever owns it)
+ * and the spacer is set to match; otherwise we leave the spacer alone so Gmail
+ * keeps managing its own companions.
+ */
+
+const RIGHT_COLUMN_SELECTOR = 'div.aUx';
+const MOLE_SPACER_SELECTOR = 'div.dw > .jAmAWb';
+
+/**
+ * Dispatched by the mole driver whenever a mole is added. Creating a mole
+ * doesn't resize the right column, so our `.aUx` observers wouldn't otherwise fire
+ */
+export const MOLE_SPACER_REFRESH_EVENT = 'inboxsdk__refreshMoleSpacer';
+
+/** Marks a spacer whose width was set by us, so we only ever clear our own. */
+const MANAGED_ATTR = 'data-inboxsdk-mole-spacer-managed';
+
+/** Stores the spacer's original inline width so we can restore it exactly. */
+const ORIGINAL_WIDTH_ATTR = 'data-inboxsdk-mole-spacer-original-width';
+
+/** Prevents multiple InboxSDK instances from each installing the observer. */
+const INSTALLED_ATTR = 'data-inboxsdk-mole-spacer-sync';
+
+/**
+ * The right column shows only a ~56px icon rail when no panel is open. Anything
+ * wider than this means a panel is present. The headroom above 56px keeps
+ * icon-rail-only states (including the rail collapsing, which Gmail also ignores)
+ * from being mistaken for an open panel.
+ */
+const ICON_RAIL_MAX_WIDTH = 80;
+
+export default function syncMoleSpacerWithRightColumn(driver: GmailDriver) {
+  const ResizeObserver = global.ResizeObserver;
+  if (!ResizeObserver) return;
+
+  const root = document.documentElement;
+  if (root.hasAttribute(INSTALLED_ATTR)) return;
+  root.setAttribute(INSTALLED_ATTR, 'true');
+
+  waitFor(() => document.querySelector<HTMLElement>(RIGHT_COLUMN_SELECTOR))
+    .then((rightColumn) => {
+      let scheduled = false;
+      // Coalesce bursts of mutations into a single read+write per frame so we
+      // don't thrash layout with getBoundingClientRect on every notification.
+      const update = () => {
+        if (scheduled) return;
+        scheduled = true;
+        requestAnimationFrame(() => {
+          scheduled = false;
+          try {
+            updateSpacer(rightColumn);
+          } catch (err) {
+            driver.getLogger().error(err as Error);
+          }
+        });
+      };
+
+      // Width changes when a panel opens/closes/resizes.
+      new ResizeObserver(update).observe(rightColumn);
+      // A panel can also toggle via `display`/`class` changes on the column
+      // itself without a resize notification, so watch those too.
+      new MutationObserver(update).observe(rightColumn, {
+        attributes: true,
+        attributeFilter: ['style', 'class'],
+        childList: true,
+      });
+      // A mole appearing (which also creates the spacer on the very first one)
+      // doesn't touch the right column, so the mole driver signals us directly.
+      document.addEventListener(MOLE_SPACER_REFRESH_EVENT, update);
+
+      update();
+    })
+    .catch(() => {
+      // No right column on this page (e.g. a Gmail surface without the side
+      // panel). Nothing to keep the moles clear of.
+    });
+}
+
+function updateSpacer(rightColumn: HTMLElement) {
+  // `.dw` has two `.jAmAWb` flex spacers: the left one (index 0) and the right
+  // one (last).
+  const spacers = document.querySelectorAll<HTMLElement>(MOLE_SPACER_SELECTOR);
+  const spacer = spacers[spacers.length - 1];
+  // The spacer is part of the mole container, which Gmail loads lazily once a
+  // compose/thread view has been used. Until it exists there is nothing to size.
+  if (!spacer) return;
+
+  const occupiedWidth = rightColumn.getBoundingClientRect().width;
+  const panelOpen = occupiedWidth > ICON_RAIL_MAX_WIDTH;
+  const managed = spacer.hasAttribute(MANAGED_ATTR);
+
+  if (managed) {
+    if (panelOpen) {
+      // Keep our spacer matched to the occupied width (panel opened/resized).
+      const targetWidth = `${occupiedWidth}px`;
+      if (spacer.style.width !== targetWidth) {
+        spacer.style.width = targetWidth;
+        refreshComposeToolbars();
+      }
+    } else {
+      // Restore what was there before we took over
+      // and hand management back to Gmail.
+      spacer.style.width = spacer.getAttribute(ORIGINAL_WIDTH_ATTR) ?? '';
+      spacer.removeAttribute(ORIGINAL_WIDTH_ATTR);
+      spacer.removeAttribute(MANAGED_ATTR);
+      refreshComposeToolbars();
+    }
+    return;
+  }
+
+  // Only act when a panel is open but Gmail hasn't already widened the
+  // spacer for it. When Gmail HAS widened it (its own companion — Calendar, Keep,
+  // etc.), the spacer is already wider than the rail, so we leave it entirely
+  // alone and let Gmail run the whole open/close lifecycle.
+  if (!panelOpen) return;
+  if (spacer.getBoundingClientRect().width > ICON_RAIL_MAX_WIDTH) return;
+
+  // A panel Gmail isn't accounting for. Take the spacer over,
+  // remembering the original width so we can restore it.
+  spacer.setAttribute(ORIGINAL_WIDTH_ATTR, spacer.style.width);
+  spacer.setAttribute(MANAGED_ATTR, 'true');
+  spacer.style.width = `${occupiedWidth}px`;
+  refreshComposeToolbars();
+}
+
+/**
+ * Widening the spacer moves the mole (`.AD`) but Gmail doesn't refresh the
+ * `position: fixed; left` it pins on the compose bottom bar (`.aDj.ahe`), so the
+ * toolbar is left behind at its old coordinates. A window resize makes Gmail
+ * re-lay-out the compose toolbars back under the mole.
+ */
+function refreshComposeToolbars() {
+  fakeWindowResize();
+}

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/sync-mole-spacer-with-right-column.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/sync-mole-spacer-with-right-column.ts
@@ -1,29 +1,26 @@
 import waitFor from '../../../lib/wait-for';
 import fakeWindowResize from '../../../lib/fake-window-resize';
+import GmailElementGetter, {
+  MOLE_CONTAINER_SELECTOR,
+} from '../gmail-element-getter';
 import type GmailDriver from '../gmail-driver';
 
 /**
  * Gmail keeps compose/SDK moles clear of the right side panel by widening a flex
- * spacer at `.dw > .jAmAWb`.
+ * spacer at the end of the mole container.
  *
  * Gmail drives that spacer for its OWN companion panels (Calendar, Keep, Tasks,
- * Contacts) but not for InboxSDK content panels, which sit in the same column
- * (`.WN9Ejb`). So whenever the column resizes (or the first mole appears) we
- * match the spacer using Gmail's own formula — companion content width + rail
- * inset
+ * Contacts) but not for InboxSDK content panels, which render in the same
+ * companion sidebar wrapper. So whenever the sidebar column resizes (or the
+ * first mole appears) we match the spacer using Gmail's own formula — companion
+ * content width + rail inset
  */
 
-/** This includes the panel and the tab rail. */
-const RIGHT_COLUMN_SELECTOR = 'div.aUx';
-
-/** Google companions and SDK panels both render their body here. */
-const COMPANION_PANEL_SELECTOR = '.WN9Ejb';
-
-const MOLE_SPACER_SELECTOR = 'div.dw > .jAmAWb';
+const MOLE_SPACER_SELECTOR = `${MOLE_CONTAINER_SELECTOR} > .jAmAWb`;
 
 /**
  * Dispatched by the mole driver whenever a mole is added. Creating a mole
- * doesn't resize the right column, so our `.aUx` observer wouldn't otherwise fire.
+ * doesn't resize the sidebar column, so our observer wouldn't otherwise fire.
  */
 export const MOLE_SPACER_REFRESH_EVENT = 'inboxsdk__refreshMoleSpacer';
 
@@ -45,7 +42,7 @@ export default function syncMoleSpacerWithRightColumn(driver: GmailDriver) {
   if (root.hasAttribute(INSTALLED_ATTR)) return;
   root.setAttribute(INSTALLED_ATTR, 'true');
 
-  waitFor(() => document.querySelector<HTMLElement>(RIGHT_COLUMN_SELECTOR))
+  waitFor(() => GmailElementGetter.getCompanionSidebarColumnElement())
     .then((rightColumn) => {
       let scheduled = false;
       // Coalesce bursts of mutations into a single read+write per frame so we
@@ -56,7 +53,7 @@ export default function syncMoleSpacerWithRightColumn(driver: GmailDriver) {
         requestAnimationFrame(() => {
           scheduled = false;
           try {
-            updateSpacer(rightColumn);
+            updateSpacer();
           } catch (err) {
             driver.getLogger().error(err as Error);
           }
@@ -78,20 +75,18 @@ export default function syncMoleSpacerWithRightColumn(driver: GmailDriver) {
     });
 }
 
-function updateSpacer(rightColumn: HTMLElement) {
-  // `.dw` has two `.jAmAWb` flex spacers: the left one (index 0) and the right
-  // one (last).
+function updateSpacer() {
+  // The mole container has two `.jAmAWb` flex spacers: the left one (index 0)
+  // and the right one (last).
   const spacers = document.querySelectorAll<HTMLElement>(MOLE_SPACER_SELECTOR);
   const spacer = spacers[spacers.length - 1];
   // The spacer is part of the mole container, which Gmail loads lazily once a
   // compose/thread view has been used. Until it exists there is nothing to size.
   if (!spacer) return;
 
-  const companion = rightColumn.querySelector<HTMLElement>(
-    COMPANION_PANEL_SELECTOR,
-  );
-  // `.WN9Ejb` stays in the DOM when collapsed (`display: none`); only count it
-  // when a companion/SDK panel is actually showing.
+  const companion = GmailElementGetter.getCompanionSidebarOuterWrapperElement();
+  // The wrapper stays in the DOM when collapsed (`display: none`); only count
+  // it when a companion/SDK panel is actually showing.
   const companionWidth =
     companion && getComputedStyle(companion).display !== 'none'
       ? companion.getBoundingClientRect().width

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -20,6 +20,31 @@ const APP_MENU = '.aeN.WR.a6o.anZ.nH.oy8Mbf[role=navigation]';
  */
 const NAV_MENU = '.aeN.WR.nH.oy8Mbf[role=navigation]';
 
+/**
+ * The right-hand column holding the companion sidebar. Both the panel and the
+ * icon rail live inside it.
+ */
+const COMPANION_SIDEBAR_COLUMN = 'div.aUx';
+
+/**
+ * Class on the companion sidebar's outer wrapper before the 2024-11-07 Gmail
+ * update, when the wrapper and the content container were the same element.
+ */
+const COMPANION_SIDEBAR_LEGACY_WRAPPER_CLASS = 'bq9';
+
+/**
+ * Class on the companion sidebar's outer wrapper in the layout Gmail shipped
+ * 2024-11-07, which moved the sidebar icons to the right of the panel. Absent
+ * on older layouts, which use {@link COMPANION_SIDEBAR_LEGACY_WRAPPER_CLASS}.
+ */
+export const COMPANION_SIDEBAR_PANEL_WRAPPER_CLASS = 'WN9Ejb';
+
+/** Outer flex container for the mole strip (spacers + mole area). Lazily created by Gmail. */
+export const MOLE_CONTAINER_SELECTOR = 'div.dw';
+
+/** The element compose windows and moles are appended to. */
+export const MOLE_PARENT_SELECTOR = `${MOLE_CONTAINER_SELECTOR} .nH > .nH > .no`;
+
 // TODO Figure out if these functions can and should be able to return null
 const GmailElementGetter = {
   getActiveMoreMenu(): HTMLElement | null {
@@ -41,6 +66,10 @@ const GmailElementGetter = {
     return document.querySelector('.no > .nn.bnl');
   },
 
+  getCompanionSidebarColumnElement(): HTMLElement | null {
+    return document.querySelector(COMPANION_SIDEBAR_COLUMN);
+  },
+
   getCompanionSidebarContentContainerElement(): HTMLElement | null {
     return document.querySelector('.brC-brG');
   },
@@ -48,6 +77,30 @@ const GmailElementGetter = {
   // <div class="brC-aT5-aOt-Jw" role="complementary" aria-label="Side panel">
   getCompanionSidebarIconContainerElement(): HTMLElement | null {
     return document.querySelector('.brC-aT5-aOt-Jw');
+  },
+
+  /**
+   * The wrapper Google's own companions (Calendar, Keep, Tasks, Contacts) and
+   * SDK content panels both render their body inside. Gmail hides it with
+   * `display: none` rather than removing it when nothing is open.
+   *
+   * @param contentContainerEl pass this when you already hold the content
+   * container, so the wrapper is derived from that same element.
+   */
+  getCompanionSidebarOuterWrapperElement(
+    contentContainerEl?: HTMLElement | null,
+  ): HTMLElement | null {
+    const companionSidebarContentContainerEl =
+      contentContainerEl ??
+      GmailElementGetter.getCompanionSidebarContentContainerElement();
+    if (!companionSidebarContentContainerEl) return null;
+    // TODO: Once the changes to the GMail DOM have been entirely ramped, drop
+    // the ternary here and always get the parentElement. (Jun 20, 2018)
+    return companionSidebarContentContainerEl.classList.contains(
+      COMPANION_SIDEBAR_LEGACY_WRAPPER_CLASS,
+    )
+      ? companionSidebarContentContainerEl
+      : companionSidebarContentContainerEl.parentElement;
   },
 
   getComposeButton(): HTMLElement | null {
@@ -58,7 +111,7 @@ const GmailElementGetter = {
   },
 
   getComposeWindowContainer(): HTMLElement | null {
-    return document.querySelector('.dw .nH > .nH > .no');
+    return document.querySelector(MOLE_PARENT_SELECTOR);
   },
 
   getContentSectionElement(): HTMLElement | undefined | null {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.tsx
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.tsx
@@ -10,7 +10,9 @@ import ReactDOM from 'react-dom';
 import AppSidebar from '../../../../../driver-common/sidebar/AppSidebar';
 import type { PanelDescriptor } from '../../../../../driver-common/sidebar/AppSidebar';
 import type GmailDriver from '../../../gmail-driver';
-import GmailElementGetter from '../../../gmail-element-getter';
+import GmailElementGetter, {
+  COMPANION_SIDEBAR_PANEL_WRAPPER_CLASS,
+} from '../../../gmail-element-getter';
 import idMap from '../../../../../lib/idMap';
 import incrementName from '../../../../../lib/incrementName';
 import querySelector from '../../../../../lib/dom/querySelectorOrFail';
@@ -691,22 +693,26 @@ class GmailAppSidebarPrimary {
       this.#instanceId,
     );
 
-    // TODO: Once the changes to the GMail DOM have been entirely ramped, drop the ternary here and
-    // always get the parentElement. (Jun 20, 2018)
-    this.#companionSidebarOuterWrapper =
-      this.#companionSidebarContentContainerEl.classList.contains('bq9')
-        ? this.#companionSidebarContentContainerEl
-        : (this.#companionSidebarContentContainerEl.parentElement as any);
+    const companionSidebarOuterWrapper =
+      GmailElementGetter.getCompanionSidebarOuterWrapperElement(
+        this.#companionSidebarContentContainerEl,
+      );
 
-    if (!this.#companionSidebarOuterWrapper) {
+    if (!companionSidebarOuterWrapper) {
       throw new Error(
         'should not happen: failed to find companionSidebarOuterWrapper',
       );
     }
 
+    this.#companionSidebarOuterWrapper = companionSidebarOuterWrapper;
+
     // detect 2024-11-07 gmail update that moved sidebar icons to the right of
     // the sidebar
-    if (this.#companionSidebarOuterWrapper.classList.contains('WN9Ejb')) {
+    if (
+      this.#companionSidebarOuterWrapper.classList.contains(
+        COMPANION_SIDEBAR_PANEL_WRAPPER_CLASS,
+      )
+    ) {
       document.body.classList.add('inboxsdk__sidebar_icons_right');
       this.#driver.getLogger().eventSite('sidebar_icons_right');
     }

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -2,7 +2,10 @@ import * as Kefir from 'kefir';
 import kefirBus from 'kefir-bus';
 import kefirStopper from 'kefir-stopper';
 import querySelector from '../../../lib/dom/querySelectorOrFail';
-import GmailElementGetter from '../gmail-element-getter';
+import GmailElementGetter, {
+  MOLE_CONTAINER_SELECTOR,
+  MOLE_PARENT_SELECTOR,
+} from '../gmail-element-getter';
 import type GmailDriver from '../gmail-driver';
 import isComposeTitleBarLightColor from '../is-compose-titlebar-light-color';
 import * as styles from './mole-view.module.css';
@@ -31,23 +34,24 @@ export type MoleOptions = {
 
 const INBOXSDK_CLASS = 'inboxsdk__mole_view' as const;
 
-const enum Selector {
-  MoleParent = '.dw .nH > .nH > .no',
-  /**
-   * Compose and SDK mole selector.
-   *
-   * @note 2023-10-11 on :not selectors:
-   *
-   * style*="order: 2147483647;" is the left mole spacer.
-   *
-   * style*="order: 0;" is the right mole spacer.
-   *
-   * .aJl is the chat placeholder.
-   */
-  Mole = `${Selector.MoleParent} > *:not([style*="order: 0;"], [style*="order: 2147483647;"], .aJl)`,
-  ComposeMole = `${Selector.Mole}.nn.nH`,
-  ChatMolePlaceholder = `${Selector.MoleParent} > .aJl`,
-}
+/**
+ * Compose and SDK mole selector.
+ *
+ * @note 2023-10-11 on :not selectors:
+ *
+ * style*="order: 2147483647;" is the left mole spacer.
+ *
+ * style*="order: 0;" is the right mole spacer.
+ *
+ * .aJl is the chat placeholder.
+ */
+const MOLE_SELECTOR = `${MOLE_PARENT_SELECTOR} > *:not([style*="order: 0;"], [style*="order: 2147483647;"], .aJl)`;
+
+const Selector = {
+  Mole: MOLE_SELECTOR,
+  ComposeMole: `${MOLE_SELECTOR}.nn.nH`,
+  ChatMolePlaceholder: `${MOLE_PARENT_SELECTOR} > .aJl`,
+} as const;
 
 const enum Tag {
   Mole = 'mole',
@@ -88,14 +92,14 @@ class GmailMoleViewDriver {
         },
         {
           tag: Tag.MoleParent,
-          selectors: [Selector.MoleParent],
+          selectors: [MOLE_PARENT_SELECTOR],
           sources: [null],
         },
       ],
       finders: {
         [Tag.MoleParent]: {
           fn: (root) =>
-            [root.querySelector<HTMLElement>(Selector.MoleParent)].filter(
+            [root.querySelector<HTMLElement>(MOLE_PARENT_SELECTOR)].filter(
               isNotNil,
             ),
           interval(elementCount, timeRunning) {
@@ -282,7 +286,7 @@ class GmailMoleViewDriver {
       return;
     }
 
-    const dw = moleParent.closest('div.dw');
+    const dw = moleParent.closest(MOLE_CONTAINER_SELECTOR);
 
     if (dw) {
       dw.classList.add('inboxsdk__moles_in_use', styles.inboxsdkMolesInUse);

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -10,6 +10,7 @@ import cx from 'classnames';
 import PageParserTree from 'page-parser-tree';
 import censorHTMLtree from '../../../../common/censorHTMLtree';
 import isNotNil from '../../../../common/isNotNil';
+import { MOLE_SPACER_REFRESH_EVENT } from '../gmail-driver/sync-mole-spacer-with-right-column';
 
 export type MoleButtonDescriptor = {
   title: string;
@@ -143,6 +144,12 @@ class GmailMoleViewDriver {
             if (el.matches(Selector.ComposeMole)) {
               this.#maybeMoveMole(el);
             }
+
+            // A new mole must clear whatever panel is open in the right column.
+            // The spacer that does that lives outside the mole parent (and is
+            // itself created alongside the first mole), so poke the sync that
+            // sizes it — adding a mole doesn't resize the column on its own.
+            document.dispatchEvent(new CustomEvent(MOLE_SPACER_REFRESH_EVENT));
 
             break;
           }


### PR DESCRIPTION
This adds the functionality of watching the right side panel area and adjusting the mole spacer if it hasn't already been managed by gmail. This fixes the bug of our side panels being covered by moles. 

[Streak box](https://streak.com/a/boxes/agxzfm1haWxmb29nYWVyNAsSDE9yZ2FuaXphdGlvbiIRb2lzbWFpbEBnbWFpbC5jb20MCxIEQ2FzZRiAgMWR-v2TCAw)