### PR TITLE
fix(message view): restore more menu items in Gmail's current menu

### DIFF
--- a/examples/toolbar-button/content.js
+++ b/examples/toolbar-button/content.js
@@ -1,7 +1,20 @@
 import * as InboxSDK from '@inboxsdk/core';
 
+// Gmail's bundled rungs for the message more menu no longer match, so this
+// example supplies its own rather than waiting for an SDK release. Measured
+// 2026-08-24; aria-expanded is deliberately absent from the button rung,
+// because Gmail only adds it once the menu has been opened.
+var selectorOverrides = {
+  'messageView.moreButton': ['button.Wsq5Cf'],
+  'messageView.openMoreMenu': ['div.tB5Jxf-M-X-ql-Kq ul.aqdrmf-Kf'],
+};
+
 InboxSDK.load(1, 'toolbar-example', {
   appIconUrl: chrome.runtime.getURL('monkey.png'),
+  selectorOverrides: selectorOverrides,
+  onInvalidSelector: function (key, selector, err) {
+    console.warn('dropped an invalid override', key, selector, err);
+  },
 }).then(function (inboxSDK) {
   window._sdk = inboxSDK;
 

--- a/examples/toolbar-button/content.js
+++ b/examples/toolbar-button/content.js
@@ -149,23 +149,17 @@ InboxSDK.load(1, 'toolbar-example', {
     messageView.addToolbarButton({
       section: 'MORE',
       iconUrl: chrome.runtime.getURL('monkey.png'),
-      title: 'Foo bar',
+      title: 'Save to CRM',
       onClick() {
-        console.log(
-          'message more button click on message from',
-          messageView.getSender().name,
-        );
+        console.log('save to CRM:', messageView.getSender().name);
       },
     });
     messageView.addToolbarButton({
       section: inboxSDK.Conversations.MessageViewToolbarSectionNames.MORE,
       iconUrl: chrome.runtime.getURL('monkey.png'),
-      title: 'Foo bar 2 long title text text text',
+      title: 'Create a task from this message',
       onClick() {
-        console.log(
-          '2 message more button click on message from',
-          messageView.getSender().name,
-        );
+        console.log('create task from:', messageView.getSender().name);
       },
     });
   });

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -1,6 +1,5 @@
 import sortBy from 'lodash/sortBy';
 import once from 'lodash/once';
-import autoHtml from 'auto-html';
 import * as Kefir from 'kefir';
 import kefirBus from 'kefir-bus';
 import type { Bus } from 'kefir-bus';
@@ -10,6 +9,10 @@ import GmailAttachmentAreaView from './gmail-attachment-area-view';
 import GmailAttachmentCardView from './gmail-attachment-card-view';
 import getUpdatedContact from './gmail-message-view/get-updated-contact';
 import AttachmentIcon from './gmail-message-view/attachment-icon';
+import {
+  createMoreMenuDivider,
+  createMoreMenuItem,
+} from './gmail-message-view/more-menu-item';
 import makeMutationObserverStream from '../../../lib/dom/make-mutation-observer-stream';
 import querySelector from '../../../lib/dom/querySelectorOrFail';
 import makeMutationObserverChunkedStream from '../../../lib/dom/make-mutation-observer-chunked-stream';
@@ -28,7 +31,10 @@ import type {
   MessageView,
   ThreadView,
 } from '../../../../inboxsdk';
-import type { VIEW_STATE } from '../../../views/conversations/message-view';
+import type {
+  MessageViewToolbarButtonDescriptor,
+  VIEW_STATE,
+} from '../../../views/conversations/message-view';
 
 let hasSeenOldElement = false;
 
@@ -76,7 +82,7 @@ class GmailMessageView {
   #eventStream: Bus<MessageViewDriverEvents, unknown> = kefirBus();
   #stopper = kefirStopper();
   #threadViewDriver: GmailThreadView;
-  #moreMenuItemDescriptors: Array<Record<string, any>>;
+  #moreMenuItemDescriptors: Array<MessageViewToolbarButtonDescriptor>;
   #moreMenuAddedElements: Array<HTMLElement>;
   #replyElementStream: Kefir.Observable<ElementWithLifetime, unknown>;
   #readyStream: Kefir.Observable<null, unknown>;
@@ -332,7 +338,7 @@ class GmailMessageView {
     gmailAttachmentAreaView.addButtonToDownloadAllArea(options);
   }
 
-  addMoreMenuItem(options: Record<string, any>) {
+  addMoreMenuItem(options: MessageViewToolbarButtonDescriptor) {
     this.#moreMenuItemDescriptors = sortBy(
       this.#moreMenuItemDescriptors.concat([options]),
       (o) => o.orderHint,
@@ -431,39 +437,26 @@ class GmailMessageView {
     if (openMoreMenu && this.#moreMenuItemDescriptors.length) {
       const originalHeight = openMoreMenu.offsetHeight;
       const originalWidth = openMoreMenu.offsetWidth;
-      const dividerEl = document.createElement('div');
-      dividerEl.className = 'J-Kh';
+      const dividerEl = createMoreMenuDivider(openMoreMenu);
 
       this.#moreMenuAddedElements.push(dividerEl);
 
       openMoreMenu.appendChild(dividerEl);
 
       this.#moreMenuItemDescriptors.forEach((options) => {
-        const itemEl = document.createElement('div');
-        itemEl.className = 'J-N';
-        itemEl.setAttribute('role', 'menuitem');
-        itemEl.innerHTML = autoHtml`<div class="J-N-Jz">${options.title}</div>`;
-        itemEl.addEventListener('mouseenter', () =>
-          itemEl.classList.add('J-N-JT'),
-        );
-        itemEl.addEventListener('mouseleave', () =>
-          itemEl.classList.remove('J-N-JT'),
-        );
-        itemEl.addEventListener('click', () => {
+        const itemEl = createMoreMenuItem(openMoreMenu, options);
+
+        itemEl.addEventListener('click', (event) => {
           this.#closeActiveEmailMenu();
 
-          options.onClick();
+          options.onClick(event);
         });
+        itemEl.addEventListener('keydown', (event) => {
+          if (event.key !== 'Enter' && event.key !== ' ') return;
 
-        if (options.iconUrl || options.iconClass) {
-          const iconEl = document.createElement('img');
-          iconEl.className = `f4 J-N-JX inboxsdk__message_more_icon ${
-            options.iconClass || ''
-          }`;
-          iconEl.src = options.iconUrl || 'images/cleardot.gif';
-          const insertionPoint = itemEl.firstElementChild;
-          if (insertionPoint) insertionPoint.appendChild(iconEl);
-        }
+          event.preventDefault();
+          itemEl.click();
+        });
 
         this.#moreMenuAddedElements.push(itemEl);
 

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view.ts
@@ -13,6 +13,7 @@ import AttachmentIcon from './gmail-message-view/attachment-icon';
 import makeMutationObserverStream from '../../../lib/dom/make-mutation-observer-stream';
 import querySelector from '../../../lib/dom/querySelectorOrFail';
 import makeMutationObserverChunkedStream from '../../../lib/dom/make-mutation-observer-chunked-stream';
+import streamWaitFor from '../../../lib/stream-wait-for';
 import type { ElementWithLifetime } from '../../../lib/dom/make-element-child-stream';
 import { simulateClick } from '../../../lib/dom/simulate-mouse-event';
 import censorHTMLtree from '../../../../common/censorHTMLtree';
@@ -30,6 +31,9 @@ import type {
 import type { VIEW_STATE } from '../../../views/conversations/message-view';
 
 let hasSeenOldElement = false;
+
+const MORE_MENU_WAIT_TIMEOUT = 5 * 1000;
+const MORE_MENU_WAIT_STEP = 16;
 
 export type MessageViewDriverEventByName = {
   viewStateChange: {
@@ -356,10 +360,10 @@ class GmailMessageView {
         return makeMutationObserverChunkedStream(moreButton, {
           attributes: true,
           attributeFilter: ['aria-expanded'],
-        }).map(() =>
+        }).flatMapLatest(() =>
           moreButton.getAttribute('aria-expanded') === 'true'
-            ? this.#getOpenMoreMenu()
-            : null,
+            ? this.#streamOpenMoreMenu()
+            : Kefir.constant(null),
         );
       })
       .takeUntilBy(this.#stopper)
@@ -379,6 +383,24 @@ class GmailMessageView {
       this.#element,
       'messageView.moreButton',
     );
+  }
+
+  /**
+   * Gmail renders the menu a frame after flipping `aria-expanded`, so a
+   * synchronous lookup misses it. Older layouts keep the synchronous path.
+   */
+  #streamOpenMoreMenu(): Kefir.Observable<HTMLElement | null, unknown> {
+    const openMoreMenu = this.#getOpenMoreMenu();
+
+    if (openMoreMenu) {
+      return Kefir.constant(openMoreMenu);
+    }
+
+    return streamWaitFor(
+      () => this.#getOpenMoreMenu(),
+      MORE_MENU_WAIT_TIMEOUT,
+      MORE_MENU_WAIT_STEP,
+    ).flatMapErrors(() => Kefir.constant(null));
   }
 
   #getOpenMoreMenu(): HTMLElement | null | undefined {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view/more-menu-item.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view/more-menu-item.ts
@@ -179,7 +179,8 @@ function applyIcon(
   // The clone still holds Gmail's own glyph, which would paint under ours.
   iconEl.replaceChildren();
   iconEl.className = cx(ICON_BASE_CLASS, ICON_CLASS, options.iconClass);
-  iconEl.style.backgroundImage = options.iconUrl
-    ? `url(${JSON.stringify(options.iconUrl)})`
+  // Scale to the 16px box; a consumer icon is rarely already that size.
+  iconEl.style.background = options.iconUrl
+    ? `url(${JSON.stringify(options.iconUrl)}) center / contain no-repeat`
     : '';
 }

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view/more-menu-item.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-message-view/more-menu-item.ts
@@ -1,0 +1,185 @@
+import autoHtml from 'auto-html';
+import cx from 'classnames';
+import isEmpty from 'lodash/isEmpty';
+import type { MessageViewToolbarButtonDescriptor } from '../../../../views/conversations/message-view';
+
+/**
+ * Attributes that wire an element to Gmail's own event handling and logging.
+ * A cloned item must not inherit them or Gmail acts on our menu item.
+ */
+const BEHAVIOR_ATTRIBUTES = [
+  'id',
+  'jsaction',
+  'jscontroller',
+  'jslog',
+  'jsname',
+  'data-action-type',
+  'soy-skip',
+  'ssk',
+];
+
+/**
+ * Scopes the SDK stylesheet's rules for injected items to the clone, including
+ * the hover painting Gmail drives from the jsaction we drop.
+ */
+const ITEM_CLASS = 'inboxsdk__message_more_item';
+
+/**
+ * Gmail's sprite base class, shared by the legacy menu and the newer one.
+ */
+const ICON_BASE_CLASS = 'f4';
+
+/** Carries the SDK stylesheet's icon box, and the consumer's own icon rules. */
+const ICON_CLASS = 'inboxsdk__message_more_icon';
+
+/**
+ * Legacy menu icon class. Only the hand-built item wears it — on a clone it
+ * also drags in Gmail's background shorthand, which blanks the consumer image.
+ */
+const LEGACY_ICON_CLASS = 'J-N-JX';
+
+/**
+ * Creates a menu item for the 'more' menu on an individual message view.
+ */
+export function createMoreMenuItem(
+  openMoreMenu: HTMLElement,
+  options: MessageViewToolbarButtonDescriptor,
+): HTMLElement {
+  const template = openMoreMenu.querySelector<HTMLElement>('li[role=menuitem]');
+  const itemEl = template
+    ? createItemFromTemplate(template, options)
+    : createLegacyItem(options);
+
+  // Gmail's roving tabindex is driven by the jscontroller we strip, so the
+  // clone would otherwise be unreachable by keyboard.
+  itemEl.tabIndex = 0;
+
+  return itemEl;
+}
+
+/**
+ * Creates a divider for the 'more' menu on an individual message view.
+ */
+export function createMoreMenuDivider(openMoreMenu: HTMLElement): HTMLElement {
+  const template = openMoreMenu.querySelector<HTMLElement>(
+    'li[role=separator], hr',
+  );
+
+  if (!template) {
+    const dividerEl = document.createElement('div');
+    dividerEl.className = 'J-Kh';
+    return dividerEl;
+  }
+
+  const dividerEl = template.cloneNode(true) as HTMLElement;
+  stripBehaviorAttributes(dividerEl);
+  return dividerEl;
+}
+
+/**
+ * Copies the layout from a live menu item rather than hardcoding it: the
+ * classes are hashed, so they churn whenever Gmail rebuilds the menu.
+ */
+function createItemFromTemplate(
+  template: HTMLElement,
+  options: MessageViewToolbarButtonDescriptor,
+): HTMLElement {
+  const itemEl = template.cloneNode(true) as HTMLElement;
+  stripBehaviorAttributes(itemEl);
+  itemEl.classList.add(ITEM_CLASS);
+
+  const labelEl = findLabelElement(itemEl);
+  if (labelEl) {
+    labelEl.textContent = options.title;
+  }
+
+  applyIcon(findIconElement(itemEl), options);
+  return itemEl;
+}
+
+/**
+ * Creates a menu item for the 'more' menu on an individual message view, using
+ * the legacy hand-built layout rather than cloning a live menu item.
+ */
+function createLegacyItem(
+  options: MessageViewToolbarButtonDescriptor,
+): HTMLElement {
+  // Gmail's legacy menu drives its own hover from JS, so the item has to
+  // toggle the hover class itself.
+  const hoverClass = 'J-N-JT';
+
+  const itemEl = document.createElement('div');
+  itemEl.className = 'J-N';
+  itemEl.setAttribute('role', 'menuitem');
+  itemEl.innerHTML = autoHtml`<div class="J-N-Jz">${options.title}</div>`;
+  itemEl.addEventListener('mouseenter', () => itemEl.classList.add(hoverClass));
+  itemEl.addEventListener('mouseleave', () =>
+    itemEl.classList.remove(hoverClass),
+  );
+
+  if (options.iconUrl || options.iconClass) {
+    const iconEl = document.createElement('img');
+    iconEl.className = cx(
+      ICON_BASE_CLASS,
+      LEGACY_ICON_CLASS,
+      ICON_CLASS,
+      options.iconClass,
+    );
+    iconEl.src = options.iconUrl || 'images/cleardot.gif';
+    itemEl.firstElementChild?.appendChild(iconEl);
+  }
+
+  return itemEl;
+}
+
+/**
+ * Removes Gmail's own wiring from a cloned menu item, so it doesn't act on our
+ * click or hover.
+ */
+function stripBehaviorAttributes(root: HTMLElement) {
+  for (const el of [root, ...root.querySelectorAll<HTMLElement>('*')]) {
+    for (const attribute of BEHAVIOR_ATTRIBUTES) {
+      el.removeAttribute(attribute);
+    }
+  }
+}
+
+function trimmedText(el: Element | null): string {
+  return (el?.textContent ?? '').trim();
+}
+
+/**
+ * The longest text-bearing leaf is the label; the item's other spans are
+ * empty slots for the ripple, icon and trailing affordances.
+ */
+function findLabelElement(itemEl: HTMLElement): HTMLElement | null {
+  let labelEl: HTMLElement | null = null;
+
+  for (const el of itemEl.querySelectorAll<HTMLElement>('*')) {
+    if (el.children.length) continue;
+    const text = trimmedText(el);
+    if (!isEmpty(text) && text.length > trimmedText(labelEl).length) {
+      labelEl = el;
+    }
+  }
+
+  return labelEl;
+}
+
+function findIconElement(itemEl: HTMLElement): HTMLElement | null {
+  return itemEl.querySelector<HTMLElement>(`.${ICON_BASE_CLASS}`);
+}
+
+function applyIcon(
+  iconEl: HTMLElement | null,
+  options: MessageViewToolbarButtonDescriptor,
+) {
+  if (!iconEl) return;
+
+  // The clone still holds Gmail's own glyph, which would paint under ours.
+  iconEl.replaceChildren();
+  iconEl.className = cx(ICON_BASE_CLASS, ICON_CLASS, options.iconClass);
+  iconEl.style.backgroundImage = options.iconUrl
+    ? `url(${JSON.stringify(options.iconUrl)})`
+    : '';
+}

--- a/src/platform-implementation-js/style/gmail.css
+++ b/src/platform-implementation-js/style/gmail.css
@@ -482,6 +482,19 @@ div.bHJ .inboxsdk__button {
   width: 16px;
 }
 
+/* The clone inherits Gmail's icon box, which scales the consumer's image up. */
+.inboxsdk__message_more_item .inboxsdk__message_more_icon {
+  height: 16px;
+  width: 16px;
+}
+
+/* Gmail paints hover through a jsaction the clone drops, so paint it here.
+   Tints from the text color so it reads on light and dark themes. */
+.inboxsdk__message_more_item:hover,
+.inboxsdk__message_more_item:focus {
+  background-color: color-mix(in srgb, currentcolor 8%, transparent);
+}
+
 /* end */
 
 /* compose buttons */


### PR DESCRIPTION
Fixes the per-message "More" menu items in Gmail's current menu.

<img width="600" alt="message - more menu items" src="https://github.com/user-attachments/assets/2f2ed97e-f945-4382-b02f-4a4a709b7e08" />

The problem was caused by two concurrent bugs:

- The SDK couldn't find the ⋮ button using the stored CSS selectors (Gmail changed the markup).
- Gmail build the menu when the menu opens, which raced with the InboxSDK trying to find the items, which caused the InboxSDK to fail intermittently.

The new selectors are identified, but I want to use this selector to prove the remote selector config idea. Once I do, I will add the new selectors into the registry. In the meantime, we can override the selectors (shown in the examples/toolbar-button example).

### Changes

- When creating a menu item, we clone an existing item and change its contents.
- Fix the race condition that was causing the InboxSDK to not find the menu sometimes.
- Update `examples/toolbar-button` with more realistic items, fix the icon size, and override the selectors.

