### PR TITLE
feat(selectors): key the compose title bar mutation targets

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/selectors.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/selectors.ts
@@ -13,10 +13,11 @@
  */
 export const GMAIL_SELECTORS = {
   /**
-   * The compose title-bar table, resolved against the compose root.
+   * The compose title-bar table.
    *
    * The `Ht`-less rung matches a superset of the `Ht` one, so it must stay BELOW it:
    * above, it would win always and the specific rung would never run.
+   * Root: compose root.
    */
   'composeView.titleBarTable': [
     '.nH.Hy.aXJ table.cf.Ht',
@@ -24,13 +25,29 @@ export const GMAIL_SELECTORS = {
   ],
 
   /**
-   * The title-bar cell holding the compose window buttons — inside the table above,
-   * but resolved against the same compose root.
+   * The title-bar cell holding the compose window buttons; inside the table above,
+   * but resolved independently of it.
+   * Root: compose root.
    */
   'composeView.titleBarTd': [
     '.nH.Hy.aXJ table.cf.Ht td.Hm',
     '.nH.Hy.aXJ table.cf td.Hm',
   ],
+
+  /**
+   * The native title element. Stay at this depth: the code anchors on its PARENT
+   * cell, not on the element itself.
+   * Root: `composeView.titleBarTable`
+   */
+  'composeView.titleBarText': ['div.Hp'],
+
+  /**
+   * The three layers `setTitleBarColor()` paints.
+   * Root: compose root.
+   */
+  'composeView.titleBarColorOuter': ['.nH.Hy.aXJ .pi > .l.o'],
+  'composeView.titleBarColorBody': ['.nH.Hy.aXJ .l.m'],
+  'composeView.titleBarColorBodyInner': ['.nH.Hy.aXJ .l.m > .l.n'],
 
   /**
    * Body of an open message.

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
@@ -84,6 +84,7 @@ import { ContactNameOptional } from '../../../../inboxsdk';
 import BasicButtonViewController from '../../../widgets/buttons/basic-button-view-controller';
 import { type PublicOnly } from '../../../../types/public-only';
 import isNotNil from '../../../../common/isNotNil';
+import { type SelectorKey } from '../selectors';
 
 let hasReportedMissingBody = false;
 
@@ -1537,20 +1538,25 @@ class GmailComposeView {
         .error(new Error('setTitleBarColor: could not find compose title bar'));
       return noop;
     }
-    const elementsToModify = [
-      this.#element.querySelector<HTMLElement>('.nH.Hy.aXJ .pi > .l.o'),
-      this.#element.querySelector<HTMLElement>('.nH.Hy.aXJ .l.m'),
-      this.#element.querySelector<HTMLElement>('.nH.Hy.aXJ .l.m > .l.n'),
-    ].filter((el): el is HTMLElement => el != null);
+
+    // The color lands on these layers, NOT on buttonParent.
+    const colorKeys: SelectorKey[] = [
+      'composeView.titleBarColorOuter',
+      'composeView.titleBarColorBody',
+      'composeView.titleBarColorBodyInner',
+    ];
+    const elementsToModify = colorKeys
+      .map((key) =>
+        this.#driver.selectors.querySelectorByKey(this.#element, key),
+      )
+      .filter(isNotNil);
+
     buttonParent.classList.add('inboxsdk__compose_customTitleBarColor');
-    elementsToModify.forEach((el) => {
-      el.style.backgroundColor = color;
-    });
+    elementsToModify.forEach((el) => setBgColor(el, color));
+
     return () => {
       buttonParent.classList.remove('inboxsdk__compose_customTitleBarColor');
-      elementsToModify.forEach((el) => {
-        el.style.backgroundColor = '';
-      });
+      elementsToModify.forEach((el) => setBgColor(el, ''));
     };
   }
 
@@ -1583,8 +1589,13 @@ class GmailComposeView {
       );
     }
 
-    const titleTextParent =
-      titleBarTable.querySelector('div.Hp')?.parentElement;
+    // The custom title is inserted after this element's parent cell, so the key
+    // resolves the text element and the code walks up — an override that points
+    // straight at the cell would insert one level too high.
+    const titleTextParent = this.#driver.selectors.querySelectorByKey(
+      titleBarTable,
+      'composeView.titleBarText',
+    )?.parentElement;
 
     if (!(titleTextParent instanceof HTMLElement)) {
       // cosmetic; log and skip rather than throw
@@ -1788,6 +1799,10 @@ export type InboxSdkModifyComposeRequest = {
     isPlainText?: boolean;
   };
 };
+
+function setBgColor(el: HTMLElement, color: string) {
+  el.style.backgroundColor = color;
+}
 
 export default GmailComposeView;
 export type ComposeViewDriver = PublicOnly<GmailComposeView>;


### PR DESCRIPTION
Follow-up to #1308. The registry landed with two keys for the compose title bar, but both resolve elements that are only *found*, never meaningfully mutated.

The changes in this PR allow us to actually override the registry in the parts where the DOM is changed.

- **`setTitleBarColor`** — the keyed `composeView.titleBarTd` only receives a marker class. The `backgroundColor` paint, which is the point of the API, went to three elements found by raw `querySelector`:

  ```
  .nH.Hy.aXJ .pi > .l.o
  .nH.Hy.aXJ .l.m
  .nH.Hy.aXJ .l.m > .l.n
  ```
- **`setTitleBarText`** — `composeView.titleBarTable` is keyed, but the insertion anchor `div.Hp` (whose parent cell the custom `<td>` is placed after, and which gets hidden) was not.


