### PR TITLE
feat: add a selector registry with overrides

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
@@ -111,6 +111,7 @@ import type {
 } from '../../namespaces/search';
 import isNotNil from '../../../common/isNotNil';
 import censorHTMLtree from '../../../common/censorHTMLtree';
+import SelectorRegistry from '../../lib/dom/selectorRegistry';
 
 /**
  * @internal
@@ -126,6 +127,8 @@ class GmailDriver {
   #logger: Logger;
   #opts: PiOpts;
   #envData: EnvData;
+  /** Resolves selector keys against the bundled defaults plus any overrides. */
+  readonly selectors: SelectorRegistry;
   #customRouteIDs: Set<string> = new Set();
   #customListRouteIDs: Map<string, Function> = new Map();
   #customListSearchStringsToRouteIds: Map<string, string> = new Map();
@@ -183,6 +186,10 @@ class GmailDriver {
     this.#logger = logger;
     this.#opts = opts;
     this.#envData = envData;
+    this.selectors = new SelectorRegistry({
+      overrides: opts.selectorOverrides,
+      onInvalidSelector: opts.onInvalidSelector,
+    });
     this.#page = makePageParserTree(this, document);
     this.#stopper.onValue(() => this.#page.dump());
 

--- a/src/platform-implementation-js/dom-driver/gmail/selectors.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/selectors.ts
@@ -1,0 +1,42 @@
+/**
+ * Bundled Gmail selector registry.
+ *
+ * Each key maps to an ORDERED list of candidates, tried one at a time until one
+ * matches. An extension can supply overrides to this registry, which are PREPENDED
+ * to the bundled chain.
+ *
+ * Selectors must be ordered by preference (which selector must be tried first),
+ * not in chronological order.
+ *
+ * Never join a chain into one comma-separated selector: `querySelector('a, b')` picks
+ * the first match in document order, which ignores this ranking.
+ */
+export const GMAIL_SELECTORS = {
+  /**
+   * The compose title-bar table, resolved against the compose root.
+   *
+   * The `Ht`-less rung matches a superset of the `Ht` one, so it must stay BELOW it:
+   * above, it would win always and the specific rung would never run.
+   */
+  'composeView.titleBarTable': [
+    '.nH.Hy.aXJ table.cf.Ht',
+    '.nH.Hy.aXJ table.cf',
+  ],
+
+  /**
+   * The title-bar cell holding the compose window buttons — inside the table above,
+   * but resolved against the same compose root.
+   */
+  'composeView.titleBarTd': [
+    '.nH.Hy.aXJ table.cf.Ht td.Hm',
+    '.nH.Hy.aXJ table.cf td.Hm',
+  ],
+} as const satisfies Record<string, readonly string[]>;
+
+export type SelectorKey = keyof typeof GMAIL_SELECTORS;
+
+/** Resolved candidates for every key. The merge builds new lists. */
+export type SelectorCandidates = Record<SelectorKey, readonly string[]>;
+
+/** Shape of the `selectors` object in a remote config. */
+export type SelectorOverrides = Partial<Record<SelectorKey, readonly string[]>>;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
@@ -1526,10 +1526,10 @@ class GmailComposeView {
   }
 
   setTitleBarColor(color: string): () => void {
-    // Gmail A/B-renames the `Ht` token; fall back to a structural selector.
-    const buttonParent =
-      this.#element.querySelector('.nH.Hy.aXJ table.cf.Ht td.Hm') ||
-      this.#element.querySelector('.nH.Hy.aXJ table.cf td.Hm');
+    const buttonParent = this.#driver.selectors.querySelectorByKey(
+      this.#element,
+      'composeView.titleBarTd',
+    );
     if (!buttonParent) {
       // cosmetic; log and skip rather than throw
       this.#driver
@@ -1561,10 +1561,10 @@ class GmailComposeView {
       );
     }
 
-    // Gmail A/B-renames the `Ht` token; fall back to a structural selector.
-    const titleBarTable =
-      this.#element.querySelector('.nH.Hy.aXJ table.cf.Ht') ||
-      this.#element.querySelector('.nH.Hy.aXJ table.cf');
+    const titleBarTable = this.#driver.selectors.querySelectorByKey(
+      this.#element,
+      'composeView.titleBarTable',
+    );
     if (!titleBarTable) {
       // cosmetic; log and skip rather than throw
       this.#driver

--- a/src/platform-implementation-js/lib/dom/mergeSelectorOverrides.test.ts
+++ b/src/platform-implementation-js/lib/dom/mergeSelectorOverrides.test.ts
@@ -1,0 +1,57 @@
+import mergeSelectorOverrides, {
+  isValidSelector,
+} from './mergeSelectorOverrides';
+
+const DEFAULTS = {
+  'a.one': ['.specific', '.general'],
+  'a.two': ['.other'],
+} as const satisfies Record<string, readonly string[]>;
+
+test('no overrides leaves every chain untouched', () => {
+  expect(mergeSelectorOverrides(DEFAULTS, {})).toEqual(DEFAULTS);
+});
+
+test('an override is prepended and the bundled chain survives as the tail', () => {
+  expect(mergeSelectorOverrides(DEFAULTS, { 'a.one': ['.hotfix'] })).toEqual({
+    'a.one': ['.hotfix', '.specific', '.general'],
+    'a.two': ['.other'],
+  });
+});
+
+test('an unknown key has nowhere to land', () => {
+  const merged = mergeSelectorOverrides(DEFAULTS, {
+    'a.fromANewerConfig': ['.whatever'],
+  } as Record<string, string[]>);
+
+  expect(merged).toEqual(DEFAULTS);
+});
+
+test('re-listing a bundled selector promotes it rather than duplicating it', () => {
+  expect(mergeSelectorOverrides(DEFAULTS, { 'a.one': ['.general'] })).toEqual({
+    'a.one': ['.general', '.specific'],
+    'a.two': ['.other'],
+  });
+});
+
+test('an unparseable candidate is dropped and reported, and the key still works', () => {
+  const onInvalid = jest.fn();
+  const merged = mergeSelectorOverrides(
+    DEFAULTS,
+    { 'a.one': ['.foo[', '.hotfix'] },
+    onInvalid,
+  );
+
+  expect(merged['a.one']).toEqual(['.hotfix', '.specific', '.general']);
+  expect(onInvalid).toHaveBeenCalledWith('a.one', '.foo[');
+});
+
+test('the bundled defaults are not mutated', () => {
+  mergeSelectorOverrides(DEFAULTS, { 'a.one': ['.hotfix'] });
+
+  expect(DEFAULTS['a.one']).toEqual(['.specific', '.general']);
+});
+
+test('isValidSelector parses rather than matches', () => {
+  expect(isValidSelector('.nothing-in-this-document')).toBe(true);
+  expect(isValidSelector('.foo[')).toBe(false);
+});

--- a/src/platform-implementation-js/lib/dom/mergeSelectorOverrides.ts
+++ b/src/platform-implementation-js/lib/dom/mergeSelectorOverrides.ts
@@ -1,0 +1,62 @@
+import uniq from 'lodash/uniq';
+
+/**
+ * Unmounted fragment, used to validate CSS selectors.
+ */
+let validationRoot: DocumentFragment | undefined;
+
+/**
+ * Check whether the given selector is valid.
+ */
+export function isValidSelector(selector: string): boolean {
+  if (!validationRoot) {
+    validationRoot = document.createDocumentFragment();
+  }
+
+  try {
+    validationRoot.querySelector(selector);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Called for each dropped candidate: silent to the user, loud to the operator. */
+export type InvalidSelectorReporter = (key: string, selector: string) => void;
+
+/**
+ * Merges two selector registry objects (defaults and overrides),
+ * filtering out invalid selectors from the overrides. If found,
+ * it prepends the valid overrides to the defaults.
+ *
+ * @example
+ * ```ts
+ * mergeSelectorOverrides(
+ *   { 'composeView.someKey': ['.foo'] },
+ *   { 'composeView.someKey': ['.bar', 'invalid selector'] }
+ * );
+ * // { 'composeView.someKey': ['.bar', '.foo'] }
+ * ```
+ */
+export default function mergeSelectorOverrides<K extends string>(
+  defaults: Record<K, readonly string[]>,
+  overrides: Partial<Record<K, readonly string[]>>,
+  onInvalid?: InvalidSelectorReporter,
+): Record<K, readonly string[]> {
+  const merged = {} as Record<K, readonly string[]>;
+
+  for (const key of Object.keys(defaults) as K[]) {
+    const extra = (overrides[key] ?? []).filter((selector) => {
+      if (isValidSelector(selector)) {
+        return true;
+      }
+
+      onInvalid?.(key, selector);
+      return false;
+    });
+
+    merged[key] = uniq([...extra, ...defaults[key]]);
+  }
+
+  return merged;
+}

--- a/src/platform-implementation-js/lib/dom/selectorRegistry.test.ts
+++ b/src/platform-implementation-js/lib/dom/selectorRegistry.test.ts
@@ -1,0 +1,157 @@
+import {
+  GMAIL_SELECTORS,
+  type SelectorKey,
+} from '../../dom-driver/gmail/selectors';
+import SelectorRegistry from './selectorRegistry';
+
+/** A compose root whose title-bar table carries the `Ht` token, or not. */
+function composeRoot(withHt: boolean): HTMLElement {
+  const root = document.createElement('div');
+  root.className = 'nH Hy aXJ';
+  root.innerHTML = `
+    <table class="cf${withHt ? ' Ht' : ''}">
+      <tbody><tr><td class="Hm"></td></tr></tbody>
+    </table>`;
+  return root;
+}
+
+test('a mistyped key is rejected at compile time', () => {
+  // @ts-expect-error — 'THIS_SELECTOR_DOES_NOT_EXIST' is not a key in GMAIL_SELECTORS
+  const mistyped: SelectorKey = 'composeView.THIS_SELECTOR_DOES_NOT_EXIST';
+
+  expect(mistyped in GMAIL_SELECTORS).toBe(false);
+});
+
+// No overrides is what most users run.
+describe('with no config loaded', () => {
+  test('a key resolves through the bundled chain', () => {
+    const registry = new SelectorRegistry();
+    const root = composeRoot(true);
+
+    expect(registry.querySelectorByKey(root, 'composeView.titleBarTable')).toBe(
+      root.querySelector('table'),
+    );
+    expect(registry.querySelectorByKey(root, 'composeView.titleBarTd')).toBe(
+      root.querySelector('td'),
+    );
+  });
+
+  test('a later rung catches what the first one misses', () => {
+    const registry = new SelectorRegistry();
+    const root = composeRoot(false);
+
+    expect(registry.querySelectorByKey(root, 'composeView.titleBarTable')).toBe(
+      root.querySelector('table'),
+    );
+  });
+
+  test('candidates are tried in LIST order, not document order', () => {
+    const registry = new SelectorRegistry();
+    const root = document.createElement('div');
+    root.append(composeRoot(false), composeRoot(true));
+
+    // The `Ht`-less table comes first in the document, but its rung is second.
+    expect(registry.querySelectorByKey(root, 'composeView.titleBarTable')).toBe(
+      root.querySelectorAll('table')[1],
+    );
+  });
+
+  test('a total miss is null, or a throw naming the key', () => {
+    const registry = new SelectorRegistry();
+    const empty = document.createElement('div');
+
+    expect(
+      registry.querySelectorByKey(empty, 'composeView.titleBarTable'),
+    ).toBe(null);
+    expect(() =>
+      registry.querySelectorByKeyOrFail(empty, 'composeView.titleBarTable'),
+    ).toThrow('composeView.titleBarTable');
+  });
+});
+
+describe('with a config loaded', () => {
+  test('an empty config is indistinguishable from no config', () => {
+    const registry = new SelectorRegistry({ overrides: {} });
+    const root = composeRoot(true);
+
+    expect(registry.querySelectorByKey(root, 'composeView.titleBarTable')).toBe(
+      root.querySelector('table'),
+    );
+  });
+
+  test('an override repairs a key the bundled chain can no longer find', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<table class="brand-new"></table>';
+
+    expect(
+      new SelectorRegistry().querySelectorByKey(
+        root,
+        'composeView.titleBarTable',
+      ),
+    ).toBe(null);
+
+    const registry = new SelectorRegistry({
+      overrides: { 'composeView.titleBarTable': ['table.brand-new'] },
+    });
+
+    expect(registry.querySelectorByKey(root, 'composeView.titleBarTable')).toBe(
+      root.querySelector('table'),
+    );
+  });
+
+  test('an override that matches nothing cannot break the bundled chain', () => {
+    const registry = new SelectorRegistry({
+      overrides: { 'composeView.titleBarTable': ['table.matches-nothing'] },
+    });
+    const root = composeRoot(true);
+
+    expect(registry.querySelectorByKey(root, 'composeView.titleBarTable')).toBe(
+      root.querySelector('table'),
+    );
+  });
+
+  test('an unparseable override is dropped, reported, and inert', () => {
+    const onInvalidSelector = jest.fn();
+    const registry = new SelectorRegistry({
+      overrides: { 'composeView.titleBarTable': ['table['] },
+      onInvalidSelector,
+    });
+    const root = composeRoot(true);
+
+    expect(onInvalidSelector).toHaveBeenCalledWith(
+      'composeView.titleBarTable',
+      'table[',
+    );
+    expect(registry.querySelectorByKey(root, 'composeView.titleBarTable')).toBe(
+      root.querySelector('table'),
+    );
+  });
+
+  test('a key from a newer config is a no-op', () => {
+    const registry = new SelectorRegistry({
+      overrides: { 'composeView.fromTheFuture': ['.x'] } as never,
+    });
+    const root = composeRoot(true);
+
+    expect(registry.querySelectorByKey(root, 'composeView.titleBarTable')).toBe(
+      root.querySelector('table'),
+    );
+  });
+
+  test('one registry cannot see another registry config', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<table class="brand-new"></table>';
+
+    const withOverrides = new SelectorRegistry({
+      overrides: { 'composeView.titleBarTable': ['table.brand-new'] },
+    });
+    const withoutOverrides = new SelectorRegistry();
+
+    expect(
+      withOverrides.querySelectorByKey(root, 'composeView.titleBarTable'),
+    ).toBe(root.querySelector('table'));
+    expect(
+      withoutOverrides.querySelectorByKey(root, 'composeView.titleBarTable'),
+    ).toBe(null);
+  });
+});

--- a/src/platform-implementation-js/lib/dom/selectorRegistry.ts
+++ b/src/platform-implementation-js/lib/dom/selectorRegistry.ts
@@ -1,0 +1,88 @@
+import {
+  GMAIL_SELECTORS,
+  type SelectorCandidates,
+  type SelectorKey,
+  type SelectorOverrides,
+} from '../../dom-driver/gmail/selectors';
+import mergeSelectorOverrides, {
+  type InvalidSelectorReporter,
+} from './mergeSelectorOverrides';
+import { SelectorError } from './querySelectorOrFail';
+
+export type SelectorRegistryOptions = {
+  /** Additional selector candidates to PREPEND to the SDK bundled defaults. */
+  overrides?: SelectorOverrides;
+  /** Fires for each override candidate dropped as invalid CSS in THIS browser. */
+  onInvalidSelector?: InvalidSelectorReporter;
+};
+
+/**
+ * Install overrides into the bundled defaults, filtering out invalid
+ * selectors. If there are any errors merging the overrides, we fallback
+ * to the SDK bundled defaults.
+ */
+function mergeOrFallBack({
+  overrides,
+  onInvalidSelector,
+}: SelectorRegistryOptions): SelectorCandidates {
+  if (!overrides) {
+    return GMAIL_SELECTORS;
+  }
+
+  try {
+    return mergeSelectorOverrides(
+      GMAIL_SELECTORS,
+      overrides,
+      onInvalidSelector,
+    );
+  } catch {
+    return GMAIL_SELECTORS;
+  }
+}
+
+/**
+ * Resolves named keys to elements, trying each of the key's candidates in
+ * order. Owned by the GmailDriver, so each InboxSDK instance resolves against
+ * its own candidates and a registry is never read before it is built.
+ */
+export default class SelectorRegistry {
+  readonly #candidates: SelectorCandidates;
+
+  constructor(options: SelectorRegistryOptions = {}) {
+    this.#candidates = mergeOrFallBack(options);
+  }
+
+  /**
+   * Resolve a registry key against `el`, returning null on a miss. Use this
+   * method if you want to degrade functionality when a selector is missing,
+   * instead of throwing an error.
+   */
+  querySelectorByKey(
+    el: Document | DocumentFragment | Element,
+    key: SelectorKey,
+  ): HTMLElement | null {
+    // Try each candidate in order, returning the first match (null otherwise).
+    for (const candidateSelector of this.#candidates[key]) {
+      const found = el.querySelector<HTMLElement>(candidateSelector);
+      if (found) {
+        return found;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolve a registry key against `el`, but throws if no candidate matches.
+   */
+  querySelectorByKeyOrFail(
+    el: Document | DocumentFragment | Element,
+    key: SelectorKey,
+  ): HTMLElement {
+    const found = this.querySelectorByKey(el, key);
+    if (!found) {
+      throw new SelectorError(`${key} (${this.#candidates[key].join(' || ')})`);
+    }
+    return found;
+  }
+}

--- a/src/platform-implementation-js/platform-implementation.ts
+++ b/src/platform-implementation-js/platform-implementation.ts
@@ -33,7 +33,10 @@ import Logger from './lib/logger';
 import isValidAppId from './lib/is-valid-app-id';
 // Some types
 import type { AppLogger } from './lib/logger';
+import type { SelectorOverrides } from './dom-driver/gmail/selectors';
+import type { InvalidSelectorReporter } from './lib/dom/mergeSelectorOverrides';
 const loadedAppIds: Set<string> = new Set();
+
 export type PiOpts = {
   appName?: string | null;
   appIconUrl?: string | null;
@@ -48,6 +51,10 @@ export type PiOpts = {
   REQUESTED_API_VERSION: number;
   primaryColor?: string;
   secondaryColor?: string;
+  /** Additional selector candidates to PREPEND to the selectors bundled with the SDK. */
+  selectorOverrides?: SelectorOverrides;
+  /** Fires for each override candidate dropped as invalid CSS in THIS browser. */
+  onInvalidSelector?: InvalidSelectorReporter;
 };
 export class PlatformImplementation extends SafeEventEmitter {
   destroyed: boolean;


### PR DESCRIPTION
Adds a selector registry to the Gmail driver: named keys that map to an **ordered list** of CSS candidates, plus an optional override map (`PiOpts.selectorOverrides`) that can *prepend* candidates to any key.

Behavior is unchanged when no overrides are passed.

## Why

Gmail changes its DOM without warning and breaks our selectors. Today a one-character selector fix ships through an `@inboxsdk/core` release, then an extension build, then a multi-day Chrome Web Store review — days of breakage for what is often a single string.

A declarative selector map can be supplied as *remote configuration*, which MV3 permits. This PR is the SDK half of that: the registry and its merge, so a later change can feed it a config. It ships nothing user-facing on its own.

The SDK never fetches anything — overrides arrive as a plain value from the extension, which keeps the SDK a pure function of its inputs.

## How the merge behaves

`mergeSelectorOverrides` iterates the bundled defaults, prepending the valid selectors to its own list. Candidates that fail a CSS parse in the current browser are dropped and reported through `onInvalidSelector`.

```ts
mergeSelectorOverrides(
  { 
    'composeView.someKey': ['.foo'] 
  }, 
  { 
    'composeView.someKey': ['.bar', 'INVALID_SELECTOR'],
    'INVALID_KEY': ['.bar']
  }
);
// { 'composeView.someKey': ['.bar', '.foo'] }
```

The `SelectorRegistry` constructor merges the bundled registry with the overrides, defaulting to the bundled registry on error.

## Where it lives

`GmailDriver` owns the registry, and creates an instance in the constructor, passing the corresponding options (`selectorOverrides`, `onInvalidSelector`). Candidates are resolved per instance, so two InboxSDK instances don't share the registry.

Call sites go through the driver to query selectors

```tsx
this.#driver.selectors.querySelectorByKey(el, 'composeView.titleBarTable');
```

## The two keys

A vertical slice to test the concept — `composeView.titleBarTable` and `composeView.titleBarTd`, lifted verbatim from the hand-rolled `||` chains already in `setTitleBarText` and `setTitleBarColor`:

```ts
// before
const titleBarTable =
  this.#element.querySelector('.nH.Hy.aXJ table.cf.Ht') ||
  this.#element.querySelector('.nH.Hy.aXJ table.cf');

// after
const titleBarTable = querySelectorByKey(this.#element, 'composeView.titleBarTable');
```

Both call sites degrade rather than throw, so both use `querySelectorByKey`. The throwing variant `querySelectorByKeyOrFail` exists for sites that want today's `querySelector` semantics.

## Notes

- The registry is immutable after construction, there is no reload. A config change takes effect on the next SDK load.
- We want to ship this to test if the Chrome Store accepts the selector registry as configuration, once that has passed a few reviews (🤞) we can start adding more selector keys and values over time.

