### PR TITLE
fix(toolbar): support Material search move actions

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/selectors.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/selectors.ts
@@ -50,6 +50,39 @@ export const GMAIL_SELECTORS = {
   'composeView.titleBarColorBodyInner': ['.nH.Hy.aXJ .l.m > .l.n'],
 
   /**
+   * Native button used to identify the Inbox-state toolbar section.
+   * Root: one `.G-Ni` section.
+   */
+  'toolbar.archiveSectionButton': [
+    '.ar9',
+    '.aFh',
+    '.aFj',
+    '.lR',
+    '.nN',
+    '.nX',
+    '.aFk',
+  ],
+
+  /**
+   * Native checkbox used to identify the selection toolbar section.
+   * Root: one `.G-Ni` section.
+   */
+  'toolbar.checkboxSectionButton': ['.T-Jo-auh'],
+
+  /**
+   * Primary native buttons or icon descendants in Gmail's Move/Label section.
+   * Root: one `.G-Ni` section.
+   */
+  'toolbar.moveSectionButton': ['.asb', '.ase', '.ns', '.mw', '.bq5'],
+
+  /**
+   * Gmail search threads retain `.aFj` around "Move to Inbox" when Material
+   * SVG icons replace the legacy `.bq5` descendant.
+   * Root: one `.G-Ni` section. Kept separate so a real Move section wins.
+   */
+  'toolbar.moveSectionFallbackButton': ['.aFj'],
+
+  /**
    * Body of an open message.
    * Root: message element.
    */

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-toolbar-view.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-toolbar-view.test.ts
@@ -1,0 +1,122 @@
+import SelectorRegistry from '../../../lib/dom/selectorRegistry';
+import type GmailDriver from '../gmail-driver';
+import type { SelectorOverrides } from '../selectors';
+import GmailToolbarView from './gmail-toolbar-view';
+
+function makeToolbarView(
+  toolbarHtml: string,
+  overrides?: SelectorOverrides,
+): {
+  element: HTMLElement;
+  view: GmailToolbarView;
+} {
+  const element = document.createElement('div');
+  element.innerHTML = toolbarHtml;
+
+  const view = Object.create(GmailToolbarView.prototype) as GmailToolbarView;
+  view._element = element;
+  view._driver = {
+    selectors: new SelectorRegistry({ overrides }),
+  } as GmailDriver;
+
+  return { element, view };
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('_getMoveSectionElement', () => {
+  test('uses the normal Move and Labels section', () => {
+    const { element, view } = makeToolbarView(`
+      <div class="G-Ni" data-section="archive"><div class="lR"></div></div>
+      <div class="G-Ni" data-section="move">
+        <div class="ns"></div><div class="mw"></div>
+      </div>
+    `);
+
+    expect(view._getMoveSectionElement()).toBe(
+      element.querySelector('[data-section="move"]'),
+    );
+  });
+
+  test('uses the legacy search section through its bq5 icon', () => {
+    const { element, view } = makeToolbarView(`
+      <div class="G-Ni" data-section="search">
+        <div class="aFj"><div class="asa"><div class="bq5"></div></div></div>
+      </div>
+    `);
+
+    expect(view._getMoveSectionElement()).toBe(
+      element.querySelector('[data-section="search"]'),
+    );
+  });
+
+  test('falls back to the Material search Move-to-Inbox button', () => {
+    const { element, view } = makeToolbarView(`
+      <div class="G-Ni" data-section="search">
+        <div class="aFj">
+          <div class="asa KCRnif"><svg class="fphLhb"></svg></div>
+        </div>
+      </div>
+    `);
+
+    expect(view._getMoveSectionElement()).toBe(
+      element.querySelector('[data-section="search"]'),
+    );
+  });
+
+  test('prefers a real Move section after an earlier aFj fallback', () => {
+    const { element, view } = makeToolbarView(`
+      <div class="G-Ni" data-section="fallback"><div class="aFj"></div></div>
+      <div class="G-Ni" data-section="move"><div class="ns"></div></div>
+    `);
+
+    expect(view._getMoveSectionElement()).toBe(
+      element.querySelector('[data-section="move"]'),
+    );
+  });
+
+  test('ignores a hidden Move button outside the active toolbar root', () => {
+    document.body.innerHTML =
+      '<div style="display:none"><div class="G-Ni"><div class="ns"></div></div></div>';
+    const { element, view } = makeToolbarView(`
+      <div class="G-Ni" data-section="search"><div class="aFj"></div></div>
+    `);
+
+    expect(view._getMoveSectionElement()).toBe(
+      element.querySelector('[data-section="search"]'),
+    );
+  });
+
+  test('accepts a remote fallback selector override', () => {
+    const { element, view } = makeToolbarView(
+      '<div class="G-Ni" data-section="override"><div class="future-move"></div></div>',
+      {
+        'toolbar.moveSectionFallbackButton': ['.future-move'],
+      } as never,
+    );
+
+    expect(view._getMoveSectionElement()).toBe(
+      element.querySelector('[data-section="override"]'),
+    );
+  });
+});
+
+test('resolves the existing Archive and checkbox sections', () => {
+  const { element, view } = makeToolbarView(`
+    <div class="G-Ni" data-section="checkbox">
+      <div class="T-Jo-auh"></div>
+    </div>
+    <div class="G-Ni" data-section="archive">
+      <div class="lR"></div>
+    </div>
+  `);
+
+  expect(view._getCheckboxSectionElement()).toBe(
+    element.querySelector('[data-section="checkbox"]'),
+  );
+  expect(view._getArchiveSectionElement()).toBe(
+    element.querySelector('[data-section="archive"]'),
+  );
+});

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-toolbar-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-toolbar-view.ts
@@ -16,6 +16,7 @@ import GmailThreadView from './gmail-thread-view';
 import GmailRowListView from './gmail-row-list-view';
 import { SECTION_NAMES } from '../../../constants/toolbars';
 import type GmailDriver from '../gmail-driver';
+import type { SelectorKey } from '../selectors';
 import type { RouteViewDriver } from '../../../driver-interfaces/route-view-driver';
 import Logger from '../../../lib/logger';
 import GmailThreadRowView from './gmail-thread-row-view';
@@ -413,29 +414,41 @@ class GmailToolbarView {
   }
 
   _getArchiveSectionElement(): HTMLElement | null | undefined {
-    return this._getSectionElementForButtonSelector(
-      '.ar9, .aFh, .aFj, .lR, .nN, .nX, .aFk',
+    return this._getSectionElementForButtonSelectorKey(
+      'toolbar.archiveSectionButton',
     );
   }
 
   _getCheckboxSectionElement(): HTMLElement | null | undefined {
-    return this._getSectionElementForButtonSelector('.T-Jo-auh');
-  }
-
-  _getMoveSectionElement(): HTMLElement | null | undefined {
-    return this._getSectionElementForButtonSelector(
-      '.asb, .ase, .ns, .mw, .bq5',
+    return this._getSectionElementForButtonSelectorKey(
+      'toolbar.checkboxSectionButton',
     );
   }
 
-  _getSectionElementForButtonSelector(
-    buttonSelector: string,
+  _getMoveSectionElement(): HTMLElement | null | undefined {
+    return (
+      this._getSectionElementForButtonSelectorKey(
+        'toolbar.moveSectionButton',
+      ) ??
+      this._getSectionElementForButtonSelectorKey(
+        'toolbar.moveSectionFallbackButton',
+      )
+    );
+  }
+
+  _getSectionElementForButtonSelectorKey(
+    selectorKey: SelectorKey,
   ): HTMLElement | null | undefined {
     const sectionElements =
       this._element.querySelectorAll<HTMLElement>('.G-Ni');
 
     for (let ii = 0; ii < sectionElements.length; ii++) {
-      if (sectionElements[ii].querySelector(buttonSelector)) {
+      if (
+        this._driver.selectors.querySelectorByKey(
+          sectionElements[ii],
+          selectorKey,
+        )
+      ) {
         return sectionElements[ii];
       }
     }


### PR DESCRIPTION
## Problem
There are some cases toolbar buttons aren't inserted correctly on a thread from gmail search, this is because some gmail accounts have a variant that we aren't considering. The way we identify Move section is the key to decide which toolbar state is at. This matters to which toolbar to be shown between thread list and thread message in different routes (whether from search or just normal inbox), in thread list, it then depends if you select a row or not.

## Fix
- Have a move section fallback selector. See comments on why we can't fold the fallback selector into the Move section selector list. 
- Migrate to selector registry for future iteration. 
- Tested in **Toolbar Button** example extension.

### Google workspace gmail — standard .ns / .mw
| Version | Normal list<br>unselected | Normal list<br>selected | Normal thread | Search list<br>unselected | Search list<br>selected | Search thread |
|---|---|---|---|---|---|---|
| Before (`441abed5`) | <a href="https://github.com/user-attachments/assets/f3afdbd8-d4f0-4acd-8340-4f9df0aed258"><img width="240" alt="meichen@streak.com normal-list-unselected before — Expected absent; 14 ROW registrations" src="https://github.com/user-attachments/assets/f3afdbd8-d4f0-4acd-8340-4f9df0aed258" /></a><br><sub>Expected absent; 14 ROW registrations; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/6e03b9fb-695c-47e4-a32a-411eb7ee7003"><img width="240" alt="meichen@streak.com normal-list-selected before — Present" src="https://github.com/user-attachments/assets/6e03b9fb-695c-47e4-a32a-411eb7ee7003" /></a><br><sub>✅ Present; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/f2281e54-f231-40cf-9189-b00ad1040212"><img width="240" alt="meichen@streak.com normal-thread before — Present" src="https://github.com/user-attachments/assets/f2281e54-f231-40cf-9189-b00ad1040212" /></a><br><sub>✅ Present; route `#inbox/:thread-id`</sub> | <a href="https://github.com/user-attachments/assets/4bb2231c-0499-459f-b131-15380fde566b"><img width="240" alt="meichen@streak.com search-list-unselected before — Expected absent; 50 ROW registrations" src="https://github.com/user-attachments/assets/4bb2231c-0499-459f-b131-15380fde566b" /></a><br><sub>Expected absent; 50 ROW registrations; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/063b9902-3952-4daa-a6d4-6776d8c74dfc"><img width="240" alt="meichen@streak.com search-list-selected before — Present" src="https://github.com/user-attachments/assets/063b9902-3952-4daa-a6d4-6776d8c74dfc" /></a><br><sub>✅ Present; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/a53354a9-8ed2-43e2-98a6-cfc0bc6cff77"><img width="240" alt="meichen@streak.com search-thread before — Present" src="https://github.com/user-attachments/assets/a53354a9-8ed2-43e2-98a6-cfc0bc6cff77" /></a><br><sub>✅ Present; route `#search/test/:thread-id`</sub> |
| After (`22958dac`) | <a href="https://github.com/user-attachments/assets/68df89c3-2150-41e2-ac28-6d73664d9102"><img width="240" alt="meichen@streak.com normal-list-unselected after — Expected absent; 14 ROW registrations" src="https://github.com/user-attachments/assets/68df89c3-2150-41e2-ac28-6d73664d9102" /></a><br><sub>Expected absent; 14 ROW registrations; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/ffa6def4-8a68-43d6-ab1d-489a595b1662"><img width="240" alt="meichen@streak.com normal-list-selected after — Present" src="https://github.com/user-attachments/assets/ffa6def4-8a68-43d6-ab1d-489a595b1662" /></a><br><sub>✅ Present; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/09e56272-6af7-4d20-9e2e-9168d32f66d3"><img width="240" alt="meichen@streak.com normal-thread after — Present" src="https://github.com/user-attachments/assets/09e56272-6af7-4d20-9e2e-9168d32f66d3" /></a><br><sub>✅ Present; route `#inbox/:thread-id`</sub> | <a href="https://github.com/user-attachments/assets/d8af0729-f58c-415f-945b-061626832b65"><img width="240" alt="meichen@streak.com search-list-unselected after — Expected absent; 50 ROW registrations" src="https://github.com/user-attachments/assets/d8af0729-f58c-415f-945b-061626832b65" /></a><br><sub>Expected absent; 50 ROW registrations; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/28893ee1-5390-4e2c-adc2-957d7a59f96e"><img width="240" alt="meichen@streak.com search-list-selected after — Present" src="https://github.com/user-attachments/assets/28893ee1-5390-4e2c-adc2-957d7a59f96e" /></a><br><sub>✅ Present; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/9d17816a-bf85-459a-8562-bbc4249a2d9d"><img width="240" alt="meichen@streak.com search-thread after — Present" src="https://github.com/user-attachments/assets/9d17816a-bf85-459a-8562-bbc4249a2d9d" /></a><br><sub>✅ Present; route `#search/test/:thread-id`</sub> |

### Google workspace gmail  — legacy full .aFj / .bq5 / .mw
| Version | Normal list<br>unselected | Normal list<br>selected | Normal thread | Search list<br>unselected | Search list<br>selected | Search thread |
|---|---|---|---|---|---|---|
| Before (`441abed5`) | <a href="https://github.com/user-attachments/assets/8caf169e-6b71-4b04-bd19-2379f7f5979e"><img width="240" alt="pipelinetest@streak.com normal-list-unselected before — Expected absent; 50 ROW registrations" src="https://github.com/user-attachments/assets/8caf169e-6b71-4b04-bd19-2379f7f5979e" /></a><br><sub>Expected absent; 50 ROW registrations; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/1a064b78-72c4-4b6e-b6c2-71714c9d2052"><img width="240" alt="pipelinetest@streak.com normal-list-selected before — Present" src="https://github.com/user-attachments/assets/1a064b78-72c4-4b6e-b6c2-71714c9d2052" /></a><br><sub>✅ Present; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/3aad7102-aff4-4eb2-b0f0-5aa76e023dc4"><img width="240" alt="pipelinetest@streak.com normal-thread before — Present" src="https://github.com/user-attachments/assets/3aad7102-aff4-4eb2-b0f0-5aa76e023dc4" /></a><br><sub>✅ Present; route `#inbox/:thread-id`</sub> | <a href="https://github.com/user-attachments/assets/eeb2b72d-f44c-4c4e-9a1b-57188c8c94ec"><img width="240" alt="pipelinetest@streak.com search-list-unselected before — Expected absent; 50 ROW registrations" src="https://github.com/user-attachments/assets/eeb2b72d-f44c-4c4e-9a1b-57188c8c94ec" /></a><br><sub>Expected absent; 50 ROW registrations; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/196cc614-7741-429e-84da-b4691ac084ea"><img width="240" alt="pipelinetest@streak.com search-list-selected before — Present" src="https://github.com/user-attachments/assets/196cc614-7741-429e-84da-b4691ac084ea" /></a><br><sub>✅ Present; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/1bdac757-770c-4fa0-a5f6-8893ee83ac00"><img width="240" alt="pipelinetest@streak.com search-thread before — Present" src="https://github.com/user-attachments/assets/1bdac757-770c-4fa0-a5f6-8893ee83ac00" /></a><br><sub>✅ Present; route `#search/test/:thread-id`</sub> |
| After (`22958dac`) | <a href="https://github.com/user-attachments/assets/8bb3fe76-ebe3-4ab4-b426-2aea7cd5c1eb"><img width="240" alt="pipelinetest@streak.com normal-list-unselected after — Expected absent; 50 ROW registrations" src="https://github.com/user-attachments/assets/8bb3fe76-ebe3-4ab4-b426-2aea7cd5c1eb" /></a><br><sub>Expected absent; 50 ROW registrations; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/ca5a456a-311b-4412-a5ce-c47aeb3c1461"><img width="240" alt="pipelinetest@streak.com normal-list-selected after — Present" src="https://github.com/user-attachments/assets/ca5a456a-311b-4412-a5ce-c47aeb3c1461" /></a><br><sub>✅ Present; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/43b06941-cb17-4025-b84b-e4232d3b1aa7"><img width="240" alt="pipelinetest@streak.com normal-thread after — Present" src="https://github.com/user-attachments/assets/43b06941-cb17-4025-b84b-e4232d3b1aa7" /></a><br><sub>✅ Present; route `#inbox/:thread-id`</sub> | <a href="https://github.com/user-attachments/assets/1a8f4dd9-b228-4451-983d-6796a46580e1"><img width="240" alt="pipelinetest@streak.com search-list-unselected after — Expected absent; 50 ROW registrations" src="https://github.com/user-attachments/assets/1a8f4dd9-b228-4451-983d-6796a46580e1" /></a><br><sub>Expected absent; 50 ROW registrations; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/fe10a043-a8e7-4d08-b4a6-eaaa3434cb7d"><img width="240" alt="pipelinetest@streak.com search-list-selected after — Present" src="https://github.com/user-attachments/assets/fe10a043-a8e7-4d08-b4a6-eaaa3434cb7d" /></a><br><sub>✅ Present; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/874f9f68-f85e-4de3-9332-3750d7d1f686"><img width="240" alt="pipelinetest@streak.com search-thread after — Present" src="https://github.com/user-attachments/assets/874f9f68-f85e-4de3-9332-3750d7d1f686" /></a><br><sub>✅ Present; route `#search/test/:thread-id`</sub> |

### Personal gmail variant-1 — legacy compact .aFj > .asa > .bq5
| Version | Normal list<br>unselected | Normal list<br>selected | Normal thread | Search list<br>unselected | Search list<br>selected | Search thread |
|---|---|---|---|---|---|---|
| Before (`441abed5`) | <a href="https://github.com/user-attachments/assets/0cbe8548-f5c9-4ace-a6cc-03b91b928b70"><img width="240" alt="meichentest4@gmail.com normal-list-unselected before — Expected absent; 50 ROW registrations" src="https://github.com/user-attachments/assets/0cbe8548-f5c9-4ace-a6cc-03b91b928b70" /></a><br><sub>Expected absent; 50 ROW registrations; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/299004a7-9a29-4681-a937-1a856e16f8cd"><img width="240" alt="meichentest4@gmail.com normal-list-selected before — Present" src="https://github.com/user-attachments/assets/299004a7-9a29-4681-a937-1a856e16f8cd" /></a><br><sub>✅ Present; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/67d03cb4-374b-489e-85aa-694d5299f4a0"><img width="240" alt="meichentest4@gmail.com normal-thread before — Present" src="https://github.com/user-attachments/assets/67d03cb4-374b-489e-85aa-694d5299f4a0" /></a><br><sub>✅ Present; route `#inbox/:thread-id`</sub> | <a href="https://github.com/user-attachments/assets/a95f1b8c-adc8-4bf6-984f-b2dfc2865df6"><img width="240" alt="meichentest4@gmail.com search-list-unselected before — Expected absent; 50 ROW registrations" src="https://github.com/user-attachments/assets/a95f1b8c-adc8-4bf6-984f-b2dfc2865df6" /></a><br><sub>Expected absent; 50 ROW registrations; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/18506de1-098b-43d6-86c9-5e845db672ad"><img width="240" alt="meichentest4@gmail.com search-list-selected before — Present" src="https://github.com/user-attachments/assets/18506de1-098b-43d6-86c9-5e845db672ad" /></a><br><sub>✅ Present; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/691dd881-a939-4258-bc56-84d007f1cc08"><img width="240" alt="meichentest4@gmail.com search-thread before — Present" src="https://github.com/user-attachments/assets/691dd881-a939-4258-bc56-84d007f1cc08" /></a><br><sub>✅ Present; route `#search/test/:thread-id`</sub> |
| After (`22958dac`) | <a href="https://github.com/user-attachments/assets/96839260-42d5-4797-a265-f3f61f91131f"><img width="240" alt="meichentest4@gmail.com normal-list-unselected after — Expected absent; 50 ROW registrations" src="https://github.com/user-attachments/assets/96839260-42d5-4797-a265-f3f61f91131f" /></a><br><sub>Expected absent; 50 ROW registrations; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/c994d81c-9b63-4a2d-b376-e46846090adf"><img width="240" alt="meichentest4@gmail.com normal-list-selected after — Present" src="https://github.com/user-attachments/assets/c994d81c-9b63-4a2d-b376-e46846090adf" /></a><br><sub>✅ Present; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/57e1f56d-bf40-4077-a082-6bcd000ebe1f"><img width="240" alt="meichentest4@gmail.com normal-thread after — Present" src="https://github.com/user-attachments/assets/57e1f56d-bf40-4077-a082-6bcd000ebe1f" /></a><br><sub>✅ Present; route `#inbox/:thread-id`</sub> | <a href="https://github.com/user-attachments/assets/a98a5551-4ac9-4dbc-96b2-8cc0aa4aad19"><img width="240" alt="meichentest4@gmail.com search-list-unselected after — Expected absent; 50 ROW registrations" src="https://github.com/user-attachments/assets/a98a5551-4ac9-4dbc-96b2-8cc0aa4aad19" /></a><br><sub>Expected absent; 50 ROW registrations; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/480483c8-172f-4ac0-8f5d-c8dec0f2bb1b"><img width="240" alt="meichentest4@gmail.com search-list-selected after — Present" src="https://github.com/user-attachments/assets/480483c8-172f-4ac0-8f5d-c8dec0f2bb1b" /></a><br><sub>✅ Present; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/9888d021-d00b-4601-8116-375596fc27b1"><img width="240" alt="meichentest4@gmail.com search-thread after — Present" src="https://github.com/user-attachments/assets/9888d021-d00b-4601-8116-375596fc27b1" /></a><br><sub>✅ Present; route `#search/test/:thread-id`</sub> |

### Personal gmail variant-2 (fixing here) — Material SVG .aFj > .asa.KCRnif > svg
| Version | Normal list<br>unselected | Normal list<br>selected | Normal thread | Search list<br>unselected | Search list<br>selected | Search thread |
|---|---|---|---|---|---|---|
| Before (`441abed5`) | <a href="https://github.com/user-attachments/assets/bd625474-0aab-4cca-b760-9d41ffb6794a"><img width="240" alt="jfmaggie@gmail.com normal-list-unselected before — Expected absent; 18 ROW registrations" src="https://github.com/user-attachments/assets/bd625474-0aab-4cca-b760-9d41ffb6794a" /></a><br><sub>Expected absent; 18 ROW registrations; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/38d7e2d9-9eb5-4f0f-a6b8-73c6cf162ed6"><img width="240" alt="jfmaggie@gmail.com normal-list-selected before — Present" src="https://github.com/user-attachments/assets/38d7e2d9-9eb5-4f0f-a6b8-73c6cf162ed6" /></a><br><sub>✅ Present; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/33424b56-3c43-455a-842e-8a86180b559f"><img width="240" alt="jfmaggie@gmail.com normal-thread before — Present" src="https://github.com/user-attachments/assets/33424b56-3c43-455a-842e-8a86180b559f" /></a><br><sub>✅ Present; route `#inbox/:thread-id`</sub> | <a href="https://github.com/user-attachments/assets/3e44139d-f782-4be3-88aa-ecc0b809ac0c"><img width="240" alt="jfmaggie@gmail.com search-list-unselected before — Expected absent; 50 ROW registrations" src="https://github.com/user-attachments/assets/3e44139d-f782-4be3-88aa-ecc0b809ac0c" /></a><br><sub>Expected absent; 50 ROW registrations; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/8953de5b-581c-4030-8d9d-be4ddfbd54c9"><img width="240" alt="jfmaggie@gmail.com search-list-selected before — Missing" src="https://github.com/user-attachments/assets/8953de5b-581c-4030-8d9d-be4ddfbd54c9" /></a><br><sub>❌ Missing; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/e2a569ce-1996-48fe-a5cc-226e7adec36d"><img width="240" alt="jfmaggie@gmail.com search-thread before — Missing" src="https://github.com/user-attachments/assets/e2a569ce-1996-48fe-a5cc-226e7adec36d" /></a><br><sub>❌ Missing; route `#search/test/:thread-id`</sub> |
| After (`22958dac`) | <a href="https://github.com/user-attachments/assets/9c04199e-e7b4-4885-ab8e-aa992d2fa364"><img width="240" alt="jfmaggie@gmail.com normal-list-unselected after — Expected absent; 18 ROW registrations" src="https://github.com/user-attachments/assets/9c04199e-e7b4-4885-ab8e-aa992d2fa364" /></a><br><sub>Expected absent; 18 ROW registrations; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/61b5f3c9-7d05-4f88-a8e7-dd77de4fb133"><img width="240" alt="jfmaggie@gmail.com normal-list-selected after — Present" src="https://github.com/user-attachments/assets/61b5f3c9-7d05-4f88-a8e7-dd77de4fb133" /></a><br><sub>✅ Present; route `#inbox`</sub> | <a href="https://github.com/user-attachments/assets/1ab6a6c1-f6e3-44ad-8dc8-6c69177b7c4e"><img width="240" alt="jfmaggie@gmail.com normal-thread after — Present" src="https://github.com/user-attachments/assets/1ab6a6c1-f6e3-44ad-8dc8-6c69177b7c4e" /></a><br><sub>✅ Present; route `#inbox/:thread-id`</sub> | <a href="https://github.com/user-attachments/assets/052f49f7-a66d-4744-ae95-f888784e56aa"><img width="240" alt="jfmaggie@gmail.com search-list-unselected after — Expected absent; 50 ROW registrations" src="https://github.com/user-attachments/assets/052f49f7-a66d-4744-ae95-f888784e56aa" /></a><br><sub>Expected absent; 50 ROW registrations; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/36efdff1-d47f-4bfc-b57a-86c8955ad022"><img width="240" alt="jfmaggie@gmail.com search-list-selected after — Present" src="https://github.com/user-attachments/assets/36efdff1-d47f-4bfc-b57a-86c8955ad022" /></a><br><sub>✅ Present; route `#search/test`</sub> | <a href="https://github.com/user-attachments/assets/47b17164-7a09-4e40-becf-eded16ed25e8"><img width="240" alt="jfmaggie@gmail.com search-thread after — Present" src="https://github.com/user-attachments/assets/47b17164-7a09-4e40-becf-eded16ed25e8" /></a><br><sub>✅ Present; route `#search/test/:thread-id`</sub> |
