### PR TITLE
feat(compose): allow opening a draft from a custom route

### DIFF
--- a/examples/compose-stream/content.js
+++ b/examples/compose-stream/content.js
@@ -13,14 +13,37 @@ InboxSDK.load(2, 'compose-stream-example').then((inboxSDK) => {
   const dataUri =
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAPCAIAAABr+ngCAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAHVJREFUeNpidNnZwkAuYGKgAFCm2VVKjwxtQF1AxARnkaQTwmBBE9r97BIx2iCAmSFAW5lXHM4HsoHo3ueXmNqQlUGsYYHbhmwqsiswfQR3HQuaEKYRWLWha8ZlBFZt2DVjGoEnCFnwhC3+kB/Y5EmJZoAAAwDdxywx4cg7qwAAAABJRU5ErkJggg==';
 
-  window.openDraftByMessageID = function (messageID) {
-    return inboxSDK.Compose.openDraftByMessageID(messageID);
+  window.openDraftByMessageID = function (messageID, opts) {
+    return inboxSDK.Compose.openDraftByMessageID(messageID, opts);
   };
+
+  // Gmail only parses `?compose=` on its own routes, so the SDK moves to a
+  // native one to open the draft. Going back afterwards is the app's job — the
+  // mole survives the navigation. Pass `routeID` to choose where it lands.
+  async function openDraftFromCustomRoute(messageID) {
+    const routeView = inboxSDK.Router.getCurrentRouteView();
+    const previousRouteID = routeView.getRouteID();
+    const previousParams = routeView.getParams();
+
+    const composeView = await inboxSDK.Compose.openDraftByMessageID(messageID);
+
+    inboxSDK.Router.goto(previousRouteID, previousParams);
+    return composeView;
+  }
+  window.openDraftFromCustomRoute = openDraftFromCustomRoute;
 
   inboxSDK.Compose.registerComposeViewHandler(function (composeView) {
     console.log('thread id', composeView.getThreadID());
 
     window._lastComposeView = composeView;
+
+    // Null for a brand new compose; set when an existing draft is opened, which
+    // is the id openDraftFromCustomRoute needs to reopen it.
+    const initialMessageID = composeView.getInitialMessageID();
+    if (initialMessageID) {
+      window._lastDraftMessageID = initialMessageID;
+      console.log('initial message id', initialMessageID);
+    }
 
     const monkeyImages = [
       chrome.runtime.getURL('monkey.png'),
@@ -272,6 +295,35 @@ InboxSDK.load(2, 'compose-stream-example').then((inboxSDK) => {
     );
     composeView.on('minimized', console.log.bind(console, 'minimized'));
     composeView.on('restored', console.log.bind(console, 'restored'));
+  });
+
+  const OPEN_DRAFT_ROUTE_ID = 'compose-stream-example/open-draft';
+
+  inboxSDK.NavMenu.addNavItem({
+    name: 'Open draft from custom route',
+    iconUrl: dataUri,
+    routeID: OPEN_DRAFT_ROUTE_ID,
+  });
+
+  inboxSDK.Router.handleCustomRoute(OPEN_DRAFT_ROUTE_ID, (customRouteView) => {
+    const input = document.createElement('input');
+    input.size = 40;
+    input.placeholder = 'draft message id';
+    input.value = window._lastDraftMessageID || '';
+
+    const openButton = document.createElement('button');
+    openButton.textContent = 'Open draft';
+    openButton.addEventListener('click', () => {
+      openDraftFromCustomRoute(input.value.trim()).catch((err) => {
+        console.error('failed to open draft', err);
+      });
+    });
+
+    const container = document.createElement('div');
+    container.appendChild(input);
+    container.appendChild(openButton);
+
+    customRouteView.getElement().appendChild(container);
   });
 
   var button = inboxSDK.Toolbars.addToolbarButtonForApp({

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver.ts
@@ -29,7 +29,9 @@ import GmailMoleViewDriver, {
 import InboxDrawerView from '../inbox/views/inbox-drawer-view';
 import GmailRouteProcessor from './views/gmail-route-view/gmail-route-processor';
 import KeyboardShortcutHelpModifier from './gmail-driver/keyboard-shortcut-help-modifier';
-import openDraftByMessageID from './gmail-driver/open-draft-by-message-id';
+import openDraftByMessageID, {
+  type OpenDraftOptions,
+} from './gmail-driver/open-draft-by-message-id';
 import UserInfo from './gmail-driver/user-info';
 import GmailButterBarDriver from './gmail-butter-bar-driver';
 import trackGmailStyles, {
@@ -593,6 +595,17 @@ class GmailDriver {
     return createLink(this.#gmailRouteProcessor, routeID, params);
   }
 
+  /**
+   * Whether the route currently showing belongs to an extension rather than to
+   * Gmail. Gmail's own router ignores hash params on these routes.
+   */
+  isCurrentRouteCustom(): boolean {
+    return (
+      this.#currentRouteViewDriver?.getRouteType() ===
+      this.#gmailRouteProcessor.RouteTypes.CUSTOM
+    );
+  }
+
   goto(
     routeID: string,
     params: RouteParams | string | null | undefined,
@@ -655,8 +668,11 @@ class GmailDriver {
       .toPromise();
   }
 
-  openDraftByMessageID(messageID: string): Promise<void> {
-    return openDraftByMessageID(this, messageID);
+  openDraftByMessageID(
+    messageID: string,
+    opts?: OpenDraftOptions,
+  ): Promise<void> {
+    return openDraftByMessageID(this, messageID, opts);
   }
 
   createModalViewDriver(options: any): GmailModalViewDriver {

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/open-draft-by-message-id.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/open-draft-by-message-id.test.ts
@@ -1,4 +1,29 @@
-import { makeNewHash } from './open-draft-by-message-id';
+jest.mock('./get-rfc-message-id-for-gmail-message-id', () =>
+  jest.fn(async () => 'rfc-message-id'),
+);
+jest.mock('../../../driver-common/getSyncThreadsForSearch', () =>
+  jest.fn(async () => ({
+    threads: [
+      {
+        syncThreadID: 'thread-f:123',
+        extraMetaData: {
+          syncMessageData: [
+            { oldMessageID: '18a', syncMessageID: 'msg-a:456' },
+          ],
+        },
+      },
+    ],
+  })),
+);
+
+import openDraftByMessageID, {
+  makeNewHash,
+  makeNewSyncHash,
+} from './open-draft-by-message-id';
+
+// encodeDraftUrlId('thread-f:123', 'msg-a:456')
+const COMPOSE_ID = 'FBkcwTvWncnsbBVBZCtfDWS';
+
 describe('makeNewHash', () => {
   it('1', () => {
     expect(makeNewHash('', '123')).toBe('#?compose=123');
@@ -16,5 +41,103 @@ describe('makeNewHash', () => {
   });
   it('5', () => {
     expect(makeNewHash('#inbox?foo=5', '123')).toBe('#inbox?foo=5&compose=123');
+  });
+});
+
+describe('makeNewSyncHash', () => {
+  it('appends to the given hash', () => {
+    expect(makeNewSyncHash('#inbox', 'thread-f:123', 'msg-a:456')).toBe(
+      `#inbox?compose=${COMPOSE_ID}`,
+    );
+  });
+  it('keeps a route that has a path segment', () => {
+    expect(
+      makeNewSyncHash('#starred/p14237', 'thread-f:123', 'msg-a:456'),
+    ).toBe(`#starred/p14237?compose=${COMPOSE_ID}`);
+  });
+  it('replaces an existing compose param', () => {
+    expect(
+      makeNewSyncHash('#inbox?compose=old', 'thread-f:123', 'msg-a:456'),
+    ).toBe(`#inbox?compose=${COMPOSE_ID}`);
+  });
+});
+
+describe('openDraftByMessageID', () => {
+  function makeMockDriver({ customRoute = false } = {}): any {
+    return {
+      isCurrentRouteCustom: () => customRoute,
+      createLink: jest.fn(
+        (routeID: string, params: any) =>
+          '#' + routeID.replace(/:page/, params?.page ?? '0'),
+      ),
+    };
+  }
+
+  beforeEach(() => {
+    window.location.hash = '#somewhere-else';
+  });
+
+  it('uses the current hash on a native route when no routeID is given', async () => {
+    const driver = makeMockDriver();
+    await openDraftByMessageID(driver, '18a');
+
+    expect(driver.createLink).not.toHaveBeenCalled();
+    expect(window.location.hash).toBe(`#somewhere-else?compose=${COMPOSE_ID}`);
+  });
+
+  it('falls back to a native route when a custom route is showing', async () => {
+    const driver = makeMockDriver({ customRoute: true });
+    await openDraftByMessageID(driver, '18a');
+
+    expect(driver.createLink).toHaveBeenCalledWith('starred/:page', {
+      page: expect.any(Number),
+    });
+    expect(window.location.hash).toMatch(
+      new RegExp(`^#starred/\\d+\\?compose=${COMPOSE_ID}$`),
+    );
+  });
+
+  it('uses a fresh fallback page on every call', async () => {
+    const driver = makeMockDriver({ customRoute: true });
+    await openDraftByMessageID(driver, '18a');
+    await openDraftByMessageID(driver, '18a');
+
+    const [[, first], [, second]] = driver.createLink.mock.calls;
+    expect(second.page).toBeGreaterThan(first.page);
+  });
+
+  it('prefers an explicit routeID over the custom-route fallback', async () => {
+    const driver = makeMockDriver({ customRoute: true });
+    await openDraftByMessageID(driver, '18a', { routeID: 'inbox/:page' });
+
+    expect(driver.createLink).toHaveBeenCalledWith('inbox/:page', undefined);
+    expect(window.location.hash).toBe(`#inbox/0?compose=${COMPOSE_ID}`);
+  });
+
+  it('builds the hash from routeID instead of the current hash', async () => {
+    const driver = makeMockDriver();
+    await openDraftByMessageID(driver, '18a', { routeID: 'starred/:page' });
+
+    expect(driver.createLink).toHaveBeenCalledWith('starred/:page', undefined);
+    expect(window.location.hash).toBe(`#starred/0?compose=${COMPOSE_ID}`);
+  });
+
+  it('passes routeParams through to createLink', async () => {
+    const driver = makeMockDriver();
+    await openDraftByMessageID(driver, '18a', {
+      routeID: 'starred/:page',
+      routeParams: { page: 14237 },
+    });
+
+    expect(driver.createLink).toHaveBeenCalledWith('starred/:page', {
+      page: 14237,
+    });
+    expect(window.location.hash).toBe(`#starred/14237?compose=${COMPOSE_ID}`);
+  });
+
+  it('throws when the message has no matching syncMessageData', async () => {
+    await expect(
+      openDraftByMessageID(makeMockDriver(), 'not-a-known-message'),
+    ).rejects.toThrow('Failed to find syncMessageData');
   });
 });

--- a/src/platform-implementation-js/dom-driver/gmail/gmail-driver/open-draft-by-message-id.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/gmail-driver/open-draft-by-message-id.ts
@@ -1,14 +1,51 @@
 import qs from 'querystring';
 
 import getSyncThreadsForSearch from '../../../driver-common/getSyncThreadsForSearch';
+import { NATIVE_ROUTE_IDS } from '../../../constants/router';
+import type { RouteParams } from '../../../namespaces/router';
 
 import GmailDriver from '../gmail-driver';
 import encodeDraftUrlId from './encodeDraftUrlId';
 import getRfcMessageIdForGmailMessageId from './get-rfc-message-id-for-gmail-message-id';
 
+export interface OpenDraftOptions {
+  /**
+   * Route to open the draft from. Gmail only parses `?compose=` on its own
+   * routes, so a draft can not be opened while a custom route is showing.
+   * Defaults to the current route when Gmail owns it, and to a native route
+   * when it does not. Takes the same values as `Router.goto`.
+   */
+  routeID?: string;
+  routeParams?: RouteParams | string | null;
+}
+
+/**
+ * Gmail refuses to reopen a draft at a route the user previously browsed away
+ * from with that draft still open, so every fallback navigation goes to a page
+ * this session has not used yet. The page is far enough in that the list it
+ * lands on is empty.
+ */
+let nextFallbackPage = 10000;
+
+function getBaseHash(
+  driver: GmailDriver,
+  { routeID, routeParams }: OpenDraftOptions,
+): string {
+  if (routeID) {
+    return driver.createLink(routeID, routeParams);
+  }
+  if (driver.isCurrentRouteCustom()) {
+    return driver.createLink(NATIVE_ROUTE_IDS.STARRED, {
+      page: nextFallbackPage++,
+    });
+  }
+  return window.location.hash;
+}
+
 export default async function openDraftByMessageID(
   driver: GmailDriver,
   messageID: string,
+  opts: OpenDraftOptions = {},
 ) {
   const rfcMessageID = await getRfcMessageIdForGmailMessageId(
     driver,
@@ -33,12 +70,11 @@ export default async function openDraftByMessageID(
 
   const { syncMessageID } = syncMessageData;
 
-  const newHash = makeNewSyncHash(
-    window.location.hash,
+  window.location.hash = makeNewSyncHash(
+    getBaseHash(driver, opts),
     thread.syncThreadID,
     syncMessageID,
   );
-  window.location.hash = newHash;
 }
 
 export function makeNewHash(oldHash: string, messageID: string): string {

--- a/src/platform-implementation-js/namespaces/compose.ts
+++ b/src/platform-implementation-js/namespaces/compose.ts
@@ -6,6 +6,7 @@ import HandlerRegistry from '../lib/handler-registry';
 import type Membrane from '../lib/Membrane';
 import type { Handler } from '../lib/handler-registry';
 import type { Driver } from '../driver-interfaces/driver';
+import { type OpenDraftOptions } from '../dom-driver/gmail/gmail-driver/open-draft-by-message-id';
 interface Members {
   driver: Driver;
   membrane: Membrane;
@@ -53,10 +54,13 @@ export default class Compose {
     return members.membrane.get(composeViewDriver);
   }
 
-  async openDraftByMessageID(messageID: string): Promise<ComposeView> {
+  async openDraftByMessageID(
+    messageID: string,
+    opts?: OpenDraftOptions,
+  ): Promise<ComposeView> {
     const members = get(memberMap, this);
     const newComposePromise = members.composeViewStream.take(1).toPromise();
-    await members.driver.openDraftByMessageID(messageID);
+    await members.driver.openDraftByMessageID(messageID, opts);
     return Kefir.fromPromise(newComposePromise)
       .merge(
         Kefir.later(15 * 1000, null).flatMap(() =>


### PR DESCRIPTION
`Compose.openDraftByMessageID` silently fails when a custom route is showing. It opens a draft by writing `?compose=<id>` onto the current hash, but on a custom route that hash path belongs to the SDK, so Gmail's router never parses the param. The call surfaces as a 15s *"draft did not open in time"* rejection.

Streak hits this from its box view, which is a custom route. The workaround there is to `Router.goto` a native route, poll until it settles, then call `openDraftByMessageID` — three hash changes and a wait for what should be one.

## What this does

**Falls back automatically.** When the current route is custom, the base hash is now a native route instead of `window.location.hash`, so the existing call works unchanged from a custom route.

**Adds optional `routeID` / `routeParams`.** A caller that wants a specific landing route can pass one; it takes the same values as `Router.goto`. Route and `?compose=` land in a single hash assignment.

```ts
// unchanged behaviour on a native route
await sdk.Compose.openDraftByMessageID(messageID);

// pick where the draft opens
await sdk.Compose.openDraftByMessageID(messageID, {
  routeID: sdk.Router.NativeRouteIDs.STARRED,
  routeParams: { page: 12345 },
});
```

Callers already on a native Gmail route are unaffected — the base hash is still `window.location.hash`.

## Implementation notes

`GmailDriver.isCurrentRouteCustom()` is new, and reads the route type off the current route view driver.

The fallback goes to **Starred** rather than the inbox, because the inbox route does not support page numbers when the user has Categories enabled. It uses a fresh page number on each call (`nextFallbackPage++`): Gmail refuses to reopen a draft at a route the user previously browsed away from with that draft still open, and the pages are far enough in that the list lands empty.

## Testing

Six new cases in `open-draft-by-message-id.test.ts` cover the native-route path, the custom-route fallback, fresh fallback pages, explicit `routeID` precedence, and `routeParams` pass-through. Full suite green — 55 suites, 412 tests. `yarn typecheck` and `yarn lint` clean.

The `compose-stream` example gains a custom route and a control to reopen the last draft from it, which is how the behaviour was exercised by hand in Gmail.
