### PR TITLE
fix(route-view): anchor custom sections to the displayed row list wrapper

### DIFF
--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/find-visible-list-toolbar.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/find-visible-list-toolbar.test.ts
@@ -1,0 +1,84 @@
+import SelectorRegistry from '../../../../lib/dom/selectorRegistry';
+import findVisibleListToolbar from './find-visible-list-toolbar';
+
+function rowListWrapper({
+  hidden,
+  withToolbar,
+}: {
+  hidden: boolean;
+  withToolbar: boolean;
+}): HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'bGI nH oy8Mbf';
+  if (hidden) {
+    wrapper.style.display = 'none';
+  }
+  if (withToolbar) {
+    const toolbar = document.createElement('div');
+    toolbar.className = 'D E G-atb';
+    toolbar.setAttribute('gh', 'tm');
+    wrapper.append(toolbar);
+  }
+  return wrapper;
+}
+
+function listContainer(...wrappers: HTMLElement[]): HTMLElement {
+  const main = document.createElement('div');
+  main.className = 'nH';
+  main.append(...wrappers);
+  return main;
+}
+
+const registry = new SelectorRegistry();
+
+// After inbox -> search, the stale inbox wrapper comes first, toolbar included.
+test('skips a hidden wrapper that still has a toolbar', () => {
+  const stale = rowListWrapper({ hidden: true, withToolbar: true });
+  const current = rowListWrapper({ hidden: false, withToolbar: true });
+  const main = listContainer(stale, current);
+
+  expect(findVisibleListToolbar(main, registry)).toBe(
+    current.querySelector('[gh=tm]'),
+  );
+});
+
+test('skips a hidden placeholder wrapper with no toolbar', () => {
+  const placeholder = rowListWrapper({ hidden: true, withToolbar: false });
+  const current = rowListWrapper({ hidden: false, withToolbar: true });
+  const main = listContainer(placeholder, current);
+
+  expect(findVisibleListToolbar(main, registry)).toBe(
+    current.querySelector('[gh=tm]'),
+  );
+});
+
+test('a lone displayed wrapper resolves to its own toolbar', () => {
+  const current = rowListWrapper({ hidden: false, withToolbar: true });
+  const main = listContainer(current);
+
+  expect(findVisibleListToolbar(main, registry)).toBe(
+    current.querySelector('[gh=tm]'),
+  );
+});
+
+test('null when no wrapper is displayed', () => {
+  const main = listContainer(
+    rowListWrapper({ hidden: true, withToolbar: true }),
+    rowListWrapper({ hidden: true, withToolbar: true }),
+  );
+
+  expect(findVisibleListToolbar(main, registry)).toBeNull();
+});
+
+test('null when the displayed wrapper has no toolbar', () => {
+  const main = listContainer(
+    rowListWrapper({ hidden: true, withToolbar: true }),
+    rowListWrapper({ hidden: false, withToolbar: false }),
+  );
+
+  expect(findVisibleListToolbar(main, registry)).toBeNull();
+});
+
+test('null when there is no wrapper at all', () => {
+  expect(findVisibleListToolbar(listContainer(), registry)).toBeNull();
+});

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/find-visible-list-toolbar.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/find-visible-list-toolbar.ts
@@ -1,0 +1,24 @@
+import type SelectorRegistry from '../../../../lib/dom/selectorRegistry';
+
+/**
+ * Gmail keeps the wrappers of views you have visited as hidden siblings,
+ * toolbar included, so the first wrapper in the DOM is often a stale one.
+ */
+export default function findVisibleListToolbar(
+  main: HTMLElement,
+  selectors: SelectorRegistry,
+): HTMLElement | null {
+  const wrappers = selectors.querySelectorAllByKey(
+    main,
+    'routeView.rowListWrapper',
+  );
+  const visibleWrapper = wrappers.find(isDisplayed);
+  if (!visibleWrapper) {
+    return null;
+  }
+  return selectors.querySelectorByKey(visibleWrapper, 'routeView.listToolbar');
+}
+
+function isDisplayed(el: HTMLElement): boolean {
+  return getComputedStyle(el).display !== 'none';
+}

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/gmail-route-view.ts
@@ -19,6 +19,7 @@ import type GmailDriver from '../../gmail-driver';
 import type GmailRouteProcessor from '../gmail-route-view/gmail-route-processor';
 import PageParserTree from 'page-parser-tree';
 import { makePageParser } from './page-parser';
+import placeSectionsContainer from './place-sections-container';
 import toItemWithLifetimeStream from '../../../../lib/toItemWithLifetimeStream';
 import waitFor from '../../../../lib/wait-for';
 import { SelectorError } from '../../../../lib/dom/querySelectorOrFail';
@@ -51,6 +52,7 @@ class GmailRouteView implements RouteViewDriver {
   _cachedRouteData: Record<string, any>;
   #page: PageParserTree;
   #destroyed = false;
+  #isKeepingSectionsContainerPlaced = false;
 
   constructor(
     { urlObject, type, routeID, cachedRouteData }: Record<string, any>,
@@ -562,43 +564,42 @@ class GmailRouteView implements RouteViewDriver {
         if (!sectionsContainer) {
           sectionsContainer = document.createElement('div');
           sectionsContainer.classList.add('inboxsdk__custom_sections');
-          this.#insertSectionsContainer(main, sectionsContainer);
         } else if (
           sectionsContainer.classList.contains('Wc') &&
           !this._isSearchRoute()
         ) {
           sectionsContainer.classList.remove('Wc');
         }
+        this.#placeSectionsContainer(main, sectionsContainer);
         return sectionsContainer;
       })
       .toProperty();
   }
 
-  /**
-   * Gmail nests the list toolbar inside the row list wrapper, so the top of
-   * the container is above it.
-   */
-  #insertSectionsContainer(main: HTMLElement, sectionsContainer: HTMLElement) {
-    const rowListWrapper = this.#driver.selectors.querySelectorByKey(
-      main,
-      'routeView.rowListWrapper',
-    );
-    const listToolbar =
-      rowListWrapper &&
-      this.#driver.selectors.querySelectorByKey(
-        rowListWrapper,
-        'routeView.listToolbar',
-      );
-
-    if (listToolbar?.parentElement) {
-      listToolbar.parentElement.insertBefore(
-        sectionsContainer,
-        listToolbar.nextSibling,
-      );
+  #placeSectionsContainer(main: HTMLElement, sectionsContainer: HTMLElement) {
+    const { selectors } = this.#driver;
+    placeSectionsContainer(main, sectionsContainer, selectors);
+    if (this.#isKeepingSectionsContainerPlaced) {
       return;
     }
+    this.#isKeepingSectionsContainerPlaced = true;
 
-    main.insertBefore(sectionsContainer, main.firstChild);
+    // Gmail can switch wrappers or draw the toolbar after sections are added.
+    makeMutationObserverChunkedStream(main, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['style', 'class'],
+    })
+      .filter((mutations) =>
+        mutations.some(
+          (mutation) => !sectionsContainer.contains(mutation.target),
+        ),
+      )
+      .takeUntilBy(this._stopper)
+      .onValue(() => {
+        placeSectionsContainer(main, sectionsContainer, selectors);
+      });
   }
 
   _getCustomParams(): Record<string, any> {

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/place-sections-container.test.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/place-sections-container.test.ts
@@ -1,0 +1,87 @@
+import SelectorRegistry from '../../../../lib/dom/selectorRegistry';
+import placeSectionsContainer from './place-sections-container';
+
+function rowListWrapper({
+  hidden,
+  withToolbar,
+}: {
+  hidden: boolean;
+  withToolbar: boolean;
+}): HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'bGI nH oy8Mbf';
+  if (hidden) {
+    wrapper.style.display = 'none';
+  }
+  if (withToolbar) {
+    const toolbar = document.createElement('div');
+    toolbar.className = 'D E G-atb';
+    toolbar.setAttribute('gh', 'tm');
+    wrapper.append(toolbar);
+  }
+  return wrapper;
+}
+
+function sectionsContainer(): HTMLElement {
+  const container = document.createElement('div');
+  container.className = 'inboxsdk__custom_sections';
+  return container;
+}
+
+function toolbarOf(wrapper: HTMLElement): Element {
+  const toolbar = wrapper.querySelector('[gh=tm]');
+  if (!toolbar) {
+    throw new Error('wrapper has no toolbar');
+  }
+  return toolbar;
+}
+
+const registry = new SelectorRegistry();
+
+test('inserts a new container below the displayed toolbar', () => {
+  const current = rowListWrapper({ hidden: false, withToolbar: true });
+  const main = document.createElement('div');
+  main.append(rowListWrapper({ hidden: true, withToolbar: true }), current);
+  const container = sectionsContainer();
+
+  expect(placeSectionsContainer(main, container, registry)).toBe(true);
+  expect(container.previousSibling).toBe(toolbarOf(current));
+});
+
+test('moves a container out of a hidden wrapper to the displayed toolbar', () => {
+  const stale = rowListWrapper({ hidden: true, withToolbar: true });
+  const current = rowListWrapper({ hidden: false, withToolbar: true });
+  const main = document.createElement('div');
+  main.append(stale, current);
+  const container = sectionsContainer();
+  toolbarOf(stale).after(container);
+
+  expect(placeSectionsContainer(main, container, registry)).toBe(true);
+  expect(container.previousSibling).toBe(toolbarOf(current));
+  expect(stale.contains(container)).toBe(false);
+});
+
+test('moves the container to the top while the displayed wrapper has no toolbar', () => {
+  const stale = rowListWrapper({ hidden: true, withToolbar: true });
+  const main = document.createElement('div');
+  main.append(stale, rowListWrapper({ hidden: false, withToolbar: false }));
+  const container = sectionsContainer();
+  toolbarOf(stale).after(container);
+
+  expect(placeSectionsContainer(main, container, registry)).toBe(false);
+  expect(main.firstChild).toBe(container);
+});
+
+test('leaves a container that is already in place untouched', () => {
+  const current = rowListWrapper({ hidden: false, withToolbar: true });
+  const main = document.createElement('div');
+  main.append(current);
+  const container = sectionsContainer();
+  toolbarOf(current).after(container);
+  const observer = new MutationObserver(jest.fn());
+  observer.observe(main, { childList: true, subtree: true });
+
+  expect(placeSectionsContainer(main, container, registry)).toBe(true);
+  expect(observer.takeRecords()).toEqual([]);
+  observer.disconnect();
+});

--- a/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/place-sections-container.ts
+++ b/src/platform-implementation-js/dom-driver/gmail/views/gmail-route-view/place-sections-container.ts
@@ -1,0 +1,26 @@
+import type SelectorRegistry from '../../../../lib/dom/selectorRegistry';
+import findVisibleListToolbar from './find-visible-list-toolbar';
+
+/**
+ * Gmail hides or deletes the wrapper of the list you leave, and every list route
+ * reuses one container. Returns false when it falls back to the top of `main`.
+ */
+export default function placeSectionsContainer(
+  main: HTMLElement,
+  sectionsContainer: HTMLElement,
+  selectors: SelectorRegistry,
+): boolean {
+  const listToolbar = findVisibleListToolbar(main, selectors);
+
+  if (listToolbar) {
+    if (listToolbar.nextSibling !== sectionsContainer) {
+      listToolbar.after(sectionsContainer);
+    }
+    return true;
+  }
+
+  if (main.firstChild !== sectionsContainer) {
+    main.prepend(sectionsContainer);
+  }
+  return false;
+}

--- a/src/platform-implementation-js/lib/dom/selectorRegistry.test.ts
+++ b/src/platform-implementation-js/lib/dom/selectorRegistry.test.ts
@@ -45,6 +45,26 @@ describe('with no config loaded', () => {
     );
   });
 
+  test('querySelectorAllByKey returns every match of the first rung that hits', () => {
+    const registry = new SelectorRegistry();
+    const root = document.createElement('div');
+    root.append(composeRoot(true), composeRoot(true), composeRoot(false));
+
+    // Both `Ht` tables come from the first rung; the `Ht`-less one is left out.
+    expect(
+      registry.querySelectorAllByKey(root, 'composeView.titleBarTable'),
+    ).toEqual(Array.from(root.querySelectorAll('table.Ht')));
+    expect(
+      registry.querySelectorAllByKey(root, 'composeView.titleBarTd'),
+    ).toHaveLength(2);
+    expect(
+      registry.querySelectorAllByKey(
+        document.createElement('div'),
+        'composeView.titleBarTable',
+      ),
+    ).toEqual([]);
+  });
+
   test('candidates are tried in LIST order, not document order', () => {
     const registry = new SelectorRegistry();
     const root = document.createElement('div');

--- a/src/platform-implementation-js/lib/dom/selectorRegistry.ts
+++ b/src/platform-implementation-js/lib/dom/selectorRegistry.ts
@@ -73,6 +73,23 @@ export default class SelectorRegistry {
   }
 
   /**
+   * Every match of the first candidate that matches, not of every candidate.
+   */
+  querySelectorAllByKey(
+    el: Document | DocumentFragment | Element,
+    key: SelectorKey,
+  ): HTMLElement[] {
+    for (const candidateSelector of this.#candidates[key]) {
+      const found = el.querySelectorAll<HTMLElement>(candidateSelector);
+      if (found.length > 0) {
+        return Array.from(found);
+      }
+    }
+
+    return [];
+  }
+
+  /**
    * Resolve a registry key against `el`, but throws if no candidate matches.
    */
   querySelectorByKeyOrFail(


### PR DESCRIPTION
Custom sections disappeared on Gmail search. Every list route shares one `.inboxsdk__custom_sections`, and Gmail hides or deletes the wrapper of the list you navigate away from.

- place the container on every list route, not only when it is created
- anchor it below the toolbar of the displayed row list wrapper, or at the top of the list container while that toolbar is missing
- keep re-placing it while the route is open, because Gmail can switch wrappers or render the toolbar after a route adds its sections
- skip the move when the container is already in place
- unit tests for the placement helper and for `querySelectorAllByKey` rung selection
- checked in Gmail with a real extension: inbox to search and back, a fresh load on search then inbox, a second search, and a wrapper switch with no route change
