### PR TITLE
feat(selectors): key eight more gmail call sites

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/selectors.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/selectors.ts
@@ -64,6 +64,15 @@ export const GMAIL_SELECTORS = {
     // pre-2023 `.if` layout
     'td > div.nH.if > div.nH.aHU div.b7.J-M[aria-haspopup=true]',
   ],
+
+  /**
+   * The "more actions" button that opens `messageView.openMoreMenu`.
+   * Only present while the message is expanded.
+   * Root: message element.
+   */
+  'messageView.moreButton': [
+    'tr.acZ div.T-I.J-J5-Ji.aap.L3[role=button][aria-haspopup]',
+  ],
 } as const satisfies Record<string, readonly string[]>;
 
 export type SelectorKey = keyof typeof GMAIL_SELECTORS;

--- a/src/platform-implementation-js/dom-driver/gmail/selectors.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/selectors.ts
@@ -80,6 +80,13 @@ export const GMAIL_SELECTORS = {
    * Root: message element.
    */
   'messageView.senderSpan': ['td.gF span[email]'],
+
+  /**
+   * The message's date element; the full date is read from its `title`,
+   * not its text.
+   * Root: message element.
+   */
+  'messageView.dateElement': ['.ads .gK .g3'],
 } as const satisfies Record<string, readonly string[]>;
 
 export type SelectorKey = keyof typeof GMAIL_SELECTORS;

--- a/src/platform-implementation-js/dom-driver/gmail/selectors.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/selectors.ts
@@ -87,6 +87,13 @@ export const GMAIL_SELECTORS = {
    * Root: message element.
    */
   'messageView.dateElement': ['.ads .gK .g3'],
+
+  /**
+   * The thread's subject heading. Read for its text, or walked child by child
+   * when it contains emoji images.
+   * Root: thread element.
+   */
+  'threadView.subject': ['.ha h2'],
 } as const satisfies Record<string, readonly string[]>;
 
 export type SelectorKey = keyof typeof GMAIL_SELECTORS;

--- a/src/platform-implementation-js/dom-driver/gmail/selectors.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/selectors.ts
@@ -44,6 +44,12 @@ export const GMAIL_SELECTORS = {
    * Root: message element.
    */
   'messageView.legacyIdBody': ['div.ii.gt'],
+
+  /**
+   * Element carrying the thread's id attributes.
+   * Root: thread element.
+   */
+  'threadView.idElement': ['[data-legacy-thread-id]'],
 } as const satisfies Record<string, readonly string[]>;
 
 export type SelectorKey = keyof typeof GMAIL_SELECTORS;

--- a/src/platform-implementation-js/dom-driver/gmail/selectors.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/selectors.ts
@@ -50,6 +50,20 @@ export const GMAIL_SELECTORS = {
    * Root: thread element.
    */
   'threadView.idElement': ['[data-legacy-thread-id]'],
+
+  /**
+   * A message's open "more actions" menu. Gmail renders it outside
+   * the message, so a match may belong to another message.
+   * Root: `document.body`.
+   */
+  'messageView.openMoreMenu': [
+    // 2023-11-16 thread-view redesign
+    'div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]',
+    // 2022-11-23, same shape under an extra `td >`
+    'td > div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]',
+    // pre-2023 `.if` layout
+    'td > div.nH.if > div.nH.aHU div.b7.J-M[aria-haspopup=true]',
+  ],
 } as const satisfies Record<string, readonly string[]>;
 
 export type SelectorKey = keyof typeof GMAIL_SELECTORS;

--- a/src/platform-implementation-js/dom-driver/gmail/selectors.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/selectors.ts
@@ -31,6 +31,12 @@ export const GMAIL_SELECTORS = {
     '.nH.Hy.aXJ table.cf.Ht td.Hm',
     '.nH.Hy.aXJ table.cf td.Hm',
   ],
+
+  /**
+   * Body of an open message.
+   * Root: message element.
+   */
+  'messageView.body': ['div.ii.gt', '.adP'],
 } as const satisfies Record<string, readonly string[]>;
 
 export type SelectorKey = keyof typeof GMAIL_SELECTORS;

--- a/src/platform-implementation-js/dom-driver/gmail/selectors.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/selectors.ts
@@ -73,6 +73,13 @@ export const GMAIL_SELECTORS = {
   'messageView.moreButton': [
     'tr.acZ div.T-I.J-J5-Ji.aap.L3[role=button][aria-haspopup]',
   ],
+
+  /**
+   * The sender's span in a message header; carries the `email` and `name`
+   * attributes the contact is built from.
+   * Root: message element.
+   */
+  'messageView.senderSpan': ['td.gF span[email]'],
 } as const satisfies Record<string, readonly string[]>;
 
 export type SelectorKey = keyof typeof GMAIL_SELECTORS;

--- a/src/platform-implementation-js/dom-driver/gmail/selectors.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/selectors.ts
@@ -37,6 +37,13 @@ export const GMAIL_SELECTORS = {
    * Root: message element.
    */
   'messageView.body': ['div.ii.gt', '.adP'],
+
+  /**
+   * Message body carrying the legacy `m<hex>` id class. Narrower than
+   * `messageView.body` on purpose — the `.adP` rung does not carry that class.
+   * Root: message element.
+   */
+  'messageView.legacyIdBody': ['div.ii.gt'],
 } as const satisfies Record<string, readonly string[]>;
 
 export type SelectorKey = keyof typeof GMAIL_SELECTORS;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -225,7 +225,10 @@ class GmailMessageView {
   getSender(): Contact {
     let sender = this.#sender;
     if (sender) return sender;
-    const senderSpan = querySelector(this.#element, 'td.gF span[email]');
+    const senderSpan = this.#driver.selectors.querySelectorByKeyOrFail(
+      this.#element,
+      'messageView.senderSpan',
+    );
     const emailAddress = senderSpan.getAttribute('email');
     if (!emailAddress) throw new Error('Could not find email address');
     sender = this.#sender = {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -296,7 +296,10 @@ class GmailMessageView {
   }
 
   getDateString(): string {
-    return querySelector(this.#element, '.ads .gK .g3').title;
+    return this.#driver.selectors.querySelectorByKeyOrFail(
+      this.#element,
+      'messageView.dateElement',
+    ).title;
   }
 
   async getDate(): Promise<number | null | undefined> {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -369,8 +369,9 @@ class GmailMessageView {
       return null;
     }
 
-    return this.#element.querySelector<HTMLElement>(
-      'tr.acZ div.T-I.J-J5-Ji.aap.L3[role=button][aria-haspopup]',
+    return this.#driver.selectors.querySelectorByKey(
+      this.#element,
+      'messageView.moreButton',
     );
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -375,21 +375,11 @@ class GmailMessageView {
   }
 
   #getOpenMoreMenu(): HTMLElement | null | undefined {
-    const selector_2022_11_23 =
-      'td > div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]';
-    const selector_2023_11_16 =
-      'div.nH.a98.iY > div.nH .aHU .b7.J-M[aria-haspopup=true]';
-
-    const maybeMoreMenu =
-      document.body.querySelector<HTMLElement>(selector_2023_11_16) ||
-      document.body.querySelector<HTMLElement>(selector_2022_11_23);
     // This will find any message's open more menu! The caller needs to make
     // sure it belongs to this message!
-    return (
-      maybeMoreMenu ||
-      document.body.querySelector<HTMLElement>(
-        'td > div.nH.if > div.nH.aHU div.b7.J-M[aria-haspopup=true]',
-      )
+    return this.#driver.selectors.querySelectorByKey(
+      document.body,
+      'messageView.openMoreMenu',
     );
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -207,12 +207,14 @@ class GmailMessageView {
     }
 
     try {
-      return querySelector(this.#element, 'div.ii.gt');
+      return this.#driver.selectors.querySelectorByKeyOrFail(
+        this.#element,
+        'messageView.body',
+      );
     } catch (err) {
-      // Keep old fallback selector until we're confident of the new one.
+      // The registry does not report its own misses yet, so keep logging here.
       this.#driver.getLogger().error(err);
-
-      return querySelector(this.#element, '.adP');
+      throw err;
     }
   }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -491,7 +491,10 @@ class GmailMessageView {
       return messageId;
     }
 
-    const messageEl = this.#element.querySelector<HTMLElement>('div.ii.gt');
+    const messageEl = this.#driver.selectors.querySelectorByKey(
+      this.#element,
+      'messageView.legacyIdBody',
+    );
 
     if (!messageEl) {
       const err = new Error('Could not find message id element');

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
@@ -550,7 +550,10 @@ class GmailThreadView {
   getThreadID(): string {
     if (this.#threadID) return this.#threadID;
 
-    const idElement = this.#element.querySelector('[data-legacy-thread-id]');
+    const idElement = this.#driver.selectors.querySelectorByKey(
+      this.#element,
+      'threadView.idElement',
+    );
     if (!idElement) throw new Error('threadID element not found');
 
     // the string value can be 'undefined'
@@ -605,7 +608,10 @@ class GmailThreadView {
   async getThreadIDAsync(): Promise<string> {
     if (this.#threadID) return this.#threadID;
 
-    const idElement = this.#element.querySelector('[data-legacy-thread-id]');
+    const idElement = this.#driver.selectors.querySelectorByKey(
+      this.#element,
+      'threadView.idElement',
+    );
     if (!idElement) throw new Error('threadID element not found');
 
     // the string value can be 'undefined'

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
@@ -517,7 +517,10 @@ class GmailThreadView {
   }
 
   getSubject(): string {
-    var subjectElement = this.#element.querySelector('.ha h2');
+    const subjectElement = this.#driver.selectors.querySelectorByKey(
+      this.#element,
+      'threadView.subject',
+    );
 
     if (!subjectElement) {
       return '';


### PR DESCRIPTION
Adds 8 selectors to the registry (one per commit). Most selectors are a drop-in replacement, but there are a few small changes in behaviour:

- `getContentsElement` used to log when the primary selector was missed. We still log if all the selectors are missed, just not when a single one does. I want to incorporate reporting misses at the selector level, but not yet.
- The error message reported by `querySelectorByKeyOrFail` has a new format (`selector1 || selector2 || ...`), instead of a single selector.

I recommend reviewing commit by commit to make it easier to check that there are no logic/selector changes, just swaps.