### PR TITLE
fix(route-view): insert custom sections below the list toolbar

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/selectors.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/selectors.ts
@@ -144,6 +144,18 @@ export const GMAIL_SELECTORS = {
    * Root: thread element.
    */
   'threadView.subject': ['.ha h2'],
+
+  /**
+   * The element holding the list toolbar and the thread list.
+   * Root: the row list element container.
+   */
+  'routeView.rowListWrapper': ['.bGI.nH'],
+
+  /**
+   * The toolbar above the thread list.
+   * Root: `routeView.rowListWrapper`.
+   */
+  'routeView.listToolbar': ['[gh=tm]', '.G-atb'],
 } as const satisfies Record<string, readonly string[]>;
 
 export type SelectorKey = keyof typeof GMAIL_SELECTORS;

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -70,7 +70,11 @@ class GmailRouteView implements RouteViewDriver {
     this.#driver = driver;
     this._eventStream = kefirBus();
     this._hasAddedCollapsibleSection = false;
-    this.#page = makePageParser(document.body, driver.getLogger());
+    this.#page = makePageParser(
+      document.body,
+      driver.getLogger(),
+      driver.selectors,
+    );
 
     if (this._type === 'CUSTOM') {
       this._setupCustomViewElement();

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -558,7 +558,7 @@ class GmailRouteView implements RouteViewDriver {
         if (!sectionsContainer) {
           sectionsContainer = document.createElement('div');
           sectionsContainer.classList.add('inboxsdk__custom_sections');
-          main.insertBefore(sectionsContainer, main.firstChild);
+          this.#insertSectionsContainer(main, sectionsContainer);
         } else if (
           sectionsContainer.classList.contains('Wc') &&
           !this._isSearchRoute()
@@ -568,6 +568,33 @@ class GmailRouteView implements RouteViewDriver {
         return sectionsContainer;
       })
       .toProperty();
+  }
+
+  /**
+   * Gmail nests the list toolbar inside the row list wrapper, so the top of
+   * the container is above it.
+   */
+  #insertSectionsContainer(main: HTMLElement, sectionsContainer: HTMLElement) {
+    const rowListWrapper = this.#driver.selectors.querySelectorByKey(
+      main,
+      'routeView.rowListWrapper',
+    );
+    const listToolbar =
+      rowListWrapper &&
+      this.#driver.selectors.querySelectorByKey(
+        rowListWrapper,
+        'routeView.listToolbar',
+      );
+
+    if (listToolbar?.parentElement) {
+      listToolbar.parentElement.insertBefore(
+        sectionsContainer,
+        listToolbar.nextSibling,
+      );
+      return;
+    }
+
+    main.insertBefore(sectionsContainer, main.firstChild);
   }
 
   _getCustomParams(): Record<string, any> {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/page-parser.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/page-parser.ts
@@ -2,8 +2,13 @@ import PageParserTree from 'page-parser-tree';
 import Logger from '../../../../lib/logger';
 import censorHTMLtree from '../../../../../common/censorHTMLtree';
 import isNotNil from '../../../../../common/isNotNil';
+import type SelectorRegistry from '../../../../lib/dom/selectorRegistry';
 
-export function makePageParser(element: HTMLElement, logger: Logger) {
+export function makePageParser(
+  element: HTMLElement,
+  logger: Logger,
+  selectors: SelectorRegistry,
+) {
   return new PageParserTree(element, {
     logError(err, el) {
       const details = {
@@ -18,13 +23,19 @@ export function makePageParser(element: HTMLElement, logger: Logger) {
         sources: [null],
         tag: 'rowListElementContainer',
         selectors: [
-          { $map: () => document.querySelector('.bGI.nH')?.parentElement },
+          {
+            $map: () =>
+              selectors.querySelectorByKey(document, 'routeView.rowListWrapper')
+                ?.parentElement,
+          },
         ],
       },
       {
         sources: ['rowListElementContainer'],
         tag: 'rowListElement',
         selectors: [
+          // `.bGI.nH` stays literal here: this is a descent path, and a
+          // registry key resolves a single element rather than a path step.
           { $or: [[], ['.bGI.nH', '.bf5', '.bv9', '.bGC']] },
           '.bGI[role=main]',
           '[gh=tl]',
@@ -34,7 +45,10 @@ export function makePageParser(element: HTMLElement, logger: Logger) {
     finders: {
       rowListElementContainer: {
         fn: (root) =>
-          [root.querySelector('.bGI.nH')?.parentElement].filter(isNotNil),
+          [
+            selectors.querySelectorByKey(root, 'routeView.rowListWrapper')
+              ?.parentElement,
+          ].filter(isNotNil),
       },
       rowListElement: {
         fn: (root) => root.querySelectorAll('[gh=tl]'),


### PR DESCRIPTION
Gmail nests the list toolbar inside the row list wrapper (`.bGI.nH`), so custom sections inserted at the top of the row list container render above the toolbar instead of below it.

Two commits:

- the insertion is anchored to the toolbar, resolved through two new registry keys (`routeView.rowListWrapper`, `routeView.listToolbar`), and falls back to the previous placement when the toolbar is not found
- the route view's page parser now takes the driver's registry and resolves the same wrapper key, rather than hardcoding `.bGI.nH`

Typecheck, tests and lint pass. Verified against live Gmail.
