### PR TITLE
refactor(element-getter): make GmailElementGetter a driver-owned class

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
@@ -129,6 +129,7 @@ class GmailDriver {
   #envData: EnvData;
   /** Resolves selector keys against the bundled defaults plus any overrides. */
   readonly selectors: SelectorRegistry;
+  readonly elementGetter: GmailElementGetter;
   #customRouteIDs: Set<string> = new Set();
   #customListRouteIDs: Map<string, Function> = new Map();
   #customListSearchStringsToRouteIds: Map<string, string> = new Map();
@@ -190,6 +191,7 @@ class GmailDriver {
       overrides: opts.selectorOverrides,
       onInvalidSelector: opts.onInvalidSelector,
     });
+    this.elementGetter = new GmailElementGetter(this);
     this.#page = makePageParserTree(this, document);
     this.#stopper.onValue(() => this.#page.dump());
 
@@ -278,7 +280,7 @@ class GmailDriver {
         trackEvents(this);
         gmailLoadEvent(this);
         overrideGmailBackButton(this, this.#gmailRouteProcessor);
-        trackGmailStyles();
+        trackGmailStyles(this);
         syncMoleSpacerWithRightColumn(this);
         temporaryTrackDownloadUrlValidity(this);
         if (opts.suppressAddonTitle != null) {
@@ -726,7 +728,7 @@ class GmailDriver {
   setShowNativeNavMarker(isNative: boolean) {
     this.#navMarkerHiddenChanged.emit(null);
     const leftNavContainerElement =
-      GmailElementGetter.getLeftNavContainerElement();
+      this.elementGetter.getLeftNavContainerElement();
     if (leftNavContainerElement) {
       if (isNative) {
         leftNavContainerElement.classList.remove(
@@ -746,9 +748,9 @@ class GmailDriver {
   setShowNativeAddonSidebar(isNative: boolean) {
     this.#addonSidebarHiddenChanged.emit(null);
     const addonContainerElement =
-      GmailElementGetter.getAddonSidebarContainerElement();
+      this.elementGetter.getAddonSidebarContainerElement();
     const mainContentBodyContainerElement =
-      GmailElementGetter.getMainContentBodyContainerElement();
+      this.elementGetter.getMainContentBodyContainerElement();
 
     if (addonContainerElement && mainContentBodyContainerElement) {
       const parent = mainContentBodyContainerElement.parentElement;
@@ -962,16 +964,16 @@ class GmailDriver {
 
   waitForGlobalSidebarReady(): Kefir.Observable<void, unknown> {
     const condition = () =>
-      GmailElementGetter.getCompanionSidebarContentContainerElement() &&
-      (GmailElementGetter.getCompanionSidebarIconContainerElement() ||
-        GmailElementGetter.getAddonSidebarContainerElement());
+      this.elementGetter.getCompanionSidebarContentContainerElement() &&
+      (this.elementGetter.getCompanionSidebarIconContainerElement() ||
+        this.elementGetter.getAddonSidebarContainerElement());
     if (condition()) {
       return Kefir.constant(undefined);
     }
     return waitFor(condition)
       .map(() => undefined)
       .mapErrors((err) => {
-        const el = GmailElementGetter.getCompanionSidebarColumnElement();
+        const el = this.elementGetter.getCompanionSidebarColumnElement();
         this.#logger.error(err, {
           reason: 'waitForGlobalSidebarReady timed out',
           aUxHtml: el ? censorHTMLtree(el) : null,
@@ -984,7 +986,7 @@ class GmailDriver {
     let appSidebarView = this.#appSidebarView;
     if (!appSidebarView) {
       const companionSidebarContentContainerEl =
-        GmailElementGetter.getCompanionSidebarContentContainerElement();
+        this.elementGetter.getCompanionSidebarContentContainerElement();
       if (!companionSidebarContentContainerEl)
         throw new Error('did not find companionSidebarContentContainerEl');
       appSidebarView = this.#appSidebarView = new GmailAppSidebarView(

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-app-menu-item.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-app-menu-item.ts
@@ -1,14 +1,14 @@
 import { AppMenuItemDescriptor } from '../../../namespaces/app-menu';
 import { GmailAppMenuItemView } from '../views/gmail-app-menu-item-view';
 import GmailDriver from '../gmail-driver';
-import GmailElementGetter from '../gmail-element-getter';
 import Logger from '../../../lib/logger';
 
 export async function addAppMenuItem(
   driver: GmailDriver,
   menuItemDescriptor: AppMenuItemDescriptor,
 ) {
-  const appMenuInjectionContainer = await GmailElementGetter.getAppMenuAsync();
+  const appMenuInjectionContainer =
+    await driver.elementGetter.getAppMenuAsync();
 
   const gmailAppMenuItemView = new GmailAppMenuItemView(
     driver,

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-collapsible-panel.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-collapsible-panel.ts
@@ -1,7 +1,6 @@
 import once from 'lodash/once';
 
 import { AppMenuItemPanelDescriptor } from '../../../namespaces/app-menu';
-import GmailElementGetter from '../gmail-element-getter';
 import waitFor from '../../../lib/wait-for';
 import Logger from '../../../lib/logger';
 import { CollapsiblePanelView } from '../../../views/collapsible-panel-view';
@@ -12,7 +11,7 @@ export async function addCollapsiblePanel(
   panelDescriptor: AppMenuItemPanelDescriptor,
   insertIndex?: number,
 ) {
-  const injectionContainer = await waitForAppMenuParentReady();
+  const injectionContainer = await waitForAppMenuParentReady(driver);
 
   const collapsiblePanelView = new CollapsiblePanelView(
     driver,
@@ -21,7 +20,7 @@ export async function addCollapsiblePanel(
 
   if (!injectionContainer || !collapsiblePanelView.element) return;
 
-  const appMenu = await GmailElementGetter.getAppMenuAsync();
+  const appMenu = await driver.elementGetter.getAppMenuAsync();
 
   if (!appMenu) return;
 
@@ -47,11 +46,11 @@ export async function addCollapsiblePanel(
   return collapsiblePanelView;
 }
 
-const waitForAppMenuParentReady = once(async () => {
-  if (!GmailElementGetter.isStandalone()) {
+const waitForAppMenuParentReady = once(async (driver: GmailDriver) => {
+  if (!driver.elementGetter.isStandalone()) {
     try {
       const menuParentElement = await waitFor(() =>
-        GmailElementGetter.getAppMenuContainer(),
+        driver.elementGetter.getAppMenuContainer(),
       );
 
       return menuParentElement;

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-nav-item.ts
@@ -1,5 +1,4 @@
 import * as Kefir from 'kefir';
-import GmailElementGetter from '../gmail-element-getter';
 import GmailNavItemView, {
   type NavItemDescriptor,
 } from '../views/gmail-nav-item-view';
@@ -17,11 +16,16 @@ import {
 } from './nav-item-section';
 
 function attachGmailNavItemView(
+  driver: GmailDriver,
   gmailNavItemView: GmailNavItemView,
   injectionContainer?: HTMLElement,
 ) {
   try {
-    const attacher = _attachNavItemView(gmailNavItemView, injectionContainer);
+    const attacher = _attachNavItemView(
+      driver,
+      gmailNavItemView,
+      injectionContainer,
+    );
 
     attacher();
 
@@ -40,13 +44,13 @@ export default async function addNavItem(
   navItemDescriptor: Kefir.Observable<NavItemDescriptor, unknown>,
   navMenuInjectionContainer?: HTMLElement,
 ): Promise<GmailNavItemView> {
-  await waitForMenuReady();
+  await waitForMenuReady(driver);
 
   const gmailNavItemView = new GmailNavItemView(driver, orderGroup, 1);
   gmailNavItemView.setNavItemDescriptor(navItemDescriptor);
 
-  if (!GmailElementGetter.isStandalone()) {
-    attachGmailNavItemView(gmailNavItemView, navMenuInjectionContainer);
+  if (!driver.elementGetter.isStandalone()) {
+    attachGmailNavItemView(driver, gmailNavItemView, navMenuInjectionContainer);
   }
 
   return gmailNavItemView;
@@ -58,37 +62,39 @@ export async function addNavItemToPanel(
   navItemDescriptor: Kefir.Observable<NavItemDescriptor, unknown>,
   panelElement: HTMLElement,
 ): Promise<GmailNavItemView> {
-  await waitForMenuReady();
+  await waitForMenuReady(driver);
 
   const gmailNavItemView = new GmailNavItemView(driver, orderGroup, 1);
   gmailNavItemView.setNavItemDescriptor(navItemDescriptor);
 
-  if (!GmailElementGetter.isStandalone()) {
+  if (!driver.elementGetter.isStandalone()) {
     if (gmailNavItemView.isSection()) {
       const container = getPanelSectionNavItemContainerElement(panelElement);
-      attachGmailNavItemView(gmailNavItemView, container);
+      attachGmailNavItemView(driver, gmailNavItemView, container);
     } else {
       const container = getPanelNavItemContainerElement(
         panelElement,
         gmailNavItemView.sectionKey,
       );
-      attachGmailNavItemView(gmailNavItemView, container);
+      attachGmailNavItemView(driver, gmailNavItemView, container);
     }
   }
 
   return gmailNavItemView;
 }
 
-export const waitForMenuReady = once(async (): Promise<void> => {
-  const appMenu = await GmailElementGetter.getAppMenuAsync();
-  if (!appMenu) {
-    await waitForNavMenuReady();
-  }
-});
+export const waitForMenuReady = once(
+  async (driver: GmailDriver): Promise<void> => {
+    const appMenu = await driver.elementGetter.getAppMenuAsync();
+    if (!appMenu) {
+      await waitForNavMenuReady(driver);
+    }
+  },
+);
 
-const waitForNavMenuReady = once(async (): Promise<void> => {
-  if (!GmailElementGetter.isStandalone()) {
-    await GmailElementGetter.waitForGmailModeToSettle();
+const waitForNavMenuReady = once(async (driver: GmailDriver): Promise<void> => {
+  if (!driver.elementGetter.isStandalone()) {
+    await driver.elementGetter.waitForGmailModeToSettle();
     await waitFor(() =>
       document.querySelector('.aeN[role=navigation], .aeN [role=navigation]'),
     );
@@ -98,6 +104,7 @@ const waitForNavMenuReady = once(async (): Promise<void> => {
 });
 
 function _attachNavItemView(
+  driver: GmailDriver,
   gmailNavItemView: GmailNavItemView,
   navMenuInjectionContainer?: HTMLElement,
 ) {
@@ -110,13 +117,13 @@ function _attachNavItemView(
     };
   }
 
-  if (!GmailElementGetter.shouldAddNavItemsInline()) {
+  if (!driver.elementGetter.shouldAddNavItemsInline()) {
     // If we're in the modern (non-classic-hangouts) leftnav, then put
     // the added nav items in a floating section at the bottom separate
     // from the Mail section.
     return function () {
       const navMenuInjectionContainer =
-        GmailElementGetter.getSeparateSectionNavItemMenuInjectionContainer();
+        driver.elementGetter.getSeparateSectionNavItemMenuInjectionContainer();
       if (!navMenuInjectionContainer) {
         throw new Error('should not happen');
       }
@@ -139,27 +146,30 @@ function _attachNavItemView(
     // If we're in the old classic-hangouts-compatible leftnav, then
     // inject our added nav items among Gmail's own nav items.
     return function () {
-      insertElementInOrder(_getNavItemsHolder(), gmailNavItemView.getElement());
+      insertElementInOrder(
+        _getNavItemsHolder(driver),
+        gmailNavItemView.getElement(),
+      );
     };
   }
 }
 
-function _getNavItemsHolder(): HTMLElement {
+function _getNavItemsHolder(driver: GmailDriver): HTMLElement {
   const holder = document.querySelector('.inboxsdk__navMenu');
   if (!holder) {
-    return _createNavItemsHolder();
+    return _createNavItemsHolder(driver);
   } else {
     return querySelector(holder, '.TK');
   }
 }
 
-function _createNavItemsHolder(): HTMLElement {
+function _createNavItemsHolder(driver: GmailDriver): HTMLElement {
   const holder = document.createElement('div');
   holder.setAttribute('class', 'LrBjie inboxsdk__navMenu');
   holder.innerHTML = '<div class="TK"></div>';
 
   const navMenuInjectionContainer =
-    GmailElementGetter.getSameSectionNavItemMenuInjectionContainer();
+    driver.elementGetter.getSameSectionNavItemMenuInjectionContainer();
   if (!navMenuInjectionContainer) throw new Error('should not happen');
   navMenuInjectionContainer.insertBefore(
     holder,

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-toolbar-button-for-app.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/add-toolbar-button-for-app.ts
@@ -1,5 +1,4 @@
 import type * as Kefir from 'kefir';
-import GmailElementGetter from '../gmail-element-getter';
 import GmailAppToolbarButtonView from '../views/gmail-app-toolbar-button-view';
 import type GmailDriver from '../gmail-driver';
 import { AppToolbarButtonDescriptor } from '../../../../inboxsdk';
@@ -8,8 +7,8 @@ export default function addToolbarButtonForApp(
   gmailDriver: GmailDriver,
   buttonDescriptor: Kefir.Observable<AppToolbarButtonDescriptor, any>,
 ): Promise<GmailAppToolbarButtonView> {
-  return GmailElementGetter.waitForGmailModeToSettle().then(() => {
-    if (GmailElementGetter.isStandalone()) {
+  return gmailDriver.elementGetter.waitForGmailModeToSettle().then(() => {
+    if (gmailDriver.elementGetter.isStandalone()) {
       return new Promise((_resolve, _reject) => {
         //never complete
       });

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/get-native-nav-item.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/get-native-nav-item.ts
@@ -1,5 +1,4 @@
 import NativeGmailNavItemView from '../views/native-gmail-nav-item-view';
-import GmailElementGetter from '../gmail-element-getter';
 import findParent from '../../../../common/find-parent';
 import waitFor from '../../../lib/wait-for';
 
@@ -10,7 +9,7 @@ export default function getNativeNavItem(
   label: string,
 ): Promise<NativeGmailNavItemView> {
   return waitFor(() => {
-    const navContainer = GmailElementGetter.getLeftNavContainerElement();
+    const navContainer = driver.elementGetter.getLeftNavContainerElement();
     if (!navContainer) return null;
     return navContainer.querySelector<HTMLElement>(`.aim a[href*="#${label}"]`);
   }, 300 * 1000)
@@ -31,7 +30,7 @@ export default function getNativeNavItem(
       return (labelElement as any).__nativeGmailNavItemView;
     })
     .catch((err) => {
-      if (GmailElementGetter.isStandalone()) {
+      if (driver.elementGetter.isStandalone()) {
         // never resolve
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         return new Promise((_resolve, _reject) => {});

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/gmail-load-event.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/gmail-load-event.ts
@@ -35,7 +35,7 @@ export default async function gmailLoadEvent(driver: GmailDriver) {
 
   const isConversationViewDisabled =
     await pageCommunicator.isConversationViewDisabled();
-  await waitForMenuReady();
+  await waitForMenuReady(driver);
   const isUsingDarkTheme = await checkForDarkThemeSafe();
   const sidePanelCollapsed = await isSidePanelCollapsed();
 

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/open-compose-window.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/open-compose-window.ts
@@ -1,25 +1,24 @@
 import { simulateClick } from '../../../lib/dom/simulate-mouse-event';
-import GmailElementGetter from '../gmail-element-getter';
 
 import waitFor from '../../../lib/wait-for';
 
 import type GmailDriver from '../gmail-driver';
 
-export default async function openComposeWindow(_gmailDriver: GmailDriver) {
-  await GmailElementGetter.waitForGmailModeToSettle();
+export default async function openComposeWindow(gmailDriver: GmailDriver) {
+  await gmailDriver.elementGetter.waitForGmailModeToSettle();
 
   if (
-    GmailElementGetter.isStandaloneComposeWindow() ||
-    GmailElementGetter.isStandaloneThreadWindow()
+    gmailDriver.elementGetter.isStandaloneComposeWindow() ||
+    gmailDriver.elementGetter.isStandaloneThreadWindow()
   ) {
     throw new Error('Can not open new compose while in standalone window');
   }
 
-  if (!GmailElementGetter.getComposeButton()) {
-    await waitFor(() => !!GmailElementGetter.getComposeButton());
+  if (!gmailDriver.elementGetter.getComposeButton()) {
+    await waitFor(() => !!gmailDriver.elementGetter.getComposeButton());
   }
 
-  const composeButton = GmailElementGetter.getComposeButton();
+  const composeButton = gmailDriver.elementGetter.getComposeButton();
   if (!composeButton) throw new Error('Could not find compose button');
   simulateClick(composeButton);
 }

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/override-gmail-back-button.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/override-gmail-back-button.ts
@@ -1,5 +1,4 @@
 import { defn } from 'ud';
-import GmailElementGetter from '../gmail-element-getter';
 import onMouseDownAndUp from '../../../lib/dom/on-mouse-down-and-up';
 import type GmailDriver from '../gmail-driver';
 import type GmailRouteView from '../views/gmail-route-view/gmail-route-view';
@@ -9,8 +8,8 @@ export default function overrideGmailBackButton(
   gmailDriver: GmailDriver,
   gmailRouteProcessor: GmailRouteProcessor,
 ) {
-  GmailElementGetter.waitForGmailModeToSettle().then(function () {
-    if (GmailElementGetter.isStandalone()) {
+  gmailDriver.elementGetter.waitForGmailModeToSettle().then(function () {
+    if (gmailDriver.elementGetter.isStandalone()) {
       return;
     }
     _setupManagement(gmailDriver, gmailRouteProcessor);
@@ -77,7 +76,7 @@ function _bindToBackButton(
   gmailDriver: GmailDriver,
   gmailRouteView: GmailRouteView,
 ) {
-  const backButton = GmailElementGetter.getThreadBackButton();
+  const backButton = gmailDriver.elementGetter.getThreadBackButton();
 
   if (!backButton) {
     return;

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/register-search-suggestions-provider.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/register-search-suggestions-provider.ts
@@ -4,7 +4,6 @@ import * as Kefir from 'kefir';
 import fromEventTargetCapture from '../../../lib/from-event-target-capture';
 import makeElementChildStream from '../../../lib/dom/make-element-child-stream';
 import makeMutationObserverChunkedStream from '../../../lib/dom/make-mutation-observer-chunked-stream';
-import gmailElementGetter from '../gmail-element-getter';
 import copyAndValidateAutocompleteResults from '../../../lib/copyAndValidateAutocompleteResults';
 
 import type GmailDriver from '../gmail-driver';
@@ -75,7 +74,7 @@ export default function registerSearchSuggestionsProvider(
   const searchBoxStream: Kefir.Observable<HTMLInputElement, unknown> = driver
     .getRouteViewDriverStream()
     .toProperty(() => null)
-    .map(() => gmailElementGetter.getSearchInput())
+    .map(() => driver.elementGetter.getSearchInput())
     .filter(isNotNil)
     .take(1);
 
@@ -83,7 +82,7 @@ export default function registerSearchSuggestionsProvider(
   const suggestionsBoxTbodyStream: Kefir.Observable<HTMLElement, unknown> =
     searchBoxStream
       .flatMapLatest((searchBox) => Kefir.fromEvents(searchBox, 'focus'))
-      .map(() => gmailElementGetter.getSearchSuggestionsBoxParent())
+      .map(() => driver.elementGetter.getSearchSuggestionsBoxParent())
       .filter(isNotNil)
       .flatMapLatest(makeElementChildStream)
       .map((x) => x.el.firstElementChild as HTMLElement)

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/setup-compose-view-driver-stream.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/setup-compose-view-driver-stream.ts
@@ -7,7 +7,6 @@ import makeElementChildStream, {
 } from '../../../lib/dom/make-element-child-stream';
 import elementViewMapper from '../../../lib/dom/element-view-mapper';
 import makeElementStreamMerger from '../../../lib/dom/make-element-stream-merger';
-import GmailElementGetter from '../gmail-element-getter';
 import GmailComposeView from '../views/gmail-compose-view';
 import type GmailMessageView from '../views/gmail-message-view';
 import type GmailDriver from '../gmail-driver';
@@ -30,18 +29,18 @@ function imp(
   messageViewDriverStream: Kefir.Observable<GmailMessageView, unknown>,
   xhrInterceptorStream: Kefir.Observable<any, unknown>,
 ): Kefir.Observable<GmailComposeView, unknown> {
-  return Kefir.fromPromise(GmailElementGetter.waitForGmailModeToSettle())
+  return Kefir.fromPromise(gmailDriver.elementGetter.waitForGmailModeToSettle())
     .flatMap(() => {
       let elementStream: Kefir.Observable<ElementWithLifetime, never>;
       let isStandalone = false;
 
-      if (GmailElementGetter.isStandaloneComposeWindow()) {
-        elementStream = _setupStandaloneComposeElementStream();
+      if (gmailDriver.elementGetter.isStandaloneComposeWindow()) {
+        elementStream = _setupStandaloneComposeElementStream(gmailDriver);
         isStandalone = true;
-      } else if (GmailElementGetter.isStandaloneThreadWindow()) {
+      } else if (gmailDriver.elementGetter.isStandaloneThreadWindow()) {
         elementStream = Kefir.never();
       } else {
-        elementStream = _setupStandardComposeElementStream();
+        elementStream = _setupStandardComposeElementStream(gmailDriver);
       }
 
       return elementStream.map(
@@ -70,9 +69,9 @@ function imp(
     .flatMap((composeViewDriver) => composeViewDriver.ready());
 }
 
-function _setupStandardComposeElementStream() {
+function _setupStandardComposeElementStream(gmailDriver: GmailDriver) {
   return _waitForContainerAndMonitorChildrenStream(() =>
-    GmailElementGetter.getComposeWindowContainer(),
+    gmailDriver.elementGetter.getComposeWindowContainer(),
   )
     .flatMap((composeGrandParent) => {
       const composeParentEl =
@@ -86,7 +85,8 @@ function _setupStandardComposeElementStream() {
       }
     })
     .merge(
-      GmailElementGetter.getFullscreenComposeWindowContainerStream()
+      gmailDriver.elementGetter
+        .getFullscreenComposeWindowContainerStream()
         .flatMap(({ el, removalStream }) =>
           makeElementChildStream(el).takeUntilBy(removalStream),
         )
@@ -125,12 +125,11 @@ function _setupStandardComposeElementStream() {
     .flatMap(makeElementStreamMerger());
 }
 
-function _setupStandaloneComposeElementStream(): Kefir.Observable<
-  ElementWithLifetime,
-  never
-> {
+function _setupStandaloneComposeElementStream(
+  gmailDriver: GmailDriver,
+): Kefir.Observable<ElementWithLifetime, never> {
   return _waitForContainerAndMonitorChildrenStream(() =>
-    GmailElementGetter.StandaloneCompose.getComposeWindowContainer(),
+    gmailDriver.elementGetter.getStandaloneComposeWindowContainer(),
   );
 }
 

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/setup-route-view-driver-stream.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/setup-route-view-driver-stream.test.ts
@@ -10,6 +10,7 @@ import delay from 'pdelay';
 import setupRouteViewDriverStream from './setup-route-view-driver-stream';
 
 import GmailRouteProcessor from '../views/gmail-route-view/gmail-route-processor';
+import GmailElementGetter from '../gmail-element-getter';
 import makeMutationEventInjector from '../../../../../test/lib/makeElementIntoEventEmitter';
 import MockMutationObserver from '../../../../../test/lib/mock-mutation-observer';
 
@@ -36,7 +37,7 @@ afterEach(() => {
 });
 
 function makeMockDriver(): any {
-  return {
+  const driver: any = {
     getStopper: _.constant(stopper),
     getCustomRouteIDs: _.constant(new Set()),
     getCustomListRouteIDs: _.constant(new Map()),
@@ -45,6 +46,8 @@ function makeMockDriver(): any {
     showNativeRouteView: jest.fn(),
     showCustomThreadList: jest.fn(),
   };
+  driver.elementGetter = new GmailElementGetter(driver);
+  return driver;
 }
 
 test('role=main changes are seen', async () => {

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/setup-route-view-driver-stream.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/setup-route-view-driver-stream.ts
@@ -3,7 +3,6 @@ import get from '../../../../common/get-or-fail';
 
 import type GmailDriver from '../gmail-driver';
 import type GmailRouteProcessor from '../views/gmail-route-view/gmail-route-processor';
-import GmailElementGetter from '../gmail-element-getter';
 import GmailRouteView from '../views/gmail-route-view/gmail-route-view';
 import getURLObject from './get-url-object';
 
@@ -90,7 +89,8 @@ export default function setupRouteViewDriverStream(
     // getMainContentElementChangedStream doesn't respect custom views so filter
     // out events from it. This filter is needed if the user is already at a custom
     // view of another InboxSDK instance while this starts up.
-    GmailElementGetter.getMainContentElementChangedStream()
+    driver.elementGetter
+      .getMainContentElementChangedStream()
       .map((_event) => ({
         urlObject: getURLObject(document.location.href),
         type: 'NATIVE',
@@ -106,7 +106,7 @@ export default function setupRouteViewDriverStream(
           urlObject.params[0],
         );
         if (customListRouteId) {
-          const searchInput = GmailElementGetter.getSearchInput();
+          const searchInput = driver.elementGetter.getSearchInput();
           if (!searchInput) throw new Error('Should not happen');
           searchInput.value = '';
 

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-route-view.ts
@@ -1,13 +1,14 @@
 import { defn } from 'ud';
-import GmailElementGetter from '../gmail-element-getter';
+import type GmailDriver from '../gmail-driver';
 
 const ACTIVE_ADD_ON_ICON_SELECTOR = '.J-KU-KO';
 import { simulateClick } from '../../../lib/dom/simulate-mouse-event';
 
 const showCustomRouteView = defn(
   module,
-  function showCustomRouteView(gmailDriver: any, element: HTMLElement) {
-    const contentSectionElement = GmailElementGetter.getContentSectionElement();
+  function showCustomRouteView(gmailDriver: GmailDriver, element: HTMLElement) {
+    const contentSectionElement =
+      gmailDriver.elementGetter.getContentSectionElement();
     if (!contentSectionElement) {
       return;
     }
@@ -40,7 +41,7 @@ const showCustomRouteView = defn(
 
     //if any thread sidebar addons are enabled then we need to turn them off
     const companionSidebarIconContainerEl =
-      GmailElementGetter.getCompanionSidebarIconContainerElement();
+      gmailDriver.elementGetter.getCompanionSidebarIconContainerElement();
     if (companionSidebarIconContainerEl) {
       const activeThreadAddOnIcon =
         companionSidebarIconContainerEl.querySelector<HTMLElement>(

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.test.ts
@@ -1,4 +1,5 @@
 import showCustomThreadList from './show-custom-thread-list';
+import GmailElementGetter from '../gmail-element-getter';
 
 import * as GSRP from '../gmail-sync-response-processor';
 
@@ -76,6 +77,7 @@ class ShowCustomThreadListTester {
     start: number;
     getOriginalSearchResponse: () => Promise<string>;
   }) {
+    this._driver.elementGetter = new GmailElementGetter(this._driver);
     this._onActivate = options.onActivate;
 
     this._threadIdsToRfcIds = new Map(options.threadAndRfcIds);

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-custom-thread-list.ts
@@ -1,7 +1,6 @@
 import find from 'lodash/find';
 import uniqBy from 'lodash/uniqBy';
 import Kefir from 'kefir';
-import GmailElementGetter from '../gmail-element-getter';
 import * as SyncGRP from '../gmail-sync-response-processor';
 import type Logger from '../../../lib/logger';
 import type GmailDriver from '../gmail-driver';
@@ -477,10 +476,11 @@ export default function showCustomThreadList(
   );
   const customHash = document.location.hash;
 
-  const searchInput = GmailElementGetter.getSearchInput();
+  const searchInput = driver.elementGetter.getSearchInput();
   if (!searchInput) throw new Error('could not find search input');
 
-  const inputStream = GmailElementGetter.getMainContentElementChangedStream()
+  const inputStream = driver.elementGetter
+    .getMainContentElementChangedStream()
     .changes()
     .take(1)
     .map(() => searchInput)

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-native-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/show-native-route-view.ts
@@ -1,9 +1,9 @@
-import GmailElementGetter from '../gmail-element-getter';
 import fakeWindowResize from '../../../lib/fake-window-resize';
 import GmailDriver from '../gmail-driver';
 
-export default function showNativeRouteView(_gmailDriver: GmailDriver) {
-  const contentSectionElement = GmailElementGetter.getContentSectionElement();
+export default function showNativeRouteView(gmailDriver: GmailDriver) {
+  const contentSectionElement =
+    gmailDriver.elementGetter.getContentSectionElement();
   if (!contentSectionElement) {
     return;
   }

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/suppressAddon.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/suppressAddon.ts
@@ -2,10 +2,9 @@ import type GmailDriver from '../gmail-driver';
 import { simulateClick } from '../../../lib/dom/simulate-mouse-event';
 import makeElementChildStream from '../../../lib/dom/make-element-child-stream';
 import waitFor from '../../../lib/stream-wait-for';
-import GmailElementGetter from '../gmail-element-getter';
 
 export default function suppressAddon(driver: GmailDriver, addonTitle: string) {
-  waitFor(() => GmailElementGetter.getCompanionSidebarIconContainerElement())
+  waitFor(() => driver.elementGetter.getCompanionSidebarIconContainerElement())
     .map((iconContainerElement) => {
       // .J-KU-Jg is pre-2018-07-30 element?
       const elementToWatch = iconContainerElement.querySelector(

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/sync-mole-spacer-with-right-column.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/sync-mole-spacer-with-right-column.ts
@@ -1,8 +1,6 @@
 import waitFor from '../../../lib/wait-for';
 import fakeWindowResize from '../../../lib/fake-window-resize';
-import GmailElementGetter, {
-  MOLE_CONTAINER_SELECTOR,
-} from '../gmail-element-getter';
+import { MOLE_CONTAINER_SELECTOR } from '../gmail-element-getter';
 import type GmailDriver from '../gmail-driver';
 
 /**
@@ -42,7 +40,7 @@ export default function syncMoleSpacerWithRightColumn(driver: GmailDriver) {
   if (root.hasAttribute(INSTALLED_ATTR)) return;
   root.setAttribute(INSTALLED_ATTR, 'true');
 
-  waitFor(() => GmailElementGetter.getCompanionSidebarColumnElement())
+  waitFor(() => driver.elementGetter.getCompanionSidebarColumnElement())
     .then((rightColumn) => {
       let scheduled = false;
       // Coalesce bursts of mutations into a single read+write per frame so we
@@ -53,7 +51,7 @@ export default function syncMoleSpacerWithRightColumn(driver: GmailDriver) {
         requestAnimationFrame(() => {
           scheduled = false;
           try {
-            updateSpacer();
+            updateSpacer(driver);
           } catch (err) {
             driver.getLogger().error(err as Error);
           }
@@ -75,7 +73,7 @@ export default function syncMoleSpacerWithRightColumn(driver: GmailDriver) {
     });
 }
 
-function updateSpacer() {
+function updateSpacer(driver: GmailDriver) {
   // The mole container has two `.jAmAWb` flex spacers: the left one (index 0)
   // and the right one (last).
   const spacers = document.querySelectorAll<HTMLElement>(MOLE_SPACER_SELECTOR);
@@ -84,7 +82,8 @@ function updateSpacer() {
   // compose/thread view has been used. Until it exists there is nothing to size.
   if (!spacer) return;
 
-  const companion = GmailElementGetter.getCompanionSidebarOuterWrapperElement();
+  const companion =
+    driver.elementGetter.getCompanionSidebarOuterWrapperElement();
   // The wrapper stays in the DOM when collapsed (`display: none`); only count
   // it when a companion/SDK panel is actually showing.
   const companionWidth =

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/track-gmail-styles.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/track-gmail-styles.ts
@@ -1,7 +1,7 @@
 import kefirBus from 'kefir-bus';
 import Logger from '../../../lib/logger';
 import waitFor, { WaitForError } from '../../../lib/wait-for';
-import GmailElementGetter from '../gmail-element-getter';
+import type GmailDriver from '../gmail-driver';
 
 /** should handle rgb and rgba */
 const RGB_REGEX = /^rgba?\s*\(\s*(\d+),\s*(\d+),\s*(\d+)\s*(,\s*(0\.)?\d+)?\)/;
@@ -101,10 +101,10 @@ const enum ClassName {
   darkBodyTheme = 'inboxsdk__gmail_dark_body_theme',
 }
 
-export default async function trackGmailStyles() {
+export default async function trackGmailStyles(driver: GmailDriver) {
   if (
     document.head.hasAttribute('data-inboxsdk-gmail-style-tracker') ||
-    GmailElementGetter.isStandalone()
+    driver.elementGetter.isStandalone()
   ) {
     return;
   }

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter.ts
@@ -1,4 +1,3 @@
-import once from 'lodash/once';
 import * as Kefir from 'kefir';
 import makeElementChildStream, {
   ElementWithLifetime,
@@ -10,6 +9,7 @@ import getMainContentElementChangedStream from './gmail-element-getter/get-main-
 import isIntegratedViewGmail from './gmail-driver/isIntegratedViewGmail';
 import Logger from '../../lib/logger';
 import waitFor from '../../lib/wait-for';
+import type GmailDriver from './gmail-driver';
 
 /**
  * The selector for the new app menu https://support.google.com/mail/answer/11555490 -- FEB 2023
@@ -46,7 +46,22 @@ export const MOLE_CONTAINER_SELECTOR = 'div.dw';
 export const MOLE_PARENT_SELECTOR = `${MOLE_CONTAINER_SELECTOR} .nH > .nH > .no`;
 
 // TODO Figure out if these functions can and should be able to return null
-const GmailElementGetter = {
+/**
+ * Reads Gmail's page-level chrome. Owned by {@link GmailDriver} as
+ * `driver.elementGetter`, so its lookups can move onto the driver's selector
+ * registry.
+ */
+export default class GmailElementGetter {
+  /** Held for the selector registry migration; see the class docs. */
+  readonly #driver: GmailDriver;
+
+  #appMenuAsync?: Promise<HTMLElement | undefined>;
+  #mainContentElementChangedStream?: Kefir.Observable<HTMLElement, never>;
+
+  constructor(driver: GmailDriver) {
+    this.#driver = driver;
+  }
+
   getActiveMoreMenu(): HTMLElement | null {
     const elements = document.querySelectorAll<HTMLElement>(
       '.J-M.aX0.aYO.jQjAxd',
@@ -59,25 +74,25 @@ const GmailElementGetter = {
     }
 
     return null;
-  },
+  }
 
   getAddonSidebarContainerElement(): HTMLElement | null {
     // only for Gmailv1 + Gmailv2-before-2018-07-30?
     return document.querySelector('.no > .nn.bnl');
-  },
+  }
 
   getCompanionSidebarColumnElement(): HTMLElement | null {
     return document.querySelector(COMPANION_SIDEBAR_COLUMN);
-  },
+  }
 
   getCompanionSidebarContentContainerElement(): HTMLElement | null {
     return document.querySelector('.brC-brG');
-  },
+  }
 
   // <div class="brC-aT5-aOt-Jw" role="complementary" aria-label="Side panel">
   getCompanionSidebarIconContainerElement(): HTMLElement | null {
     return document.querySelector('.brC-aT5-aOt-Jw');
-  },
+  }
 
   /**
    * The wrapper Google's own companions (Calendar, Keep, Tasks, Contacts) and
@@ -91,8 +106,7 @@ const GmailElementGetter = {
     contentContainerEl?: HTMLElement | null,
   ): HTMLElement | null {
     const companionSidebarContentContainerEl =
-      contentContainerEl ??
-      GmailElementGetter.getCompanionSidebarContentContainerElement();
+      contentContainerEl ?? this.getCompanionSidebarContentContainerElement();
     if (!companionSidebarContentContainerEl) return null;
     // TODO: Once the changes to the GMail DOM have been entirely ramped, drop
     // the ternary here and always get the parentElement. (Jun 20, 2018)
@@ -101,18 +115,18 @@ const GmailElementGetter = {
     )
       ? companionSidebarContentContainerEl
       : companionSidebarContentContainerEl.parentElement;
-  },
+  }
 
   getComposeButton(): HTMLElement | null {
     if (isIntegratedViewGmail()) {
       return document.querySelector('.aIH .aic div[role=button].L3');
     }
     return document.querySelector('[gh=cm]');
-  },
+  }
 
   getComposeWindowContainer(): HTMLElement | null {
     return document.querySelector(MOLE_PARENT_SELECTOR);
-  },
+  }
 
   getContentSectionElement(): HTMLElement | undefined | null {
     // New method for finding the content section element that also supports
@@ -125,7 +139,7 @@ const GmailElementGetter = {
     if (isIntegratedViewGmail()) {
       return el;
     } else {
-      const leftNavContainer = GmailElementGetter.getLeftNavContainerElement();
+      const leftNavContainer = this.getLeftNavContainerElement();
       const oldMethodEl = leftNavContainer
         ? (leftNavContainer.nextElementSibling!.children[0] as HTMLElement)
         : null;
@@ -142,11 +156,11 @@ const GmailElementGetter = {
       }
       return oldMethodEl;
     }
-  },
+  }
 
   getFullscreenComposeWindowContainer(): HTMLElement | null {
     return document.querySelector('.aSs .aSt');
-  },
+  }
 
   getFullscreenComposeWindowContainerStream(): Kefir.Observable<
     ElementWithLifetime,
@@ -165,11 +179,11 @@ const GmailElementGetter = {
         .map(({ el }) => ({ el, removalStream: Kefir.never() }))
         .toProperty()
     );
-  },
+  }
 
   getGtalkButtons(): HTMLElement | null {
     return document.querySelector('.aeN .aj5.J-KU-Jg');
-  },
+  }
 
   getLeftNavContainerElement(): HTMLElement | null {
     if (this.getAppMenu()) {
@@ -179,28 +193,27 @@ const GmailElementGetter = {
       return document.querySelector('div[role=navigation] + div.aqn');
     }
     return document.querySelector('.aeN');
-  },
+  }
 
   getLeftNavHeightElement(): HTMLElement | null {
     return document.querySelector('.aeN');
-  },
+  }
 
   getMainContentBodyContainerElement(): HTMLElement | null {
     return document.querySelector('.no > .nn.bkK');
-  },
+  }
 
   getMainContentContainer(): HTMLElement | null {
     // This method used to just look for the div[role=main] element and then
     // return its parent, but it turns out the Contacts page does not set
     // role=main.
     return document.querySelector('div.aeF > div.nH');
-  },
+  }
 
-  getMainContentElementChangedStream: once(function (
-    this: any,
-  ): Kefir.Observable<HTMLElement, never> {
-    return getMainContentElementChangedStream(this);
-  }),
+  getMainContentElementChangedStream(): Kefir.Observable<HTMLElement, never> {
+    return (this.#mainContentElementChangedStream ??=
+      getMainContentElementChangedStream(this));
+  }
 
   /**
    * This method checks whether we should use the old InboxSDK style of adding nav items
@@ -232,11 +245,15 @@ const GmailElementGetter = {
     } else {
       return false;
     }
-  },
+  }
 
-  getAppMenuAsync: once(async () => {
-    if (!GmailElementGetter.isStandalone()) {
-      await GmailElementGetter.waitForGmailModeToSettle();
+  getAppMenuAsync(): Promise<HTMLElement | undefined> {
+    return (this.#appMenuAsync ??= this.#findAppMenuAsync());
+  }
+
+  async #findAppMenuAsync(): Promise<HTMLElement | undefined> {
+    if (!this.isStandalone()) {
+      await this.waitForGmailModeToSettle();
 
       try {
         const element = await waitFor(() =>
@@ -252,33 +269,33 @@ const GmailElementGetter = {
         Logger.error(e);
       }
     }
-  }),
+  }
 
   getAppBurgerMenu() {
     return document.querySelector<HTMLElement>(
       'header[role="banner"] > div > div > div[aria-expanded]',
     );
-  },
+  }
 
   isAppBurgerMenuOpen() {
     return this.getAppBurgerMenu()?.getAttribute('aria-expanded') === 'true';
-  },
+  }
 
   getAppMenuContainer() {
     return document.querySelector<HTMLElement>('.aqk.aql.bkL');
-  },
+  }
 
   getAppMenu() {
     return document.querySelector<HTMLElement>(APP_MENU);
-  },
+  }
 
   getAppHeader() {
     return document.querySelector<HTMLElement>('.oy8Mbf.qp');
-  },
+  }
 
   getSeparateSectionNavItemMenuInjectionContainer(): HTMLElement | null {
     return document.querySelector('.aeN');
-  },
+  }
 
   getSameSectionNavItemMenuInjectionContainer(): HTMLElement | null {
     if (isIntegratedViewGmail()) {
@@ -286,13 +303,13 @@ const GmailElementGetter = {
     } else {
       return document.querySelector('.aeN .n3');
     }
-  },
+  }
 
   getRowListElementsContainer(): HTMLElement | null {
     // This selector can find multiple elements but they should all be siblings
     // so it's fine because we get the common parent.
     return document.querySelector('.bGI.nH')?.parentElement ?? null;
-  },
+  }
 
   getRowListElements(): HTMLElement[] | null {
     const rowListElements = document.querySelectorAll<HTMLElement>('[gh=tl]');
@@ -300,36 +317,36 @@ const GmailElementGetter = {
       return null;
     }
     return Array.from(rowListElements);
-  },
+  }
 
   getScrollContainer(): HTMLElement | null {
     return document.querySelector('div.Tm.aeJ');
-  },
+  }
 
   getSearchInput(): HTMLInputElement | null {
     return document.querySelector(
       'form[role=search] input',
     ) as HTMLInputElement | null;
-  },
+  }
 
   getSearchSuggestionsBoxParent(): HTMLElement | null {
     return document.querySelector('table.gstl_50 > tbody > tr > td.gssb_e');
-  },
+  }
 
   getSidebarContainerElement(): HTMLElement | null {
     return document.querySelector('[role=main] table.Bs > tr .y3');
-  },
+  }
 
   getThreadBackButton(): HTMLElement | null {
     let toolbarElement;
     try {
-      toolbarElement = GmailElementGetter.getToolbarElement();
+      toolbarElement = this.getToolbarElement();
     } catch (err) {
       return null;
     }
 
     return toolbarElement.querySelector('.lS');
-  },
+  }
 
   getThreadContainerElement(): HTMLElement | null {
     const selector = '[role=main] .g.id table.Bs > tr';
@@ -343,27 +360,27 @@ const GmailElementGetter = {
     }
 
     return document.querySelector(selector_2023_11_16);
-  },
+  }
 
   getPreviewPaneContainerElement(): HTMLElement | null {
     // This element is always present in thread lists, but it only has contents
     // when in preview pane mode. We want to monitor it in either case
     // because the user could switch into preview pane mode.
     return document.querySelector<HTMLElement>('div[role=main] .aia');
-  },
+  }
 
   getToolbarElement(): HTMLElement {
     return querySelector(document, '[gh=tm]');
-  },
+  }
 
   getTopAccountContainer(): HTMLElement | null {
     return document.querySelector(
       'header[role="banner"] > div:nth-child(2) > div:nth-child(2)',
     );
-  },
+  }
 
   isGplusEnabled(): boolean {
-    const topAccountContainer = GmailElementGetter.getTopAccountContainer();
+    const topAccountContainer = this.getTopAccountContainer();
     if (!topAccountContainer) {
       return false;
     }
@@ -373,27 +390,27 @@ const GmailElementGetter = {
         'a[href*="https://plus"][href*="upgrade"]',
       ).length === 0
     );
-  },
+  }
 
   /** @deprecated this doesn't include Gmail themes where the frame is dark and the body is not. Use Global.gmailTheme instead */
   isDarkTheme(): boolean {
     return document.body.classList.contains('inboxsdk__gmail_dark_theme');
-  },
+  }
 
   isPreviewPane(): boolean {
     return !!document.querySelector('.aia');
-  },
+  }
 
   isStandalone(): boolean {
     return this.isStandaloneComposeWindow() || this.isStandaloneThreadWindow();
-  },
+  }
 
   isStandaloneComposeWindow(): boolean {
     return (
       document.body.classList.contains('xE') &&
       document.body.classList.contains('xp')
     );
-  },
+  }
 
   isStandaloneThreadWindow(): boolean {
     return (
@@ -401,17 +418,14 @@ const GmailElementGetter = {
       document.body.classList.contains('xE') &&
       document.body.classList.contains('Su')
     );
-  },
+  }
 
-  StandaloneCompose: {
-    getComposeWindowContainer(): HTMLElement | null {
-      return document.querySelector('[role=main]');
-    },
-  },
+  /** Was `StandaloneCompose.getComposeWindowContainer` before this became a class. */
+  getStandaloneComposeWindowContainer(): HTMLElement | null {
+    return document.querySelector('[role=main]');
+  }
 
   waitForGmailModeToSettle(): Promise<void> {
     return waitForGmailModeToSettle().toPromise();
-  },
-};
-
-export default GmailElementGetter;
+  }
+}

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter/get-main-content-element-changed-stream.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-element-getter/get-main-content-element-changed-stream.ts
@@ -5,12 +5,12 @@ import streamWaitFor from '../../../lib/stream-wait-for';
 import makeMutationObserverChunkedStream from '../../../lib/dom/make-mutation-observer-chunked-stream';
 import makeElementChildStream from '../../../lib/dom/make-element-child-stream';
 
-import _GmailElementGetter from '../gmail-element-getter';
+import type GmailElementGetter from '../gmail-element-getter';
 
 export default function getMainContentElementChangedStream(
-  GmailElementGetter: typeof _GmailElementGetter,
+  elementGetter: GmailElementGetter,
 ): Kefir.Observable<HTMLElement, never> {
-  const s = waitForMainContentContainer(GmailElementGetter)
+  const s = waitForMainContentContainer(elementGetter)
     .flatMap((mainContentContainer) =>
       makeElementChildStream(mainContentContainer)
         .filter(({ el }) => el.classList.contains('nH'))
@@ -39,13 +39,11 @@ export default function getMainContentElementChangedStream(
   return s as Kefir.Observable<HTMLElement, never>;
 }
 
-function waitForMainContentContainer(
-  GmailElementGetter: typeof _GmailElementGetter,
-) {
-  if (GmailElementGetter.isStandaloneComposeWindow()) {
+function waitForMainContentContainer(elementGetter: GmailElementGetter) {
+  if (elementGetter.isStandaloneComposeWindow()) {
     return Kefir.never();
   }
-  return streamWaitFor(() => GmailElementGetter.getMainContentContainer());
+  return streamWaitFor(() => elementGetter.getMainContentContainer());
 }
 
 function _isNowVisible(mutation: { target: HTMLElement } | MutationRecord) {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-menu-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-menu-item-view.ts
@@ -4,7 +4,6 @@ import querySelector from '../../../lib/dom/querySelectorOrFail';
 import TypedEventEmitter from 'typed-emitter';
 import { EventEmitter } from 'events';
 import cx from 'classnames';
-import GmailElementGetter from '../gmail-element-getter';
 import { stylesStream } from '../gmail-driver/track-gmail-styles';
 import isEqual from 'fast-deep-equal';
 
@@ -121,7 +120,7 @@ export class GmailAppMenuItemView extends (EventEmitter as new () => TypedEventE
     const { iconUrl, iconClassName } = this.#menuItemDescriptor ?? {};
 
     if (iconUrl) {
-      const rawTheme = GmailElementGetter.isDarkTheme()
+      const rawTheme = this.#driver.elementGetter.isDarkTheme()
         ? iconUrl.darkTheme
         : iconUrl.lightTheme;
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/index.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/index.test.ts
@@ -20,6 +20,7 @@ import delay from 'pdelay';
 import GmailAppSidebarView from './index';
 import MockWebStorage from 'mock-webstorage';
 import GmailThreadView from '../gmail-thread-view';
+import GmailElementGetter from '../../gmail-element-getter';
 import { type ContentPanelDescriptor } from '../../../../driver-common/sidebar/ContentPanelViewDriver';
 
 jest.mock('../../../../lib/dom/make-element-child-stream', () => {
@@ -109,7 +110,7 @@ describe('GmailAppSidebarView Primary', function () {
 });
 
 function makeDriver(appId?: string, opts?: any): any {
-  return {
+  const driver: any = {
     getAppId: () => appId || 'test',
     getOpts: () =>
       opts || {
@@ -129,6 +130,8 @@ function makeDriver(appId?: string, opts?: any): any {
       };
     },
   };
+  driver.elementGetter = new GmailElementGetter(driver);
+  return driver;
 }
 
 function makeSidebarContainerElement() {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.tsx
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-sidebar-view/primary/index.tsx
@@ -10,9 +10,7 @@ import ReactDOM from 'react-dom';
 import AppSidebar from '../../../../../driver-common/sidebar/AppSidebar';
 import type { PanelDescriptor } from '../../../../../driver-common/sidebar/AppSidebar';
 import type GmailDriver from '../../../gmail-driver';
-import GmailElementGetter, {
-  COMPANION_SIDEBAR_PANEL_WRAPPER_CLASS,
-} from '../../../gmail-element-getter';
+import { COMPANION_SIDEBAR_PANEL_WRAPPER_CLASS } from '../../../gmail-element-getter';
 import idMap from '../../../../../lib/idMap';
 import incrementName from '../../../../../lib/incrementName';
 import querySelector from '../../../../../lib/dom/querySelectorOrFail';
@@ -44,9 +42,13 @@ class GmailAppSidebarPrimary {
    * There could be multiple InboxSDK instances (and therefore GmailDrivers)
    * talking to this Primary, so we shouldn't privilege the specific GmailDriver
    * that happened to create the Primary. Only use this GmailDriver for
-   * logging-related functionality!
+   * logging-related functionality and for page-chrome lookups, which are the
+   * same for every app!
    */
-  #driver: { getLogger: GmailDriver['getLogger'] };
+  #driver: {
+    getLogger: GmailDriver['getLogger'];
+    elementGetter: GmailDriver['elementGetter'];
+  };
   /**
    * This Primary has an identifier used by the DOM events to specify they're
    * talking to this Primary. This leaves us some room for having multiple
@@ -633,7 +635,7 @@ class GmailAppSidebarPrimary {
     isGlobal: boolean,
   ) {
     const companionSidebarIconContainerEl =
-      GmailElementGetter.getCompanionSidebarIconContainerElement();
+      this.#driver.elementGetter.getCompanionSidebarIconContainerElement();
     if (!companionSidebarIconContainerEl)
       throw new Error(
         'Could not find companion sidebar icon container element',
@@ -682,7 +684,7 @@ class GmailAppSidebarPrimary {
 
   #setupElement() {
     const companionSidebarIconContainerEl =
-      GmailElementGetter.getCompanionSidebarIconContainerElement();
+      this.#driver.elementGetter.getCompanionSidebarIconContainerElement();
     if (!companionSidebarIconContainerEl)
       throw new Error(
         'Could not find companion sidebar icon container element',
@@ -694,7 +696,7 @@ class GmailAppSidebarPrimary {
     );
 
     const companionSidebarOuterWrapper =
-      GmailElementGetter.getCompanionSidebarOuterWrapperElement(
+      this.#driver.elementGetter.getCompanionSidebarOuterWrapperElement(
         this.#companionSidebarContentContainerEl,
       );
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-toolbar-button-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-app-toolbar-button-view.ts
@@ -4,7 +4,6 @@ import * as Kefir from 'kefir';
 import kefirStopper from 'kefir-stopper';
 import type { Stopper } from 'kefir-stopper';
 import updateIcon from '../../../driver-common/update-icon';
-import GmailElementGetter from '../gmail-element-getter';
 import GmailTooltipView from '../widgets/gmail-tooltip-view';
 import DropdownView from '../../../widgets/buttons/dropdown-view';
 import monitorTopBannerSizeAndReact from './gmail-app-toolbar-button-view/monitor-top-banner-size-and-react';
@@ -176,7 +175,7 @@ function _createAppButtonElement(
     event.preventDefault();
     onclick(event);
   });
-  const topAccountContainer = GmailElementGetter.getTopAccountContainer();
+  const topAccountContainer = driver.elementGetter.getTopAccountContainer();
 
   if (!topAccountContainer) {
     const err = new Error('Could not make button');
@@ -201,7 +200,7 @@ function _createAppButtonElement(
   }
 
   try {
-    if (!GmailElementGetter.isGplusEnabled()) {
+    if (!driver.elementGetter.isGplusEnabled()) {
       element.classList.add('inboxsdk__appButton_noGPlus');
     }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-compose-view.ts
@@ -25,7 +25,6 @@ import {
   simulateDrop,
   simulateDragEnd,
 } from '../../../lib/dom/simulate-drag-and-drop';
-import GmailElementGetter from '../gmail-element-getter';
 import setCss from '../../../lib/dom/set-css';
 import waitFor from '../../../lib/wait-for';
 import streamWaitFor from '../../../lib/stream-wait-for';
@@ -566,7 +565,7 @@ class GmailComposeView {
         this.#isFullscreen = true;
       } else {
         const fullScreenContainer =
-          GmailElementGetter.getFullscreenComposeWindowContainer();
+          this.#driver.elementGetter.getFullscreenComposeWindowContainer();
 
         if (!fullScreenContainer) {
           this.#isFullscreen = false;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-nav-item-view.ts
@@ -2,8 +2,6 @@ import autoHtml from 'auto-html';
 import * as Kefir from 'kefir';
 import kefirBus, { Bus } from 'kefir-bus';
 
-import GmailElementGetter from '../gmail-element-getter';
-
 import getInsertBeforeElement from '../../../lib/dom/get-insert-before-element';
 import querySelector from '../../../lib/dom/querySelectorOrFail';
 import makeMutationObserverChunkedStream from '../../../lib/dom/make-mutation-observer-chunked-stream';
@@ -130,7 +128,8 @@ export default class GmailNavItemView {
     this._orderGroup = orderGroup;
 
     this._isNewLeftNavParent =
-      !GmailElementGetter.shouldAddNavItemsInline() && this._level === 1;
+      !this._driver.elementGetter.shouldAddNavItemsInline() &&
+      this._level === 1;
 
     this._element = this.#setupElement();
   }
@@ -320,7 +319,7 @@ export default class GmailNavItemView {
 
     const element = gmailNavItemView.getElement();
 
-    if (!GmailElementGetter.shouldAddNavItemsInline()) {
+    if (!this._driver.elementGetter.shouldAddNavItemsInline()) {
       querySelector(element, '.TN').style.marginLeft =
         6 * indentationFactor + 'px';
     } else {
@@ -435,7 +434,7 @@ export default class GmailNavItemView {
       vAlign: 'top',
     };
 
-    const container = GmailElementGetter.getLeftNavContainerElement();
+    const container = this._driver.elementGetter.getLeftNavContainerElement();
     if (!container) throw new Error('leftNavContainer not found');
 
     buttonOptions.dropdownShowFunction = (event: any) => {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -14,7 +14,6 @@ import getInsertBeforeElement from '../../../../lib/dom/get-insert-before-elemen
 import GmailRowListView from '../gmail-row-list-view';
 import GmailThreadView from '../gmail-thread-view';
 import GmailCollapsibleSectionView from '../gmail-collapsible-section-view';
-import GmailElementGetter from '../../gmail-element-getter';
 import { simulateClick } from '../../../../lib/dom/simulate-mouse-event';
 import type GmailDriver from '../../gmail-driver';
 import type GmailRouteProcessor from '../gmail-route-view/gmail-route-processor';
@@ -296,7 +295,7 @@ class GmailRouteView implements RouteViewDriver {
   }
 
   _monitorLeftNavHeight() {
-    var leftNav = GmailElementGetter.getLeftNavHeightElement();
+    var leftNav = this.#driver.elementGetter.getLeftNavHeightElement();
 
     if (!leftNav) {
       return;
@@ -313,11 +312,12 @@ class GmailRouteView implements RouteViewDriver {
   }
 
   _setCustomViewElementHeight() {
-    const leftNav = GmailElementGetter.getLeftNavHeightElement();
-    const gtalkButtons = GmailElementGetter.getGtalkButtons();
+    const leftNav = this.#driver.elementGetter.getLeftNavHeightElement();
+    const gtalkButtons = this.#driver.elementGetter.getGtalkButtons();
     const customViewEl = this._customViewElement;
     if (!leftNav || !customViewEl) throw new Error('Should not happen');
-    const contentSectionElement = GmailElementGetter.getContentSectionElement();
+    const contentSectionElement =
+      this.#driver.elementGetter.getContentSectionElement();
     const contentSectionElementBottomMargin = contentSectionElement
       ? parseInt(getComputedStyle(contentSectionElement).marginBottom, 10)
       : 0;
@@ -425,7 +425,7 @@ class GmailRouteView implements RouteViewDriver {
         }
 
         const previewPaneContainerElement =
-          GmailElementGetter.getPreviewPaneContainerElement();
+          this.#driver.elementGetter.getPreviewPaneContainerElement();
         if (previewPaneContainerElement) {
           return { previewPaneContainerElement };
         }
@@ -463,7 +463,7 @@ class GmailRouteView implements RouteViewDriver {
 
   _setupScrollStream() {
     const SCROLL_DEBOUNCE_MS = 100;
-    const scrollContainer = GmailElementGetter.getScrollContainer();
+    const scrollContainer = this.#driver.elementGetter.getScrollContainer();
     const { scrollTop: cachedScrollTop } = this._cachedRouteData;
 
     if (scrollContainer && this._hasAddedCollapsibleSection) {
@@ -813,10 +813,9 @@ class GmailRouteView implements RouteViewDriver {
 
   // Used to click gmail refresh button in thread lists
   refresh() {
-    var el =
-      GmailElementGetter.getToolbarElement().querySelector<HTMLElement>(
-        'div.T-I.nu',
-      );
+    var el = this.#driver.elementGetter
+      .getToolbarElement()
+      .querySelector<HTMLElement>('div.T-I.nu');
 
     if (el) {
       var prevActive = document.activeElement as HTMLElement;
@@ -845,7 +844,7 @@ class GmailRouteView implements RouteViewDriver {
   }
 
   _getThreadContainerElement() {
-    return GmailElementGetter.getThreadContainerElement();
+    return this.#driver.elementGetter.getThreadContainerElement();
   }
 }
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-thread-view.ts
@@ -12,7 +12,6 @@ import idMap from '../../../lib/idMap';
 import SimpleElementView from '../../../views/SimpleElementView';
 import CustomMessageView from '../../../views/conversations/custom-message-view';
 import type GmailDriver from '../gmail-driver';
-import GmailElementGetter from '../gmail-element-getter';
 import GmailMessageView from './gmail-message-view';
 import GmailToolbarView from './gmail-toolbar-view';
 import type { CustomMessageDescriptor } from '../../../views/conversations/custom-message-view';
@@ -993,8 +992,9 @@ class GmailThreadView {
   async #logAddonElementInfo() {
     if (hasLoggedAddonInfo) return;
 
-    function readInfo() {
-      const container = GmailElementGetter.getAddonSidebarContainerElement();
+    const readInfo = () => {
+      const container =
+        this.#driver.elementGetter.getAddonSidebarContainerElement();
       if (!container) return null;
       const isDisplayNone = {
         parent: container.parentElement
@@ -1016,7 +1016,7 @@ class GmailThreadView {
         isDisplayNone,
         size,
       };
-    }
+    };
 
     const eventData = {
       time: {} as any,

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-toolbar-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-toolbar-view.ts
@@ -7,7 +7,6 @@ import streamWaitFor from '../../../lib/stream-wait-for';
 import makeMutationObserverStream from '../../../lib/dom/make-mutation-observer-stream';
 import insertElementInOrder from '../../../lib/dom/insert-element-in-order';
 import isElementVisible from '../../../../common/isElementVisible';
-import GmailElementGetter from '../gmail-element-getter';
 import ButtonView from '../widgets/buttons/button-view';
 import GmailDropdownView from '../widgets/gmail-dropdown-view';
 import BasicButtonViewController from '../../../widgets/buttons/basic-button-view-controller';
@@ -549,7 +548,7 @@ class GmailToolbarView {
   }
 
   _addToOpenMoreMenu(buttonDescriptor: Record<string, any>) {
-    const moreMenu = GmailElementGetter.getActiveMoreMenu();
+    const moreMenu = this._driver.elementGetter.getActiveMoreMenu();
 
     if (!moreMenu) {
       return;

--- a/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/widgets/gmail-mole-view-driver.ts
@@ -2,7 +2,7 @@ import * as Kefir from 'kefir';
 import kefirBus from 'kefir-bus';
 import kefirStopper from 'kefir-stopper';
 import querySelector from '../../../lib/dom/querySelectorOrFail';
-import GmailElementGetter, {
+import {
   MOLE_CONTAINER_SELECTOR,
   MOLE_PARENT_SELECTOR,
 } from '../gmail-element-getter';
@@ -310,7 +310,7 @@ class GmailMoleViewDriver {
     // If the gmail mode has settled, we've been loaded for 10 seconds, and
     // we don't have the mole parent yet, then force the mole parent to load
     // by opening a compose view and then closing it.
-    Kefir.fromPromise(GmailElementGetter.waitForGmailModeToSettle())
+    Kefir.fromPromise(this.#driver.elementGetter.waitForGmailModeToSettle())
       .flatMap(() => {
         // delay until we've passed TimestampOnReady + 5 seconds
         return this.#driver.delayToTimeAfterReady(5_000);

--- a/src/platform-implementation-js/namespaces/app-menu.ts
+++ b/src/platform-implementation-js/namespaces/app-menu.ts
@@ -1,7 +1,6 @@
 import kefir, { stream } from 'kefir';
 import { RouteView } from '../../inboxsdk';
 import GmailDriver from '../dom-driver/gmail/gmail-driver';
-import GmailElementGetter from '../dom-driver/gmail/gmail-element-getter';
 import { AppMenuItemView } from '../views/app-menu-item-view';
 import { CollapsiblePanelView } from '../views/collapsible-panel-view';
 import isNotNil from '../../common/isNotNil';
@@ -124,7 +123,7 @@ export default class AppMenu {
         return;
       }
 
-      const appMenu = await GmailElementGetter.getAppMenuAsync();
+      const appMenu = await this.#driver.elementGetter.getAppMenuAsync();
 
       if (!appMenu) {
         return;
@@ -166,7 +165,7 @@ export default class AppMenu {
   constructor(driver: GmailDriver) {
     this.#driver = driver;
 
-    AppMenu.#monitorAppMenuState();
+    AppMenu.#monitorAppMenuState(driver);
   }
 
   /**
@@ -182,7 +181,7 @@ export default class AppMenu {
    * @returns whether or not the AppMenu Burger is uncollapsed or not.
    */
   isMenuOpen() {
-    return GmailElementGetter.isAppBurgerMenuOpen();
+    return this.#driver.elementGetter.isAppBurgerMenuOpen();
   }
 
   /**
@@ -201,12 +200,12 @@ export default class AppMenu {
    * @returns true if the app menu is visible. At time of writing, this typically means they have chose to enable Chat, Meet, or both.
    */
   async isShown() {
-    const result = await GmailElementGetter.getAppMenuAsync();
+    const result = await this.#driver.elementGetter.getAppMenuAsync();
     return !!result;
   }
 
   static #monitorInitialized = false;
-  static async #monitorAppMenuState() {
+  static async #monitorAppMenuState(driver: GmailDriver) {
     /**
      * Gmail could set menu item to active asynchronously, monitor changes to the menu DOM and
      * deactivate all other menu items that don't have the SDK specific active class name.
@@ -222,7 +221,7 @@ export default class AppMenu {
 
     kefir
       .fromPromise<HTMLElement | undefined, unknown>(
-        GmailElementGetter.getAppMenuAsync(),
+        driver.elementGetter.getAppMenuAsync(),
       )
       .filter(isNotNil)
       .flatMap((appMenu) =>
@@ -242,10 +241,10 @@ export default class AppMenu {
       )
       .throttle(10, { leading: true, trailing: true })
       .map(() => {
-        const activeMenuItem = AppMenuItemView.getActiveMenuItem();
+        const activeMenuItem = AppMenuItemView.getActiveMenuItem(driver);
 
         if (activeMenuItem) {
-          const otherMenuItems = AppMenuItemView.getAllMenuItems().filter(
+          const otherMenuItems = AppMenuItemView.getAllMenuItems(driver).filter(
             (menuItem) => menuItem !== activeMenuItem,
           );
 
@@ -254,9 +253,9 @@ export default class AppMenu {
           );
         }
 
-        const activePanel = AppMenuItemView.getActivePanel();
+        const activePanel = AppMenuItemView.getActivePanel(driver);
         if (activePanel) {
-          const otherPanels = AppMenuItemView.getAllPanels().filter(
+          const otherPanels = AppMenuItemView.getAllPanels(driver).filter(
             (panel) => panel !== activePanel,
           );
 

--- a/src/platform-implementation-js/views/app-menu-item-view.ts
+++ b/src/platform-implementation-js/views/app-menu-item-view.ts
@@ -20,7 +20,6 @@ import {
 } from './collapsible-panel-view';
 import GmailDriver from '../dom-driver/gmail/gmail-driver';
 import { addCollapsiblePanel } from '../dom-driver/gmail/gmail-driver/add-collapsible-panel';
-import GmailElementGetter from '../dom-driver/gmail/gmail-element-getter';
 import defer from '../../common/defer';
 
 type MessageEvents = {
@@ -88,11 +87,19 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
   static #routeViewDriverStream: ReturnType<
     GmailDriver['getRouteViewDriverStream']
   >;
+  /**
+   * The class-level machinery below runs once per page, not once per app, so it
+   * borrows the first driver it sees. Only use it for page chrome, which is the
+   * same for every app. The setup that starts at module load has no driver yet,
+   * so it waits on {@link AppMenuItemView.#sharedDriverReady} instead.
+   */
+  static #sharedDriver: GmailDriver | undefined;
+  static #sharedDriverReady = defer<GmailDriver>();
   static #menuItemToPanelMap = new Map<HTMLElement, HTMLElement | undefined>();
   static #appMenuItemViews = new Set<AppMenuItemView>();
 
-  static getAllPanels() {
-    const appMenuElement = GmailElementGetter.getAppMenuContainer();
+  static getAllPanels(driver: GmailDriver) {
+    const appMenuElement = driver.elementGetter.getAppMenuContainer();
 
     const nativePanels = appMenuElement?.querySelectorAll<HTMLElement>(
       `.${PANEL_NATIVE_CLASS}`,
@@ -101,8 +108,8 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
     return Array.from(nativePanels ?? []);
   }
 
-  static getActivePanel(useSdkActiveSelector = true) {
-    const appMenuElement = GmailElementGetter.getAppMenuContainer();
+  static getActivePanel(driver: GmailDriver, useSdkActiveSelector = true) {
+    const appMenuElement = driver.elementGetter.getAppMenuContainer();
     const { ACTIVE, SDK_ACTIVE } = CollapsiblePanelView.elementCss;
 
     const nativePanel = appMenuElement?.querySelector<HTMLElement>(
@@ -133,15 +140,15 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
     return element.classList.contains(NATIVE_CLASS);
   }
 
-  static getAllMenuItems() {
-    const appMenuElement = GmailElementGetter.getAppMenuContainer();
+  static getAllMenuItems(driver: GmailDriver) {
+    const appMenuElement = driver.elementGetter.getAppMenuContainer();
     return Array.from(
       appMenuElement?.querySelectorAll<HTMLElement>(`.${NATIVE_CLASS}`) ?? [],
     );
   }
 
-  static getActiveMenuItem() {
-    const appMenuElement = GmailElementGetter.getAppMenuContainer();
+  static getActiveMenuItem(driver: GmailDriver) {
+    const appMenuElement = driver.elementGetter.getAppMenuContainer();
     const { ACTIVE, SDK_ACTIVE } = GmailAppMenuItemView.elementCss;
 
     const button = appMenuElement?.querySelector<HTMLElement>(
@@ -165,13 +172,13 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
     }
   }
 
-  static #isPanelLess() {
-    const activePanel = AppMenuItemView.getActivePanel(false);
+  static #isPanelLess(driver: GmailDriver) {
+    const activePanel = AppMenuItemView.getActivePanel(driver, false);
     return !activePanel;
   }
-  static #adjustTooltipNub() {
+  static #adjustTooltipNub(driver: GmailDriver) {
     // adjust all menu items' collapsible panel's tooltip nub position
-    const appMenuElement = GmailElementGetter.getAppMenu();
+    const appMenuElement = driver.elementGetter.getAppMenu();
     for (const menuItem of appMenuElement?.querySelectorAll<HTMLElement>(
       `.${NATIVE_CLASS}`,
     ) ?? []) {
@@ -270,7 +277,8 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
   }
   static {
     (async function init() {
-      const gmailAppMenu = await GmailElementGetter.getAppMenuAsync();
+      const driver = await AppMenuItemView.#sharedDriverReady.promise;
+      const gmailAppMenu = await driver.elementGetter.getAppMenuAsync();
       if (!gmailAppMenu) {
         return;
       }
@@ -301,10 +309,12 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
   }
   static {
     AppMenuItemView.#menuItemAddedDeferred.promise.then(() => {
+      const driver = AppMenuItemView.#sharedDriver;
+      if (!driver) return;
       // Set up event listeners we use to control menu UI
       // We intercept some events emitted on Gmail (native) menu items to gain full control of the menu (menu items and panels).
       // Thus, some native event handlers won't be invoked so we replicate the Gmail's behavior by ourselves.
-      const appMenuElement = GmailElementGetter.getAppMenuContainer();
+      const appMenuElement = driver.elementGetter.getAppMenuContainer();
       for (const nativeMenuItem of appMenuElement?.querySelectorAll<HTMLElement>(
         `.${NATIVE_CLASS}:not(.${INBOXSDK_CLASS})`,
       ) ?? []) {
@@ -358,11 +368,13 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
   }
   static {
     AppMenuItemView.#menuItemChangeStream.onValue(async (v) => {
+      const driver = AppMenuItemView.#sharedDriver;
+      if (!driver) return;
       const [type, menuItem, mouseEvent] = v;
       const { HOVER } = GmailAppMenuItemView.elementCss;
 
-      function handleActivate() {
-        const appMenuElement = GmailElementGetter.getAppMenuContainer();
+      const handleActivate = () => {
+        const appMenuElement = driver.elementGetter.getAppMenuContainer();
 
         // deactivate menu items and handle keyboard accessibility
         for (const menuItem_ of appMenuElement?.querySelectorAll<HTMLElement>(
@@ -383,7 +395,7 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
         // activate panel
         const panel = AppMenuItemView.#menuItemToPanelMap.get(menuItem);
         if (panel) {
-          const otherPanels = AppMenuItemView.getAllPanels().filter(
+          const otherPanels = AppMenuItemView.getAllPanels(driver).filter(
             (p) => p !== panel,
           );
 
@@ -393,14 +405,14 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
 
           activatePanel(panel);
         }
-      }
+      };
 
       switch (type) {
         case 'mouseenter': {
           const panel = AppMenuItemView.#menuItemToPanelMap.get(menuItem);
-          const activeMenuItem = AppMenuItemView.getActiveMenuItem();
-          const activePanel = AppMenuItemView.getActivePanel();
-          const burgerMenuOpen = GmailElementGetter.isAppBurgerMenuOpen();
+          const activeMenuItem = AppMenuItemView.getActiveMenuItem(driver);
+          const activePanel = AppMenuItemView.getActivePanel(driver);
+          const burgerMenuOpen = driver.elementGetter.isAppBurgerMenuOpen();
 
           // hover-styled panel is displayed for collapsed burger menu
           if (
@@ -453,8 +465,8 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
           const isPanelDropdownShown = AppMenuItemView.#isPanelDropdownShown();
           if (isPanelDropdownShown) return;
 
-          const activeMenuItem = AppMenuItemView.getActiveMenuItem();
-          const activePanel = AppMenuItemView.getActivePanel();
+          const activeMenuItem = AppMenuItemView.getActiveMenuItem(driver);
+          const activePanel = AppMenuItemView.getActivePanel(driver);
           const activeMenuItemPanel =
             activeMenuItem &&
             AppMenuItemView.#menuItemToPanelMap.get(activeMenuItem);
@@ -466,7 +478,7 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
           )
             return;
 
-          const burgerMenuOpen = GmailElementGetter.isAppBurgerMenuOpen();
+          const burgerMenuOpen = driver.elementGetter.isAppBurgerMenuOpen();
 
           if (activePanel === activeMenuItemPanel && burgerMenuOpen) return;
 
@@ -500,7 +512,7 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
           handleActivate();
 
           // handle panel-less mode
-          const isPanelLess = AppMenuItemView.#isPanelLess();
+          const isPanelLess = AppMenuItemView.#isPanelLess(driver);
 
           for (const panel of document.querySelectorAll(
             CollapsiblePanelView.elementSelectors.NATIVE,
@@ -510,11 +522,12 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
               isPanelLess,
             );
           }
-          GmailElementGetter.getAppMenu()?.classList.toggle('aTO', isPanelLess);
-          GmailElementGetter.getAppHeader()?.classList.toggle(
-            'aTO',
-            isPanelLess,
-          );
+          driver.elementGetter
+            .getAppMenu()
+            ?.classList.toggle('aTO', isPanelLess);
+          driver.elementGetter
+            .getAppHeader()
+            ?.classList.toggle('aTO', isPanelLess);
           break;
         }
 
@@ -554,7 +567,7 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
 
       if (gmailElement) {
         AppMenuItemView.#menuItemToPanelMap.set(gmailElement, undefined);
-        AppMenuItemView.#adjustTooltipNub();
+        AppMenuItemView.#adjustTooltipNub(this.#driver);
       }
 
       gmailView.on('destroy', () => {
@@ -585,6 +598,10 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
       });
     });
 
+    if (!AppMenuItemView.#sharedDriver) {
+      AppMenuItemView.#sharedDriver = driver;
+      AppMenuItemView.#sharedDriverReady.resolve(driver);
+    }
     AppMenuItemView.#setUpRouteViewDriverStream(driver);
     AppMenuItemView.#menuItemAddedDeferred.resolve(undefined);
     AppMenuItemView.#appMenuItemViews.add(this);
@@ -602,9 +619,9 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
       ...panelDescriptor,
       className: cx(panelDescriptor.className, {
         [CollapsiblePanelView.elementCss.COLLAPSED]:
-          !GmailElementGetter.isAppBurgerMenuOpen(),
+          !this.#driver.elementGetter.isAppBurgerMenuOpen(),
         [CollapsiblePanelView.elementCss.PANEL_LESS]:
-          AppMenuItemView.#isPanelLess(),
+          AppMenuItemView.#isPanelLess(this.#driver),
       }),
     };
 
@@ -631,7 +648,7 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
             gmailElement,
             collapsiblePanel.element,
           );
-          AppMenuItemView.#adjustTooltipNub();
+          AppMenuItemView.#adjustTooltipNub(this.#driver);
         }
       });
     }
@@ -663,7 +680,7 @@ export class AppMenuItemView extends (EventEmitter as new () => TypedEmitter<Mes
       gmailView.element &&
         AppMenuItemView.#menuItemToPanelMap.delete(gmailView.element);
       gmailView.remove();
-      AppMenuItemView.#adjustTooltipNub();
+      AppMenuItemView.#adjustTooltipNub(this.#driver);
     });
     AppMenuItemView.#appMenuItemViews.delete(this);
   }

--- a/src/platform-implementation-js/views/collapsible-panel-view.ts
+++ b/src/platform-implementation-js/views/collapsible-panel-view.ts
@@ -7,7 +7,6 @@ import EventEmitter from '../lib/safe-event-emitter';
 import { AppMenuItemPanelDescriptor } from '../namespaces/app-menu';
 import autoHtml from 'auto-html';
 import querySelector from '../lib/dom/querySelectorOrFail';
-import GmailElementGetter from '../dom-driver/gmail/gmail-element-getter';
 import GmailDriver from '../dom-driver/gmail/gmail-driver';
 import { NavItemDescriptor } from '../dom-driver/gmail/views/gmail-nav-item-view';
 import NavItemView from './nav-item-view';
@@ -176,7 +175,7 @@ export class CollapsiblePanelView extends (EventEmitter as new () => TypedEmitte
       return;
     }
 
-    const theme = GmailElementGetter.isDarkTheme()
+    const theme = this.#driver.elementGetter.isDarkTheme()
       ? iconUrl.darkTheme
       : iconUrl.lightTheme;
 


### PR DESCRIPTION
Make `GmailElementGetter` a class owned by the driver, so it can reach to the selector registry.

The `GmailElementContainer` was, until now, a static object with methods to find Gmail containers, page transitions and wait for dynamically rendered elements. Now, `GmailElementGetter` is a class that holds a driver reference, so it can use the selector registry:

```tsx
// Before
getLeftNavContainerElement() {
  return document.querySelector('.aeN');
}

// After
getLeftNavContainerElement() {
  return this.#driver.selectors.querySelectorByKey(document, 'leftNav.container');
}
```

### Changes

- [`GmailElementGetter`](https://github.com/InboxSDK/InboxSDK/pull/1315/changes#diff-8a2131bf804c5a51df0023f46c9e4f337b571de0bab7871c6ae5131232d17f14R54) is now a class, instantiated by [`GmailDriver`](https://github.com/InboxSDK/InboxSDK/pull/1315/changes#diff-e64a242dac9365f817061afbc0dc6523ca3872cecfc23c03774668093b9968caR132).
- All (34) call sites swap `GmailElementGetter.x()` → `driver.elementGetter.x()` - most changes in this PR fall in this group.
- Four call sites now need a driver parameter: [track-gmail-styles](https://github.com/InboxSDK/InboxSDK/pull/1315/changes#diff-97d4c0e362b42f8d65c1f08819210f86eabd1083ec587e1e3ae4bdcc378105a1R76), [app-menu.ts](https://github.com/InboxSDK/InboxSDK/pull/1315/changes#diff-daf1a77f96edd93506d8d52977b2dd9e25a727cc7fefc220b4b1565638ac1d74R168), [add-collapsible-panel.ts](https://github.com/InboxSDK/InboxSDK/pull/1315/changes#diff-4c8ecbae3561c941137c1e5cd161db7163725f391806ba9a94658dcb1e7c5e3dR468), and [AppMenuItemView](https://github.com/InboxSDK/InboxSDK/pull/1315/changes#diff-4c8ecbae3561c941137c1e5cd161db7163725f391806ba9a94658dcb1e7c5e3dR468).