### PR TITLE
Harden getThreadIDAsync for Gmail split/reading pane

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -11,7 +11,9 @@ import GmailAttachmentCardView from './gmail-attachment-card-view';
 import getUpdatedContact from './gmail-message-view/get-updated-contact';
 import AttachmentIcon from './gmail-message-view/attachment-icon';
 import makeMutationObserverStream from '../../../lib/dom/make-mutation-observer-stream';
-import querySelector from '../../../lib/dom/querySelectorOrFail';
+import querySelector, {
+  SelectorError,
+} from '../../../lib/dom/querySelectorOrFail';
 import makeMutationObserverChunkedStream from '../../../lib/dom/make-mutation-observer-chunked-stream';
 import type { ElementWithLifetime } from '../../../lib/dom/make-element-child-stream';
 import { simulateClick } from '../../../lib/dom/simulate-mouse-event';
@@ -206,14 +208,16 @@ class GmailMessageView {
       throw new Error('tried to get message contents before message is loaded');
     }
 
-    try {
-      return querySelector(this.#element, 'div.ii.gt');
-    } catch (err) {
-      // Keep old fallback selector until we're confident of the new one.
-      this.#driver.getLogger().error(err);
-
-      return querySelector(this.#element, '.adP');
+    // Prefer current Gmail body markup. `.adP` is gone in modern Gmail (including
+    // reading/split pane), so treat both as one lookup instead of logging a
+    // primary-selector miss and then failing on a dead fallback.
+    const contentsElement =
+      this.#element.querySelector<HTMLElement>('div.ii.gt') ??
+      this.#element.querySelector<HTMLElement>('.adP');
+    if (!contentsElement) {
+      throw new SelectorError('div.ii.gt, .adP');
     }
+    return contentsElement;
   }
 
   isElementInQuotedArea(element: HTMLElement): boolean {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view-thread-id.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view-thread-id.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as Kefir from 'kefir';
+import GmailThreadView from './gmail-thread-view';
+
+function createDriverMock(overrides: Record<string, any> = {}) {
+  return {
+    getOpts: () => ({ REQUESTED_API_VERSION: 2 }),
+    waitForGlobalSidebarReady: () => Kefir.constant(null),
+    delayToTimeAfterReady: () => Kefir.never(),
+    getLogger: () => ({
+      error: jest.fn(),
+      eventSdkPassive: jest.fn(),
+    }),
+    getPageCommunicator: () => ({
+      getCurrentThreadID: jest.fn(),
+    }),
+    getOldGmailThreadIdFromSyncThreadId: jest.fn(async (id: string) => {
+      if (id === 'thread-f:123') return 'abcdef0123456789';
+      throw new Error('unknown sync id');
+    }),
+    getAppId: () => 'test',
+    ...overrides,
+  };
+}
+
+describe('GmailThreadView.getThreadIDAsync', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns data-legacy-thread-id from the thread element', async () => {
+    const el = document.createElement('div');
+    el.innerHTML = `<h2 class="hP" data-legacy-thread-id="19fb3e4994277632" data-thread-perm-id="thread-f:1">Subject</h2>`;
+    document.body.appendChild(el);
+
+    const view = new (GmailThreadView as any)(
+      el,
+      null,
+      createDriverMock(),
+      true,
+    );
+    await expect(view.getThreadIDAsync()).resolves.toBe('19fb3e4994277632');
+  });
+
+  it('waits for data-legacy-thread-id in preview pane', async () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+
+    const view = new (GmailThreadView as any)(
+      el,
+      null,
+      createDriverMock(),
+      true,
+    );
+    const pending = view.getThreadIDAsync();
+
+    setTimeout(() => {
+      el.innerHTML = `<h2 class="hP" data-legacy-thread-id="19fb4041fbed794e">Subject</h2>`;
+    }, 150);
+
+    await expect(pending).resolves.toBe('19fb4041fbed794e');
+  });
+
+  it('falls back to selected row legacy id in preview pane', async () => {
+    document.body.innerHTML = `
+      <div gh="tl">
+        <table><tbody>
+          <tr class="aps">
+            <td><span data-thread-id="#thread-f:1872158555841721906" data-legacy-thread-id="19fb3e4994277632">Subject</span></td>
+          </tr>
+        </tbody></table>
+      </div>
+      <div class="preview"></div>
+    `;
+    const el = document.querySelector('.preview') as HTMLElement;
+
+    const view = new (GmailThreadView as any)(
+      el,
+      null,
+      createDriverMock(),
+      true,
+    );
+    await expect(view.getThreadIDAsync()).resolves.toBe('19fb3e4994277632');
+  });
+
+  it('falls back to sync id conversion when only sync id is available', async () => {
+    jest.useFakeTimers();
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+
+    const getCurrentThreadID = jest.fn(() => 'thread-f:123');
+    const view = new (GmailThreadView as any)(
+      el,
+      null,
+      createDriverMock({
+        getPageCommunicator: () => ({ getCurrentThreadID }),
+      }),
+      true,
+    );
+
+    const pending = view.getThreadIDAsync();
+    await jest.advanceTimersByTimeAsync(5_100);
+    await expect(pending).resolves.toBe('abcdef0123456789');
+    expect(getCurrentThreadID).toHaveBeenCalledWith(el, true);
+    jest.useRealTimers();
+  });
+});

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
@@ -26,6 +26,7 @@ import BasicButtonViewController, {
 } from '../../../widgets/buttons/basic-button-view-controller';
 import { type ButtonDescriptor } from '../../../../inboxsdk';
 import censorHTMLtree from '../../../../common/censorHTMLtree';
+import waitFor, { WaitForError } from '../../../lib/wait-for';
 
 let hasLoggedAddonInfo = false;
 
@@ -605,29 +606,87 @@ class GmailThreadView {
   async getThreadIDAsync(): Promise<string> {
     if (this.#threadID) return this.#threadID;
 
-    const idElement = this.#element.querySelector('[data-legacy-thread-id]');
+    const resolveFromIdElement = async (
+      idElement: Element,
+    ): Promise<string | null | undefined> => {
+      // the string value can be 'undefined'
+      const syncAttributeValue = idElement.getAttribute('data-thread-perm-id');
+      if (
+        !this.#syncThreadID &&
+        syncAttributeValue &&
+        syncAttributeValue !== 'undefined'
+      ) {
+        this.#syncThreadID = syncAttributeValue;
+      }
+
+      let threadID = idElement.getAttribute('data-legacy-thread-id');
+      if (!threadID && this.#syncThreadID) {
+        threadID = await this.#driver.getOldGmailThreadIdFromSyncThreadId(
+          this.#syncThreadID,
+        );
+      }
+      return threadID;
+    };
+
+    // In preview/split pane, ThreadView is created as soon as `.a98.iY` appears,
+    // which can be before Gmail paints data-legacy-thread-id on the subject.
+    let idElement = this.#element.querySelector('[data-legacy-thread-id]');
+    if (idElement) {
+      this.#threadID = await resolveFromIdElement(idElement);
+      if (this.#threadID) return this.#threadID;
+    }
+
+    // Preview pane stays on a list route, so use the selected thread row when
+    // the preview thread root does not have the id yet.
+    if (this.#isPreviewedThread) {
+      const rowLegacyThreadId = document
+        .querySelector('[gh=tl] tr.aps [data-legacy-thread-id]')
+        ?.getAttribute('data-legacy-thread-id');
+      if (rowLegacyThreadId) {
+        this.#threadID = rowLegacyThreadId;
+        return rowLegacyThreadId;
+      }
+    }
+
+    if (!idElement) {
+      try {
+        idElement = await waitFor(
+          () => this.#element.querySelector('[data-legacy-thread-id]'),
+          5_000,
+          100,
+        );
+      } catch (err) {
+        if (!(err instanceof WaitForError)) {
+          throw err;
+        }
+      }
+
+      if (idElement) {
+        this.#threadID = await resolveFromIdElement(idElement);
+        if (this.#threadID) return this.#threadID;
+      }
+    }
+
+    if (this.#isPreviewedThread) {
+      try {
+        const syncThreadID = this.#driver
+          .getPageCommunicator()
+          .getCurrentThreadID(this.#element, true);
+        if (syncThreadID && syncThreadID !== 'undefined') {
+          this.#syncThreadID = syncThreadID;
+          this.#threadID =
+            await this.#driver.getOldGmailThreadIdFromSyncThreadId(
+              syncThreadID,
+            );
+          if (this.#threadID) return this.#threadID;
+        }
+      } catch (err) {
+        this.#driver.getLogger().error(err);
+      }
+    }
+
     if (!idElement) throw new Error('threadID element not found');
-
-    // the string value can be 'undefined'
-    const syncAttributeValue = idElement.getAttribute('data-thread-perm-id');
-    if (
-      !this.#syncThreadID &&
-      syncAttributeValue &&
-      syncAttributeValue !== 'undefined'
-    ) {
-      this.#syncThreadID = syncAttributeValue;
-    }
-
-    this.#threadID = idElement.getAttribute('data-legacy-thread-id');
-
-    if (!this.#threadID && this.#syncThreadID) {
-      this.#threadID = await this.#driver.getOldGmailThreadIdFromSyncThreadId(
-        this.#syncThreadID,
-      );
-    }
-
-    if (this.#threadID) return this.#threadID;
-    else throw new Error('Failed to get id for thread');
+    throw new Error('Failed to get id for thread');
   }
 
   addLabel(): SimpleElementView {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Customer report (horizontal split pane → infinite “Add to pipeline” sidebar spinner) pointed at thread ID reliability in preview/list context. Their saved HTML shows split pane (`.aia` / `.a98.iY`) **and** `data-legacy-thread-id` present on both the preview subject and the selected `tr.aps` row — so this is not “Gmail removed the attribute.” The SDK path still had races/gaps that can fail to resolve an ID reliably when ThreadView is created before attrs paint.

## Changes
- `GmailThreadView.getThreadIDAsync`:
  - wait briefly for `[data-legacy-thread-id]` under the preview thread root
  - immediately fall back to selected row `[gh=tl] tr.aps [data-legacy-thread-id]`
  - then fall back to sync id → legacy conversion via page communicator
- `GmailMessageView.getContentsElement`: stop logging a `div.ii.gt` miss then hard-failing on dead `.adP` (absent in modern Gmail / this customer’s HTML)
- Unit tests covering immediate resolve, delayed attr paint, row fallback, and sync-id conversion

## Customer HTML notes
- Preview selectors used today (`.ao9:has(.a98.iY)`) still match; `table.Bs` is gone but already had a fallback
- No `.adP` in the dump; body is `div.ii.gt`
- No Sentry events for this user on `threadID element not found` / `Failed to get id for thread`

## Test plan
- [x] `yarn test src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view-thread-id.test.ts`
- [ ] Manual: Gmail → Settings → Reading pane horizontal → open thread in bottom pane → confirm `ThreadView.getThreadIDAsync()` returns hex id
- [ ] Pair with streak-side that commits `threadViewState.id` immediately after resolve
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7652fa7a-24c4-4b70-bd04-9b4fed41e20b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7652fa7a-24c4-4b70-bd04-9b4fed41e20b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

